### PR TITLE
feat(app): improve header + main screen styles

### DIFF
--- a/src/components/Chat/components/usernotices/ViewerMilestoneNotice.tsx
+++ b/src/components/Chat/components/usernotices/ViewerMilestoneNotice.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@app/components/Typography';
 import { ParsedPart } from '@app/utils';
 import { unescapeIrcTag } from '@app/utils/chat/unescapeIrcTag';
 import { useMemo } from 'react';
+import { View } from 'react-native';
 import { StyleSheet } from 'react-native-unistyles';
 
 interface ViewerMilestoneNoticeProps {
@@ -21,13 +22,26 @@ export function ViewerMileStoneNotice({ part }: ViewerMilestoneNoticeProps) {
   }
 
   return (
-    <Typography color="gray.text" style={styles.messageText}>
-      {unescapedSystemMsg}
-    </Typography>
+    <View style={styles.container}>
+      <Typography color="gray.text" style={styles.messageText}>
+        {unescapedSystemMsg}
+      </Typography>
+    </View>
   );
 }
 
 const styles = StyleSheet.create(theme => ({
+  container: {
+    width: '100%',
+    padding: theme.spacing.sm,
+    backgroundColor: theme.colors.gray.uiActive,
+    borderLeftWidth: 3,
+    borderRightWidth: 3,
+    borderLeftColor: theme.colors.violet.accent,
+    borderRightColor: theme.colors.violet.accent,
+    borderCurve: 'continuous',
+    marginVertical: theme.spacing.xs,
+  },
   messageText: {
     lineHeight: theme.spacing['2xl'],
   },

--- a/src/components/ScreenHeader/HeroHeader.tsx
+++ b/src/components/ScreenHeader/HeroHeader.tsx
@@ -1,0 +1,195 @@
+import { LinearGradient } from 'expo-linear-gradient';
+import { ReactNode } from 'react';
+import { View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { StyleSheet } from 'react-native-unistyles';
+import { IconButton } from '../IconButton';
+import { Image } from '../Image';
+import { Typography } from '../Typography';
+
+export interface HeroHeaderProps {
+  /**
+   * Main title to be displayed prominently
+   */
+  title: string;
+  /**
+   * Optional subtitle displayed below the title
+   * mainly metadata gets displayed here
+   */
+  subtitle?: string;
+  /**
+   * Background image URL for the hero section
+   */
+  backgroundImage?: string;
+  /**
+   * Featured image (e.g., category box art, profile picture etc.)
+   */
+  featuredImage?: string;
+  /**
+   * Whether to show back button
+   */
+  back?: boolean;
+  /**
+   * Custom back handler
+   */
+  onBack?: () => void;
+  /**
+   * Optional content to render on the right side of the back button row
+   */
+  trailing?: ReactNode;
+  /**
+   * Optional badges/stats to display below the title
+   */
+  badges?: ReactNode;
+  /**
+   * Optional content to render at the bottom of the hero
+   */
+  children?: ReactNode;
+  /**
+   * Height of the hero background
+   */
+  heroHeight?: number;
+}
+
+export function HeroHeader({
+  title,
+  subtitle,
+  backgroundImage,
+  featuredImage,
+  back = true,
+  onBack,
+  trailing,
+  badges,
+  children,
+  heroHeight = 280,
+}: HeroHeaderProps) {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View style={styles.container}>
+      {backgroundImage && (
+        <View style={[styles.heroBackground, { height: heroHeight }]}>
+          <Image
+            source={backgroundImage}
+            style={styles.heroBackgroundImage}
+            contentFit="cover"
+          />
+          <LinearGradient
+            colors={['rgba(0,0,0,0.3)', 'rgba(0,0,0,0.85)', 'rgba(0,0,0,1)']}
+            locations={[0, 0.6, 1]}
+            style={styles.heroGradient}
+          />
+        </View>
+      )}
+
+      {(back || trailing) && (
+        <View style={[styles.navRow, { top: insets.top + 8 }]}>
+          {back && (
+            <IconButton icon="arrowLeft" label="goBack" onPress={onBack} />
+          )}
+          <View style={styles.navSpacer} />
+          {trailing}
+        </View>
+      )}
+
+      {/* Hero content */}
+      <View style={styles.heroContent(backgroundImage)}>
+        <View style={styles.heroInner}>
+          {featuredImage && (
+            <Image source={featuredImage} style={styles.featuredImage} />
+          )}
+          <View style={styles.textContent}>
+            <Typography
+              size="xl"
+              fontWeight="bold"
+              style={styles.title}
+              numberOfLines={2}
+            >
+              {title}
+            </Typography>
+            {subtitle && (
+              <Typography
+                size="sm"
+                color="gray.textLow"
+                style={styles.subtitle}
+              >
+                {subtitle}
+              </Typography>
+            )}
+            {badges}
+          </View>
+        </View>
+      </View>
+
+      {children}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create(theme => ({
+  container: {
+    position: 'relative',
+  },
+  heroBackground: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    overflow: 'hidden',
+  },
+  heroBackgroundImage: {
+    width: '100%',
+    height: '100%',
+    opacity: 0.4,
+  },
+  heroGradient: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  navRow: {
+    position: 'absolute',
+    left: theme.spacing.sm,
+    right: theme.spacing.sm,
+    flexDirection: 'row',
+    alignItems: 'center',
+    zIndex: 10,
+  },
+  navSpacer: {
+    flex: 1,
+  },
+  heroContent: (backgroundImage?: string) => ({
+    paddingHorizontal: theme.spacing.md,
+    paddingBottom: theme.spacing.lg,
+    paddingTop: backgroundImage ? 100 : 80,
+  }),
+  heroInner: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: theme.spacing.md,
+  },
+  featuredImage: {
+    width: 100,
+    height: 134,
+    borderRadius: 8,
+    borderWidth: 2,
+    borderColor: theme.colors.violet.accent,
+    shadowColor: theme.colors.violet.accent,
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 12,
+  },
+  textContent: {
+    flex: 1,
+    paddingBottom: theme.spacing.xs,
+    gap: theme.spacing.sm,
+  },
+  title: {
+    lineHeight: 28,
+  },
+  subtitle: {
+    lineHeight: 20,
+  },
+}));

--- a/src/components/ScreenHeader/ScreenHeader.tsx
+++ b/src/components/ScreenHeader/ScreenHeader.tsx
@@ -1,0 +1,127 @@
+import { ReactNode } from 'react';
+import { View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { StyleSheet } from 'react-native-unistyles';
+import { IconButton } from '../IconButton';
+import { Typography } from '../Typography';
+
+/**
+ * TODO: unify heroheader props with this type
+ */
+export interface ScreenHeaderProps {
+  /**
+   * Main title
+   */
+  title: string;
+  /**
+   * Optional subtitle displayed below the title
+   * mainly for metadata
+   */
+  subtitle?: string;
+  /**
+   * Show back button (calls navigation.goBack by default)
+   */
+  back?: boolean;
+  /**
+   * Custom back handler
+   */
+  onBack?: () => void;
+  /**
+   * Optional content to render on the right side of the header
+   */
+  trailing?: ReactNode;
+  /**
+   * Optional content to render below the title/subtitle
+   */
+  children?: ReactNode;
+  /**
+   * Size variant for the header
+   */
+  size?: 'large' | 'medium' | 'compact';
+  /**
+   * Whether to add top safe area padding
+   */
+  safeArea?: boolean;
+}
+
+export function ScreenHeader({
+  title,
+  subtitle,
+  back = true,
+  onBack,
+  trailing,
+  children,
+  size = 'large',
+  safeArea = true,
+}: ScreenHeaderProps) {
+  const insets = useSafeAreaInsets();
+
+  const getTitleSize = () => {
+    if (size === 'large') return '2xl';
+    if (size === 'medium') return 'xl';
+    return 'lg';
+  };
+
+  const titleSize = getTitleSize();
+  const subtitleSize = size === 'compact' ? 'xs' : 'sm';
+
+  return (
+    <View
+      style={[styles.container, safeArea && { paddingTop: insets.top + 12 }]}
+    >
+      <View style={styles.navRow}>
+        {back && (
+          <IconButton icon="arrowLeft" label="goBack" onPress={onBack} />
+        )}
+        <View style={styles.navSpacer} />
+        {trailing}
+      </View>
+
+      <View style={styles.titleSection}>
+        <Typography
+          size={titleSize}
+          fontWeight="bold"
+          style={styles.title}
+          numberOfLines={2}
+        >
+          {title}
+        </Typography>
+        {subtitle && (
+          <Typography
+            size={subtitleSize}
+            color="gray.textLow"
+            style={styles.subtitle}
+          >
+            {subtitle}
+          </Typography>
+        )}
+      </View>
+
+      {children}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create(theme => ({
+  container: {
+    paddingHorizontal: theme.spacing.md,
+    paddingBottom: theme.spacing.md,
+  },
+  navRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: theme.spacing.md,
+  },
+  navSpacer: {
+    flex: 1,
+  },
+  titleSection: {
+    gap: theme.spacing.xs,
+  },
+  title: {
+    lineHeight: 34,
+  },
+  subtitle: {
+    lineHeight: 20,
+  },
+}));

--- a/src/components/ScreenHeader/index.ts
+++ b/src/components/ScreenHeader/index.ts
@@ -1,0 +1,4 @@
+export { ScreenHeader } from './ScreenHeader';
+export type { ScreenHeaderProps } from './ScreenHeader';
+export { HeroHeader } from './HeroHeader';
+export type { HeroHeaderProps } from './HeroHeader';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -15,6 +15,7 @@ export * from './ModalHandle';
 export * from './NavigationSectionList';
 export * from './OTAUpdates';
 export * from './SafeAreaViewFixed';
+export * from './ScreenHeader';
 export * from './SearchBox';
 export * from './SearchHistory';
 export * from './Seperator';

--- a/src/screens/FollowingScreen.tsx
+++ b/src/screens/FollowingScreen.tsx
@@ -3,15 +3,17 @@ import {
   LiveStreamCard,
   AnimatedFlashList,
   ListRenderItem,
+  ScreenHeader,
 } from '@app/components';
 import { LiveStreamCardSkeleton } from '@app/components/LiveStreamCard/LiveStreamCardSkeleton';
 import { RefreshControl } from '@app/components/RefreshControl';
-import { Screen } from '@app/components/Screen';
 import { useAuthContext } from '@app/context/AuthContext';
 import { twitchQueries } from '@app/queries/twitchQueries';
 import { TwitchStream } from '@app/services/twitch-service';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMemo, useState, JSX, useCallback } from 'react';
+import { View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
 
 import { toast } from 'sonner-native';
 
@@ -75,14 +77,33 @@ export default function FollowingScreen() {
     );
   }
 
+  const liveCount = streams?.length ?? 0;
+
+  const renderHeader = () => (
+    <ScreenHeader
+      title="Following"
+      subtitle={`${liveCount} channel${liveCount !== 1 ? 's' : ''} live`}
+      back={false}
+      size="large"
+    />
+  );
+
   return (
-    <Screen preset="fixed" safeAreaEdges={['top']}>
+    <View style={styles.container}>
       <AnimatedFlashList<TwitchStream>
         data={streams}
         keyExtractor={item => item.id}
         renderItem={renderItem}
+        ListHeaderComponent={renderHeader}
         refreshControl={<RefreshControl onRefresh={onRefresh} />}
       />
-    </Screen>
+    </View>
   );
 }
+
+const styles = StyleSheet.create(theme => ({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.gray.bg,
+  },
+}));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce reusable HeroHeader/ScreenHeader and apply them to Category and Following screens; enhance viewer milestone notice styling.
> 
> - **UI Components**:
>   - **`ScreenHeader`**: New configurable header (title/subtitle, back/trailing, sizes, safe-area handling).
>   - **`HeroHeader`**: New hero-style header with background/featured images, gradient overlay, badges, and children slot.
>   - Exported via `components/ScreenHeader/index.ts` and added to root `components/index.ts`.
> - **Screens**:
>   - **`CategoryScreen`**: Replaced ad-hoc header with `HeroHeader` (category art as background/featured image, subtitle with total viewers), added "Live Channels" section header, set screen background color, navigation back.
>   - **`FollowingScreen`**: Added `ScreenHeader` as list header (shows live count), replaced `Screen` wrapper with plain `View`, set background color.
> - **Chat**:
>   - **`ViewerMilestoneNotice`**: Wrapped message in styled container (full-width, padding, gray background, violet side borders, vertical margin).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2705f9437f22e4aea8916676677171e233c661ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->