### PR TITLE
fix(chat): load paints on first load

### DIFF
--- a/src/components/Chat/components/ChatMessage/CosmeticUsername.stories.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername.stories.tsx
@@ -1,7 +1,7 @@
 import type { PaintData } from '@app/utils/color/seventv-ws-service';
 import type { Meta, StoryObj } from '@storybook/react';
 import { View } from 'react-native';
-import { PaintedUsername } from './CosmeticUsername';
+import { PaintedUsername } from './CosmeticUsername/CosmeticUsername';
 
 function rgbaToSevenTvColor(
   r: number,

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/angleToPoints.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/angleToPoints.test.ts
@@ -1,0 +1,114 @@
+import { angleToPoints } from '../angleToPoints';
+
+describe('angleToPoints', () => {
+  describe('Standard angles', () => {
+    test('0deg should go from bottom to top', () => {
+      const result = angleToPoints(0);
+      // 0deg = bottom to top
+      // Start should be at bottom (y ≈ 1), end at top (y ≈ 0)
+      expect(result.start.y).toBeCloseTo(1, 5);
+      expect(result.end.y).toBeCloseTo(0, 5);
+      // Both should be centered horizontally
+      expect(result.start.x).toBeCloseTo(0.5, 5);
+      expect(result.end.x).toBeCloseTo(0.5, 5);
+    });
+
+    test('90deg should go from left to right', () => {
+      const result = angleToPoints(90);
+      // 90deg = left to right
+      // Start should be at left (x ≈ 0), end at right (x ≈ 1)
+      expect(result.start.x).toBeCloseTo(0, 5);
+      expect(result.end.x).toBeCloseTo(1, 5);
+      // Both should be centered vertically
+      expect(result.start.y).toBeCloseTo(0.5, 5);
+      expect(result.end.y).toBeCloseTo(0.5, 5);
+    });
+
+    test('180deg should go from top to bottom', () => {
+      const result = angleToPoints(180);
+      // 180deg = top to bottom
+      // Start should be at top (y ≈ 0), end at bottom (y ≈ 1)
+      expect(result.start.y).toBeCloseTo(0, 5);
+      expect(result.end.y).toBeCloseTo(1, 5);
+      // Both should be centered horizontally
+      expect(result.start.x).toBeCloseTo(0.5, 5);
+      expect(result.end.x).toBeCloseTo(0.5, 5);
+    });
+
+    test('270deg should go from right to left', () => {
+      const result = angleToPoints(270);
+      // 270deg = right to left
+      // Start should be at right (x ≈ 1), end at left (x ≈ 0)
+      expect(result.start.x).toBeCloseTo(1, 5);
+      expect(result.end.x).toBeCloseTo(0, 5);
+      // Both should be centered vertically
+      expect(result.start.y).toBeCloseTo(0.5, 5);
+      expect(result.end.y).toBeCloseTo(0.5, 5);
+    });
+  });
+
+  describe('Diagonal angles', () => {
+    test('45deg should go from bottom-left to top-right', () => {
+      const result = angleToPoints(45);
+      // 45deg = bottom-left to top-right
+      expect(result.start.x).toBeLessThan(0.5);
+      expect(result.start.y).toBeGreaterThan(0.5);
+      expect(result.end.x).toBeGreaterThan(0.5);
+      expect(result.end.y).toBeLessThan(0.5);
+    });
+
+    test('135deg should go from top-left to bottom-right', () => {
+      const result = angleToPoints(135);
+      // 135deg = top-left to bottom-right
+      expect(result.start.x).toBeLessThan(0.5);
+      expect(result.start.y).toBeLessThan(0.5);
+      expect(result.end.x).toBeGreaterThan(0.5);
+      expect(result.end.y).toBeGreaterThan(0.5);
+    });
+
+    test('225deg should go from top-right to bottom-left', () => {
+      const result = angleToPoints(225);
+      // 225deg = top-right to bottom-left
+      expect(result.start.x).toBeGreaterThan(0.5);
+      expect(result.start.y).toBeLessThan(0.5);
+      expect(result.end.x).toBeLessThan(0.5);
+      expect(result.end.y).toBeGreaterThan(0.5);
+    });
+
+    test('315deg should go from bottom-right to top-left', () => {
+      const result = angleToPoints(315);
+      // 315deg = bottom-right to top-left
+      expect(result.start.x).toBeGreaterThan(0.5);
+      expect(result.start.y).toBeGreaterThan(0.5);
+      expect(result.end.x).toBeLessThan(0.5);
+      expect(result.end.y).toBeLessThan(0.5);
+    });
+  });
+
+  describe('Coordinates', () => {
+    test('all coordinates should be in valid range [0, 1]', () => {
+      const angles = [0, 45, 90, 135, 180, 225, 270, 315, 360];
+      angles.forEach(angle => {
+        const result = angleToPoints(angle);
+        expect(result.start.x).toBeGreaterThanOrEqual(0);
+        expect(result.start.x).toBeLessThanOrEqual(1);
+        expect(result.start.y).toBeGreaterThanOrEqual(0);
+        expect(result.start.y).toBeLessThanOrEqual(1);
+        expect(result.end.x).toBeGreaterThanOrEqual(0);
+        expect(result.end.x).toBeLessThanOrEqual(1);
+        expect(result.end.y).toBeGreaterThanOrEqual(0);
+        expect(result.end.y).toBeLessThanOrEqual(1);
+      });
+    });
+
+    test('start and end points should be different', () => {
+      const angles = [0, 45, 90, 135, 180, 225, 270, 315];
+      angles.forEach(angle => {
+        const result = angleToPoints(angle);
+        expect(
+          result.start.x !== result.end.x || result.start.y !== result.end.y,
+        ).toBe(true);
+      });
+    });
+  });
+});

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/angleToPoints.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/angleToPoints.ts
@@ -1,0 +1,24 @@
+/**
+ * Calculate gradient start and end points based on angle
+ * CSS gradient angles: 0deg = bottom to top, 90deg = left to right
+ * We convert to expo-linear-gradient's coordinate system
+ */
+export function angleToPoints(angle: number): {
+  start: { x: number; y: number };
+  end: { x: number; y: number };
+} {
+  // Convert CSS angle to radians
+  // CSS: 0deg = bottom to top, clockwise positive
+  // We need to convert to coordinate points where (0,0) is top-left
+  const rad = ((angle - 90) * Math.PI) / 180;
+
+  const x1 = 0.5 + 0.5 * Math.cos(rad + Math.PI);
+  const y1 = 0.5 + 0.5 * Math.sin(rad + Math.PI);
+  const x2 = 0.5 + 0.5 * Math.cos(rad);
+  const y2 = 0.5 + 0.5 * Math.sin(rad);
+
+  return {
+    start: { x: x1, y: y1 },
+    end: { x: x2, y: y2 },
+  };
+}

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/buildGradientConfig.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/buildGradientConfig.ts
@@ -1,0 +1,57 @@
+import { indexedCollectionToArray } from '@app/services/ws/util/indexedCollection';
+import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
+import { PaintData, PaintStop } from '@app/utils/color/seventv-ws-service';
+import { angleToPoints } from './angleToPoints';
+
+export interface GradientConfig {
+  colors: string[];
+  locations: number[];
+  start: { x: number; y: number };
+  end: { x: number; y: number };
+}
+
+/**
+ * Build gradient configuration from paint data
+ */
+export function buildGradientConfig(
+  paint: PaintData,
+  fallbackColor: string,
+): GradientConfig {
+  // Handle URL paints or empty stops - use solid color
+  if (paint.function === 'URL' || !paint.stops || paint.stops.length === 0) {
+    const solidColor =
+      paint.color !== null ? sevenTvColorToCss(paint.color) : fallbackColor;
+    return {
+      colors: [solidColor, solidColor],
+      locations: [0, 1],
+      start: { x: 0, y: 0 },
+      end: { x: 1, y: 0 },
+    };
+  }
+
+  const stops = indexedCollectionToArray<PaintStop>(paint.stops);
+  const sortedStops = [...stops].sort((a, b) => a.at - b.at);
+
+  const gradientColors = sortedStops.map(stop => sevenTvColorToCss(stop.color));
+  const gradientLocations = sortedStops.map(stop => stop.at);
+
+  // Need at least 2 stops for a gradient
+  if (gradientColors.length < 2) {
+    const color = gradientColors[0] || fallbackColor;
+    return {
+      colors: [color, color],
+      locations: [0, 1],
+      start: { x: 0, y: 0 },
+      end: { x: 1, y: 0 },
+    };
+  }
+
+  const points = angleToPoints(paint.angle || 0);
+
+  return {
+    colors: gradientColors,
+    locations: gradientLocations,
+    start: points.start,
+    end: points.end,
+  };
+}

--- a/src/components/Chat/components/ChatMessage/__tests__/CosmeticUsername.test.tsx
+++ b/src/components/Chat/components/ChatMessage/__tests__/CosmeticUsername.test.tsx
@@ -1,6 +1,6 @@
 import type { PaintData } from '@app/utils/color/seventv-ws-service';
 import { render } from '@testing-library/react-native';
-import { PaintedUsername } from '../CosmeticUsername';
+import { PaintedUsername } from '../CosmeticUsername/CosmeticUsername';
 
 jest.mock('@app/store/chatStore', () => ({
   chatStore$: {

--- a/src/components/Chat/components/ChatMessage/index.ts
+++ b/src/components/Chat/components/ChatMessage/index.ts
@@ -1,2 +1,2 @@
 export * from './ChatMessage';
-export * from './CosmeticUsername';
+export * from './CosmeticUsername/CosmeticUsername';

--- a/src/components/Chat/hooks/useChatEmoteLoader.ts
+++ b/src/components/Chat/hooks/useChatEmoteLoader.ts
@@ -1,3 +1,4 @@
+import { useAuthContext } from '@app/context/AuthContext';
 import {
   loadChannelResources,
   createLoadController,
@@ -38,6 +39,7 @@ export const useChatEmoteLoader = ({
   channelId,
   enabled = true,
 }: UseChatEmoteLoaderOptions): UseChatEmoteLoaderResult => {
+  const { user } = useAuthContext();
   const [status, setStatus] = useState<EmoteLoadingStatus>('idle');
   const isMountedRef = useRef(true);
   const currentChannelRef = useRef<string | null>(null);
@@ -82,6 +84,7 @@ export const useChatEmoteLoader = ({
           channelId,
           forceRefresh,
           signal: controller.signal,
+          twitchUserId: user?.id,
         });
 
         // Don't update state if aborted or unmounted
@@ -122,7 +125,7 @@ export const useChatEmoteLoader = ({
         }
       }
     },
-    [channelId],
+    [channelId, user?.id],
   );
 
   const refetch = useCallback(async () => {

--- a/src/components/Chat/hooks/useEmoteResourceLoader.ts
+++ b/src/components/Chat/hooks/useEmoteResourceLoader.ts
@@ -1,3 +1,4 @@
+import { useAuthContext } from '@app/context/AuthContext';
 import {
   loadChannelResources,
   getSevenTvEmoteSetId,
@@ -21,6 +22,7 @@ export const useEmoteResourceLoader = ({
   isChatConnected,
   isMountedRef,
 }: UseEmoteResourceLoaderOptions) => {
+  const { user } = useAuthContext();
   const loadingAbortRef = useRef<AbortController | null>(null);
   const emoteLoadingStartedRef = useRef(false);
 
@@ -46,7 +48,10 @@ export const useEmoteResourceLoader = ({
 
       if (chatConnected) {
         emoteLoadingStartedRef.current = true;
-        void loadChannelResources(channelId).then(success => {
+        void loadChannelResources({
+          channelId,
+          twitchUserId: user?.id,
+        }).then(success => {
           if (isMountedRef.current && !abortController.signal.aborted) {
             if (!success) {
               emoteLoadingStartedRef.current = false;
@@ -71,12 +76,16 @@ export const useEmoteResourceLoader = ({
       abortController.abort();
       emoteLoadingStartedRef.current = false;
     };
-  }, [channelId, accessToken, isChatConnected, isMountedRef]);
+  }, [channelId, accessToken, isMountedRef, isChatConnected, user?.id]);
 
   const handleRefetch = useCallback(() => {
     emoteLoadingStartedRef.current = false;
-    void loadChannelResources(channelId, true);
-  }, [channelId]);
+    void loadChannelResources({
+      channelId,
+      forceRefresh: true,
+      twitchUserId: user?.id,
+    });
+  }, [channelId, user?.id]);
 
   const cleanup = useCallback(() => {
     if (loadingAbortRef.current) {

--- a/src/screens/DevTools/CachedImagesScreen.tsx
+++ b/src/screens/DevTools/CachedImagesScreen.tsx
@@ -3,15 +3,24 @@ import { FlashList, ListRenderItem } from '@app/components/FlashList';
 import { Image } from '@app/components/Image';
 import { ScreenHeader } from '@app/components/ScreenHeader';
 import { Text } from '@app/components/Text';
-import { clearEmoteImageCache } from '@app/store/chatStore';
+import {
+  chatStore$,
+  clearEmoteImageCache,
+  clearPaints,
+  clearSevenTvBadges,
+  usePaints,
+} from '@app/store/chatStore';
 import {
   CachedImageInfo,
   getCacheDirectoryPath,
   listCachedImages,
 } from '@app/utils/image/image-cache';
-import { useCallback, useEffect, useState } from 'react';
+import { useSelector } from '@legendapp/state/react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Alert, View } from 'react-native';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+
+type TabType = 'images' | 'badges' | 'paints';
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B';
@@ -21,10 +30,29 @@ function formatBytes(bytes: number): string {
   return `${parseFloat((bytes / k ** i).toFixed(2))} ${sizes[i]}`;
 }
 
+interface BadgeInfo {
+  id: string;
+  url: string;
+  title: string;
+  type: string;
+  provider?: string;
+}
+
+interface PaintInfo {
+  id: string;
+  name: string;
+  function: string;
+  color: string | null;
+}
+
 export function CachedImagesScreen() {
   const { theme } = useUnistyles();
+  const [activeTab, setActiveTab] = useState<TabType>('images');
   const [images, setImages] = useState<CachedImageInfo[]>([]);
   const [refreshKey, setRefreshKey] = useState(0);
+
+  const badges = useSelector(chatStore$.badges);
+  const paints = usePaints();
 
   useEffect(() => {
     const cachedImages = listCachedImages();
@@ -32,6 +60,27 @@ export function CachedImagesScreen() {
   }, [refreshKey]);
 
   const totalSize = images.reduce((acc, img) => acc + img.size, 0);
+
+  const badgeList = useMemo<BadgeInfo[]>(() => {
+    return Object.values(badges).map(badge => ({
+      id: badge.id,
+      url: badge.url,
+      title: badge.title,
+      type: badge.type,
+      provider: badge.provider,
+    }));
+  }, [badges]);
+
+  const paintList = useMemo<PaintInfo[]>(() => {
+    return Object.values(paints).map(paint => ({
+      id: paint.id,
+      name: paint.name,
+      function: paint.function,
+      color: paint.color
+        ? `#${paint.color.toString(16).padStart(8, '0')}`
+        : null,
+    }));
+  }, [paints]);
 
   const handleClearCache = useCallback(() => {
     Alert.alert(
@@ -55,19 +104,105 @@ export function CachedImagesScreen() {
     setRefreshKey(k => k + 1);
   }, []);
 
-  const renderItem: ListRenderItem<CachedImageInfo> = useCallback(
+  const handleClearBadges = useCallback(() => {
+    Alert.alert(
+      'Clear 7TV Badges',
+      `Are you sure you want to clear ${badgeList.length} cached 7TV badges?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Clear',
+          style: 'destructive',
+          onPress: () => {
+            clearSevenTvBadges();
+            Alert.alert('Success', 'All 7TV badges have been cleared');
+            setRefreshKey(k => k + 1);
+          },
+        },
+      ],
+    );
+  }, [badgeList.length]);
+
+  const handleClearPaints = useCallback(() => {
+    Alert.alert(
+      'Clear Paints',
+      `Are you sure you want to clear ${paintList.length} cached 7TV paints?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Clear',
+          style: 'destructive',
+          onPress: () => {
+            clearPaints();
+            Alert.alert('Success', 'All paints have been cleared');
+            setRefreshKey(k => k + 1);
+          },
+        },
+      ],
+    );
+  }, [paintList.length]);
+
+  const renderImageItem: ListRenderItem<CachedImageInfo> = useCallback(
+    ({ item }) => {
+      const fileName = item.uri.split('/').pop() ?? item.name;
+      return (
+        <View style={styles.item}>
+          <View style={styles.thumbnailContainer}>
+            <Image
+              source={{ uri: item.uri }}
+              style={styles.thumbnail}
+              contentFit="contain"
+            />
+          </View>
+          <View style={styles.itemInfo}>
+            <View style={styles.itemHeader}>
+              <Text style={styles.itemName} numberOfLines={1}>
+                {fileName}
+              </Text>
+              <View style={styles.sizeBadge}>
+                <Text style={styles.sizeBadgeText}>
+                  {formatBytes(item.size)}
+                </Text>
+              </View>
+            </View>
+            <Text style={styles.itemPath} selectable numberOfLines={1}>
+              {item.uri}
+            </Text>
+          </View>
+        </View>
+      );
+    },
+    [],
+  );
+
+  const renderBadgeItem: ListRenderItem<BadgeInfo> = useCallback(
     ({ item }) => (
-      <View style={styles.imageItem}>
-        <Image
-          source={{ uri: item.uri }}
-          style={styles.thumbnail}
-          contentFit="contain"
-        />
-        <View style={styles.imageInfo}>
-          <Text style={styles.imageName}>{item.name}</Text>
-          <Text style={styles.imageSize}>{formatBytes(item.size)}</Text>
-          <Text style={styles.imagePath} selectable>
-            {item.uri}
+      <View style={styles.item}>
+        <View style={styles.thumbnailContainer}>
+          <Image
+            source={{ uri: item.url }}
+            style={styles.thumbnail}
+            contentFit="contain"
+          />
+        </View>
+        <View style={styles.itemInfo}>
+          <View style={styles.itemHeader}>
+            <Text style={styles.itemName} numberOfLines={1}>
+              {item.title}
+            </Text>
+          </View>
+          <View style={styles.badgeMeta}>
+            <Text style={styles.itemMeta}>{item.type}</Text>
+            {item.provider && (
+              <View style={styles.providerBadge}>
+                <Text style={styles.providerBadgeText}>
+                  {item.provider.toUpperCase()}
+                </Text>
+              </View>
+            )}
+          </View>
+          <Text style={styles.itemPath} selectable numberOfLines={1}>
+            {item.id}
           </Text>
         </View>
       </View>
@@ -75,60 +210,261 @@ export function CachedImagesScreen() {
     [],
   );
 
+  const renderPaintItem: ListRenderItem<PaintInfo> = useCallback(
+    ({ item }) => (
+      <View style={styles.item}>
+        <View style={styles.thumbnailContainer}>
+          <View
+            style={[
+              styles.paintPreview,
+              item.color
+                ? { backgroundColor: item.color }
+                : { backgroundColor: theme.colors.gray.ui },
+            ]}
+          />
+        </View>
+        <View style={styles.itemInfo}>
+          <View style={styles.itemHeader}>
+            <Text style={styles.itemName} numberOfLines={1}>
+              {item.name || 'Unnamed Paint'}
+            </Text>
+            {item.color && (
+              <View
+                style={[styles.colorBadge, { backgroundColor: item.color }]}
+              />
+            )}
+          </View>
+          <Text style={styles.itemMeta}>
+            {item.function.replace(/_/g, ' ').toLowerCase()}
+          </Text>
+          <Text style={styles.itemPath} selectable numberOfLines={1}>
+            {item.id}
+          </Text>
+        </View>
+      </View>
+    ),
+    [theme.colors.gray.ui],
+  );
+
+  const getSubtitle = () => {
+    switch (activeTab) {
+      case 'images':
+        return `${images.length} images • ${formatBytes(totalSize)}`;
+      case 'badges':
+        return `${badgeList.length} badges`;
+      case 'paints':
+        return `${paintList.length} paints`;
+      default:
+        return '';
+    }
+  };
+
+  const renderEmptyState = (message: string, submessage: string) => (
+    <View style={styles.emptyState}>
+      <Text style={styles.emptyText}>{message}</Text>
+      <Text style={styles.emptySubtext}>{submessage}</Text>
+    </View>
+  );
+
+  const renderListHeader = () => (
+    <View style={styles.headerContainer}>
+      <View style={styles.tabContainer}>
+        <Button
+          onPress={() => setActiveTab('images')}
+          style={[
+            styles.tabButton,
+            activeTab === 'images' && styles.tabButtonActive,
+            activeTab === 'images' && {
+              backgroundColor: theme.colors.blue.accent,
+            },
+          ]}
+        >
+          <Text
+            style={[
+              styles.tabButtonText,
+              activeTab === 'images' && styles.tabButtonTextActive,
+            ]}
+          >
+            Images
+          </Text>
+        </Button>
+        <Button
+          onPress={() => setActiveTab('badges')}
+          style={[
+            styles.tabButton,
+            activeTab === 'badges' && styles.tabButtonActive,
+            activeTab === 'badges' && {
+              backgroundColor: theme.colors.orange.accent,
+            },
+          ]}
+        >
+          <Text
+            style={[
+              styles.tabButtonText,
+              activeTab === 'badges' && styles.tabButtonTextActive,
+            ]}
+          >
+            Badges
+          </Text>
+        </Button>
+        <Button
+          onPress={() => setActiveTab('paints')}
+          style={[
+            styles.tabButton,
+            activeTab === 'paints' && styles.tabButtonActive,
+            activeTab === 'paints' && {
+              backgroundColor:
+                theme.colors.violet?.accent || theme.colors.orange.accent,
+            },
+          ]}
+        >
+          <Text
+            style={[
+              styles.tabButtonText,
+              activeTab === 'paints' && styles.tabButtonTextActive,
+            ]}
+          >
+            Paints
+          </Text>
+        </Button>
+      </View>
+
+      {/* Cache Location (only show for images) */}
+      {activeTab === 'images' && (
+        <View style={styles.pathContainer}>
+          <Text style={styles.pathLabel}>Cache Location</Text>
+          <Text style={styles.pathValue} numberOfLines={1} selectable>
+            {getCacheDirectoryPath()}
+          </Text>
+        </View>
+      )}
+
+      {/* Action Buttons */}
+      <View style={styles.actions}>
+        <Button onPress={handleRefresh} style={styles.button}>
+          <Text style={styles.buttonText}>Refresh</Text>
+        </Button>
+        {activeTab === 'images' && (
+          <Button
+            onPress={handleClearCache}
+            style={styles.button}
+            disabled={images.length === 0}
+          >
+            <Text
+              style={[
+                styles.buttonText,
+                images.length === 0 && styles.buttonTextDisabled,
+              ]}
+            >
+              Clear
+            </Text>
+          </Button>
+        )}
+        {activeTab === 'badges' && (
+          <Button
+            onPress={handleClearBadges}
+            style={styles.button}
+            disabled={badgeList.length === 0}
+          >
+            <Text
+              style={[
+                styles.buttonText,
+                badgeList.length === 0 && styles.buttonTextDisabled,
+              ]}
+            >
+              Clear
+            </Text>
+          </Button>
+        )}
+        {activeTab === 'paints' && (
+          <Button
+            onPress={handleClearPaints}
+            style={styles.button}
+            disabled={paintList.length === 0}
+          >
+            <Text
+              style={[
+                styles.buttonText,
+                paintList.length === 0 && styles.buttonTextDisabled,
+              ]}
+            >
+              Clear
+            </Text>
+          </Button>
+        )}
+      </View>
+    </View>
+  );
+
+  const renderContent = () => {
+    switch (activeTab) {
+      case 'images':
+        return (
+          <FlashList
+            data={images}
+            contentInsetAdjustmentBehavior="automatic"
+            renderItem={renderImageItem}
+            keyExtractor={item => item.uri}
+            contentContainerStyle={styles.listContent}
+            ListHeaderComponent={renderListHeader}
+            ListEmptyComponent={() =>
+              renderEmptyState(
+                'No cached images found',
+                'Emote images will appear here after visiting a chat',
+              )
+            }
+          />
+        );
+      case 'badges':
+        return (
+          <FlashList
+            data={badgeList}
+            contentInsetAdjustmentBehavior="automatic"
+            renderItem={renderBadgeItem}
+            keyExtractor={item => item.id}
+            contentContainerStyle={styles.listContent}
+            ListHeaderComponent={renderListHeader}
+            ListEmptyComponent={() =>
+              renderEmptyState(
+                'No cached badges found',
+                '7TV badges will appear here after viewing users with badges in chat',
+              )
+            }
+          />
+        );
+      case 'paints':
+        return (
+          <FlashList
+            data={paintList}
+            contentInsetAdjustmentBehavior="automatic"
+            renderItem={renderPaintItem}
+            keyExtractor={item => item.id}
+            contentContainerStyle={styles.listContent}
+            ListHeaderComponent={renderListHeader}
+            ListEmptyComponent={() =>
+              renderEmptyState(
+                'No cached paints found',
+                '7TV paints will appear here after viewing users with paints in chat',
+              )
+            }
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
   return (
     <View style={styles.screenContainer}>
       <View style={styles.container}>
         <ScreenHeader
-          title="Cached Images"
-          subtitle={`${images.length} images • ${formatBytes(totalSize)}`}
+          title="Cache Manager"
+          subtitle={getSubtitle()}
           size="medium"
         />
 
-        <View style={styles.pathContainer}>
-          <Text style={styles.pathLabel}>Cache Location:</Text>
-          <Text style={styles.pathValue} numberOfLines={2}>
-            {getCacheDirectoryPath()}
-          </Text>
-        </View>
-
-        <View style={styles.actions}>
-          <Button
-            onPress={handleRefresh}
-            style={[
-              styles.button,
-              { backgroundColor: theme.colors.blue.accent },
-            ]}
-          >
-            <Text style={styles.buttonText}>Refresh</Text>
-          </Button>
-          <Button
-            onPress={handleClearCache}
-            style={[
-              styles.button,
-              { backgroundColor: theme.colors.red.accent },
-            ]}
-            disabled={images.length === 0}
-          >
-            <Text style={styles.buttonText}>Clear All</Text>
-          </Button>
-        </View>
-
-        {images.length === 0 ? (
-          <View style={styles.emptyState}>
-            <Text style={styles.emptyText}>No cached images found</Text>
-            <Text style={styles.emptySubtext}>
-              Emote images will appear here after visiting a chat
-            </Text>
-          </View>
-        ) : (
-          <FlashList
-            data={images}
-            contentInsetAdjustmentBehavior="automatic"
-            renderItem={renderItem}
-            keyExtractor={item => item.uri}
-            contentContainerStyle={styles.listContent}
-          />
-        )}
+        {/* Content List with Header */}
+        {renderContent()}
       </View>
     </View>
   );
@@ -142,95 +478,213 @@ const styles = StyleSheet.create(theme => ({
   container: {
     flex: 1,
   },
+  headerContainer: {
+    backgroundColor: theme.colors.gray.bg,
+    paddingBottom: 8,
+  },
+  tabContainer: {
+    flexDirection: 'row',
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 8,
+  },
+  tabButton: {
+    flex: 1,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: theme.colors.gray.ui,
+    borderWidth: 1,
+    borderColor: theme.colors.gray.border,
+  },
+  tabButtonActive: {
+    borderColor: 'transparent',
+  },
+  tabButtonText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: theme.colors.gray.text,
+    letterSpacing: 0.2,
+  },
+  tabButtonTextActive: {
+    color: '#fff',
+  },
   pathContainer: {
     paddingHorizontal: 16,
-    paddingVertical: 8,
-    backgroundColor: theme.colors.gray.bg,
+    paddingVertical: 12,
+    backgroundColor: theme.colors.gray.ui,
     marginHorizontal: 16,
-    borderRadius: 8,
+    borderRadius: 10,
     marginBottom: 8,
+    borderWidth: 1,
+    borderColor: theme.colors.gray.border,
   },
   pathLabel: {
-    fontSize: 12,
-    fontWeight: '600',
+    fontSize: 11,
+    fontWeight: '700',
     color: theme.colors.gray.textLow,
-    marginBottom: 4,
+    marginBottom: 6,
+    letterSpacing: 0.5,
   },
   pathValue: {
     fontSize: 11,
     color: theme.colors.gray.text,
     fontFamily: 'monospace',
+    lineHeight: 16,
   },
   actions: {
     flexDirection: 'row',
-    gap: 12,
+    gap: 8,
     paddingHorizontal: 16,
-    paddingVertical: 12,
+    paddingTop: 4,
+    paddingBottom: 4,
   },
   button: {
     flex: 1,
-    paddingVertical: 12,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
     borderRadius: 8,
     alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: theme.colors.gray.ui,
+    borderWidth: 1,
+    borderColor: theme.colors.gray.border,
   },
   buttonText: {
-    color: '#fff',
-    fontWeight: '600',
+    color: theme.colors.gray.text,
+    fontWeight: '500',
+    fontSize: 13,
+  },
+  buttonTextDisabled: {
+    color: theme.colors.gray.textLow,
+    opacity: 0.5,
   },
   listContent: {
     paddingHorizontal: 16,
+    paddingTop: 8,
     paddingBottom: 16,
   },
-  imageItem: {
+  item: {
     flexDirection: 'row',
     alignItems: 'flex-start',
-    padding: 12,
+    padding: 16,
+    backgroundColor: theme.colors.gray.ui,
+    borderRadius: 14,
+    marginBottom: 12,
+    gap: 14,
+    borderWidth: 1,
+    borderColor: theme.colors.gray.border,
+  },
+  thumbnailContainer: {
+    borderRadius: 10,
+    overflow: 'hidden',
     backgroundColor: theme.colors.gray.bg,
-    borderRadius: 12,
-    marginBottom: 8,
-    gap: 12,
   },
   thumbnail: {
-    width: 56,
-    height: 56,
-    borderRadius: 8,
-    backgroundColor: theme.colors.gray.ui,
+    width: 64,
+    height: 64,
+    borderRadius: 10,
   },
-  imageInfo: {
+  paintPreview: {
+    width: 64,
+    height: 64,
+    borderRadius: 10,
+    borderWidth: 2,
+    borderColor: theme.colors.gray.border,
+  },
+  itemInfo: {
     flex: 1,
     flexShrink: 1,
-    gap: 2,
+    gap: 6,
   },
-  imageName: {
-    fontSize: 14,
-    fontWeight: '500',
+  itemHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 2,
+  },
+  itemName: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: '600',
     color: theme.colors.gray.text,
+    letterSpacing: -0.2,
   },
-  imageSize: {
+  sizeBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    backgroundColor: theme.colors.gray.bg,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: theme.colors.gray.border,
+  },
+  sizeBadgeText: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: theme.colors.gray.text,
+    fontFamily: 'monospace',
+  },
+  providerBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 3,
+    backgroundColor: theme.colors.gray.bg,
+    borderRadius: 4,
+    marginLeft: 6,
+  },
+  providerBadgeText: {
+    fontSize: 9,
+    fontWeight: '700',
+    color: theme.colors.gray.textLow,
+    letterSpacing: 0.5,
+  },
+  colorBadge: {
+    width: 20,
+    height: 20,
+    borderRadius: 6,
+    borderWidth: 1.5,
+    borderColor: theme.colors.gray.border,
+  },
+  itemMeta: {
     fontSize: 12,
     color: theme.colors.gray.textLow,
+    fontWeight: '500',
   },
-  imagePath: {
+  itemPath: {
     fontSize: 10,
     color: theme.colors.gray.textLow,
     fontFamily: 'monospace',
-    marginTop: 4,
+    marginTop: 2,
+    opacity: 0.7,
+  },
+  badgeMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 4,
   },
   emptyState: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     paddingHorizontal: 32,
+    paddingTop: 80,
+    paddingBottom: 40,
   },
   emptyText: {
-    fontSize: 18,
-    fontWeight: '600',
+    fontSize: 19,
+    fontWeight: '700',
     color: theme.colors.gray.textLow,
-    marginBottom: 8,
+    marginBottom: 10,
+    letterSpacing: -0.3,
   },
   emptySubtext: {
     fontSize: 14,
     color: theme.colors.gray.textLow,
     textAlign: 'center',
+    lineHeight: 21,
+    opacity: 0.8,
   },
 }));

--- a/src/screens/DevTools/DebugScreen.tsx
+++ b/src/screens/DevTools/DebugScreen.tsx
@@ -77,7 +77,6 @@ export function DebugScreen() {
     if (!channelName.trim()) {
       return;
     }
-    // Navigate to root-level Chat (outside tabs) so tab bar is hidden
     navigation
       .getParent()
       ?.getParent()

--- a/src/screens/Stream/LiveStreamScreen.tsx
+++ b/src/screens/Stream/LiveStreamScreen.tsx
@@ -1,6 +1,5 @@
 import { Chat } from '@app/components/Chat';
 import { Spinner } from '@app/components/Spinner';
-import { Text } from '@app/components/Text';
 import { StreamStackScreenProps } from '@app/navigators/StreamStackNavigator';
 import { twitchQueries } from '@app/queries/twitchQueries';
 import { useQueries } from '@tanstack/react-query';
@@ -129,14 +128,6 @@ export const LiveStreamScreen: FC<StreamStackScreenProps<'LiveStream'>> = ({
     return <Spinner />;
   }
 
-  if (!stream) {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.videoUser}>User Offline</Text>
-      </View>
-    );
-  }
-
   return (
     <View style={[styles.contentContainer, isLandscape && styles.row]}>
       {/* <GestureDetector gesture={doubleTapGesture}>
@@ -157,7 +148,7 @@ export const LiveStreamScreen: FC<StreamStackScreenProps<'LiveStream'>> = ({
 
       {(isChatVisible || chatOpacity.value > 0) && (
         <Animated.View style={[styles.chatContainer, animatedChatStyle]}>
-          {shouldRenderChat && stream.user_login && stream.user_id && (
+          {shouldRenderChat && stream?.user_login && stream.user_id && (
             <View style={styles.chatContent}>
               <Chat
                 channelId={stream.user_id}

--- a/src/services/twitch-badge-service.ts
+++ b/src/services/twitch-badge-service.ts
@@ -27,6 +27,7 @@ export interface SanitisedBadgeSet {
     | 'Twitch Global Badge'
     | 'FFZ Badge'
     | 'FFZ Channel Badge'
+    | '7TV Badge'
   >;
   title: string;
 
@@ -36,6 +37,10 @@ export interface SanitisedBadgeSet {
    * The set ID
    */
   set: string;
+  /**
+   * The provider of the badge (7TV, BTTV, FFZ)
+   */
+  provider?: '7tv' | 'bttv' | 'ffz';
 }
 
 export const twitchBadgeService = {
@@ -65,6 +70,7 @@ export const twitchBadgeService = {
           });
         });
       }
+
       if (badgeSet.set_id === 'subscriber') {
         badgeSet.versions.forEach((badge: TwitchBadgeVersion) => {
           sanitisedBadges.push({


### PR DESCRIPTION
Resolves 7tv paints not loading on first load of chat - due to us not performing a GQL request to fetch the paint data rather than wait and pray that an cosmetic.create event comes thru for that given user (faster + more reliable to hit the GQL endpoint once and then cache the result for that user)