### PR TITLE
Support URL/image-based paint for painted usernames

### DIFF
--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/CosmeticUsername.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/CosmeticUsername.tsx
@@ -7,7 +7,13 @@ import { useSelector } from '@legendapp/state/react';
 import MaskedView from '@react-native-masked-view/masked-view';
 import { LinearGradient } from 'expo-linear-gradient';
 import { memo, useMemo } from 'react';
-import { type StyleProp, TextStyle, View, StyleSheet } from 'react-native';
+import {
+  type StyleProp,
+  TextStyle,
+  View,
+  StyleSheet,
+  Image,
+} from 'react-native';
 import Svg, {
   Defs,
   RadialGradient as SvgRadialGradient,
@@ -103,6 +109,7 @@ function PaintedUsernameComponent({
   }, [paint]);
 
   const isRadial = paint?.function === 'RADIAL_GRADIENT';
+  const isAssetPaint = paint?.function === 'URL' && !!paint.image_url;
 
   const renderGradient = () => {
     if (isRadial) {
@@ -139,6 +146,23 @@ function PaintedUsernameComponent({
             </Svg>
           </View>
           {/* Invisible text to size the gradient correctly */}
+          <Text style={[styles.hiddenText, usernameTextStyle, shadowStyle]}>
+            {displayUsername}
+          </Text>
+        </View>
+      );
+    }
+
+    if (isAssetPaint) {
+      return (
+        <View style={styles.gradient}>
+          <View style={styles.svgContainer}>
+            <Image
+              source={{ uri: paint.image_url }}
+              style={styles.assetPaintImage}
+              resizeMode={paint.repeat ? 'repeat' : 'cover'}
+            />
+          </View>
           <Text style={[styles.hiddenText, usernameTextStyle, shadowStyle]}>
             {displayUsername}
           </Text>
@@ -202,6 +226,13 @@ const styles = StyleSheet.create({
   },
   svgGradient: {
     position: 'absolute',
+  },
+  assetPaintImage: {
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
   },
 });
 

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/buildGradientConfig.sevenTvParity.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/buildGradientConfig.sevenTvParity.test.ts
@@ -1,0 +1,100 @@
+import type { PaintData } from '@app/utils/color/seventv-ws-service';
+import { buildGradientConfig } from '../buildGradientConfig';
+
+function rgbaToSevenTvColor(
+  r: number,
+  g: number,
+  b: number,
+  a: number,
+): number {
+  // eslint-disable-next-line no-bitwise
+  return ((r << 24) | (g << 16) | (b << 8) | a) >>> 0;
+}
+
+const createPaintData = (overrides: Partial<PaintData> = {}): PaintData => ({
+  id: 'paint-1',
+  name: 'Test Paint',
+  color: null,
+  gradients: { length: 0 },
+  shadows: { length: 0 },
+  text: null,
+  function: 'LINEAR_GRADIENT',
+  repeat: false,
+  angle: 90,
+  shape: 'circle',
+  image_url: '',
+  stops: { length: 0 },
+  ...overrides,
+});
+
+describe('buildGradientConfig (7TV parity fixtures)', () => {
+  const fallbackColor = '#FFFFFF';
+
+  test('rose gold fixture keeps stop order/locations and left->right angle behavior', () => {
+    const roseGold = createPaintData({
+      angle: 90,
+      stops: {
+        0: { at: 0, color: rgbaToSevenTvColor(254, 118, 148, 255) },
+        1: { at: 0.5, color: rgbaToSevenTvColor(255, 200, 180, 255) },
+        2: { at: 1, color: rgbaToSevenTvColor(255, 77, 115, 255) },
+        length: 3,
+      },
+    });
+
+    const config = buildGradientConfig(roseGold, fallbackColor);
+    expect(config.colors).toEqual(['#fe7694ff', '#ffc8b4ff', '#ff4d73ff']);
+    expect(config.locations).toEqual([0, 0.5, 1]);
+    expect(config.start.x).toBeCloseTo(0, 5);
+    expect(config.start.y).toBeCloseTo(0.5, 5);
+    expect(config.end.x).toBeCloseTo(1, 5);
+    expect(config.end.y).toBeCloseTo(0.5, 5);
+  });
+
+  test('radial fixture still returns mapped stop colors/locations for radial renderer', () => {
+    const flowerchild = createPaintData({
+      function: 'RADIAL_GRADIENT',
+      stops: {
+        0: { at: 0, color: rgbaToSevenTvColor(100, 200, 220, 255) },
+        1: { at: 0.5, color: rgbaToSevenTvColor(0, 150, 180, 255) },
+        2: { at: 1, color: rgbaToSevenTvColor(0, 96, 128, 255) },
+        length: 3,
+      },
+    });
+
+    const config = buildGradientConfig(flowerchild, fallbackColor);
+    expect(config.colors).toEqual(['#64c8dcff', '#0096b4ff', '#006080ff']);
+    expect(config.locations).toEqual([0, 0.5, 1]);
+  });
+
+  test('unsorted stops are normalized to ascending at-values', () => {
+    const unsorted = createPaintData({
+      angle: 0,
+      stops: {
+        0: { at: 1, color: rgbaToSevenTvColor(255, 77, 115, 255) },
+        1: { at: 0, color: rgbaToSevenTvColor(254, 118, 148, 255) },
+        2: { at: 0.5, color: rgbaToSevenTvColor(255, 200, 180, 255) },
+        length: 3,
+      },
+    });
+
+    const config = buildGradientConfig(unsorted, fallbackColor);
+    expect(config.locations).toEqual([0, 0.5, 1]);
+    expect(config.colors).toEqual(['#fe7694ff', '#ffc8b4ff', '#ff4d73ff']);
+    expect(config.start.x).toBeCloseTo(0.5, 5);
+    expect(config.start.y).toBeCloseTo(1, 5);
+    expect(config.end.x).toBeCloseTo(0.5, 5);
+    expect(config.end.y).toBeCloseTo(0, 5);
+  });
+
+  test('URL paints still resolve to a deterministic solid fallback in gradient config', () => {
+    const assetPaint = createPaintData({
+      function: 'URL',
+      color: rgbaToSevenTvColor(194, 168, 0, 255),
+      image_url: 'https://cdn.7tv.app/paint/test/4x.webp',
+    });
+
+    const config = buildGradientConfig(assetPaint, fallbackColor);
+    expect(config.colors).toEqual(['#c2a800ff', '#c2a800ff']);
+    expect(config.locations).toEqual([0, 1]);
+  });
+});

--- a/src/components/Chat/components/ChatMessage/__tests__/CosmeticUsername.test.tsx
+++ b/src/components/Chat/components/ChatMessage/__tests__/CosmeticUsername.test.tsx
@@ -1,5 +1,6 @@
 import type { PaintData } from '@app/utils/color/seventv-ws-service';
 import { render } from '@testing-library/react-native';
+import { Image } from 'react-native';
 import { PaintedUsername } from '../CosmeticUsername/CosmeticUsername';
 
 jest.mock('@app/store/chatStore/state', () => ({
@@ -130,6 +131,39 @@ describe('PaintedUsername', () => {
       );
 
       expect(getAllByText('UrlPaint:').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('should render URL paint as asset image with repeat resize mode', () => {
+      const urlPaint = createPaintData({
+        function: 'URL',
+        image_url: 'https://cdn.7tv.app/paint/test/2x.webp',
+        repeat: true,
+      });
+
+      const { UNSAFE_getByType } = render(
+        <PaintedUsername username="AssetRepeat" paint={urlPaint} />,
+      );
+
+      const paintImage = UNSAFE_getByType(Image);
+      expect(paintImage.props.source).toEqual({
+        uri: 'https://cdn.7tv.app/paint/test/2x.webp',
+      });
+      expect(paintImage.props.resizeMode).toBe('repeat');
+    });
+
+    test('should render URL paint as asset image with cover resize mode', () => {
+      const urlPaint = createPaintData({
+        function: 'URL',
+        image_url: 'https://cdn.7tv.app/paint/test/4x.webp',
+        repeat: false,
+      });
+
+      const { UNSAFE_getByType } = render(
+        <PaintedUsername username="AssetCover" paint={urlPaint} />,
+      );
+
+      const paintImage = UNSAFE_getByType(Image);
+      expect(paintImage.props.resizeMode).toBe('cover');
     });
 
     test('should handle single stop gradient by duplicating color', () => {


### PR DESCRIPTION
### Motivation
- Add support for image-based paints so username cosmetics with `paint.function === 'URL'` and an `image_url` render correctly as the masked fill.
- Preserve existing sizing and repeat/cover behavior so image paints match gradient and radial rendering semantics.

### Description
- Import `Image` from `react-native` and add an `isAssetPaint` check for `paint.function === 'URL' && !!paint.image_url` in `PaintedUsernameComponent`.
- Render an `Image` inside the existing gradient container when `isAssetPaint` is true and set `resizeMode` to `repeat` when `paint.repeat` is truthy or to `cover` otherwise.
- Keep the invisible sizing `Text` for proper mask sizing and add an `assetPaintImage` style matching the SVG container positioning.

### Testing
- Ran TypeScript type check and linting against the modified file with no errors reported.
- Ran the component snapshot/unit tests for chat components and all affected snapshots/tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eaca78630833083e4e2ec2d70aa80)