### PR TITLE
fix(app): composer + chat provider timeout caching

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,6 @@
 const jestConfig = {
   preset: 'jest-expo',
   setupFilesAfterEnv: ['./test/setupTests.ts'],
-  setupFiles: ['./node_modules/react-native-gesture-handler/jestSetup.js'],
   transform: {
     '^.+\\.(t|j)sx?$': 'babel-jest',
   },

--- a/src/components/ui/Input/Input.ios.helpers.ts
+++ b/src/components/ui/Input/Input.ios.helpers.ts
@@ -323,16 +323,12 @@ export function buildTextFieldModifiers({
     padding(paddingForStyle(style)),
     ...fontModifiersForStyle(style),
   ];
-  const heightFrame = frameForStyle(style, multiline ? 'topLeading' : 'center');
   const keyboard = keyboardTypeForInput(inputMode, keyboardType);
   const submit = submitLabelForInput(enterKeyHint, returnKeyType);
   const autocapitalization = autocapitalizationForInput(autoCapitalize);
   const contentType = contentTypeForInput(textContentType, autoComplete);
   const textAlignment = textAlignmentForInput(textAlign ?? style.textAlign);
 
-  if (heightFrame) {
-    modifiers.push(frame(heightFrame));
-  }
   if (multiline) {
     modifiers.push(lineLimit(numberOfLines ?? 5));
   }

--- a/src/components/ui/Input/Input.ios.tsx
+++ b/src/components/ui/Input/Input.ios.tsx
@@ -675,16 +675,12 @@ function buildTextFieldModifiers({
     padding(paddingForStyle(style)),
     ...fontModifiersForStyle(style),
   ];
-  const heightFrame = frameForStyle(style, multiline ? 'topLeading' : 'center');
   const keyboard = keyboardTypeForInput(inputMode, keyboardType);
   const submit = submitLabelForInput(enterKeyHint, returnKeyType);
   const autocapitalization = autocapitalizationForInput(autoCapitalize);
   const contentType = contentTypeForInput(textContentType, autoComplete);
   const textAlignment = textAlignmentForInput(textAlign ?? style.textAlign);
 
-  if (heightFrame) {
-    modifiers.push(frame(heightFrame));
-  }
   if (multiline) {
     modifiers.push(lineLimit(numberOfLines ?? 5));
   }

--- a/src/components/ui/Input/__tests__/Input.ios.helpers.test.ts
+++ b/src/components/ui/Input/__tests__/Input.ios.helpers.test.ts
@@ -1,0 +1,28 @@
+import { buildTextFieldModifiers } from '../Input.ios.helpers';
+
+describe('Input iOS helpers', () => {
+  test('does not frame multiline text fields inside their padded container', () => {
+    const modifiers = buildTextFieldModifiers({
+      disabled: false,
+      multiline: true,
+      style: {
+        maxHeight: 120,
+        minHeight: 48,
+        paddingBottom: 12,
+        paddingTop: 12,
+      },
+      textColor: '#ffffff',
+      tintColor: '#ffffff',
+    });
+
+    expect(modifiers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ $type: 'padding' }),
+        expect.objectContaining({ $type: 'lineLimit', limit: 5 }),
+      ]),
+    );
+    expect(modifiers).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ $type: 'frame' })]),
+    );
+  });
+});

--- a/src/services/ffz-service.ts
+++ b/src/services/ffz-service.ts
@@ -163,7 +163,7 @@ export const ffzService = {
         },
         warningCause: error,
       });
-      return [];
+      throw error;
     }
   },
 
@@ -249,7 +249,7 @@ export const ffzService = {
         },
         warningCause: error,
       });
-      return [];
+      throw error;
     }
   },
 
@@ -292,7 +292,7 @@ export const ffzService = {
         },
         warningCause: error,
       });
-      return [];
+      throw error;
     }
   },
 
@@ -335,7 +335,7 @@ export const ffzService = {
         },
         warningCause: error,
       });
-      return [];
+      throw error;
     }
   },
 } as const;

--- a/src/store/chatStore/__tests__/channelLoad.test.ts
+++ b/src/store/chatStore/__tests__/channelLoad.test.ts
@@ -1,0 +1,382 @@
+import type { SanitisedBadgeSet } from '@app/services/twitch-badge-service';
+import type { SanitisedEmote } from '@app/types/emote';
+import { bttvEmoteService } from '@app/services/bttv-emote-service';
+import { chatterinoService } from '@app/services/chatterino-service';
+import { ffzService } from '@app/services/ffz-service';
+import { sevenTvService } from '@app/services/seventv-service';
+import { twitchBadgeService } from '@app/services/twitch-badge-service';
+import { twitchEmoteService } from '@app/services/twitch-emote-service';
+
+import { emptyEmoteData } from '../constants';
+import { loadChannelResources } from '../channelLoad';
+import { chatStore$ } from '../state';
+
+jest.mock('@legendapp/state/persist', () => ({
+  configureObservablePersistence: jest.fn(),
+  persistObservable: jest.fn(),
+}));
+
+jest.mock('react-native-mmkv', () => ({
+  MMKV: class MockMMKV {
+    set = jest.fn();
+    getString = jest.fn();
+    getAllKeys = jest.fn(() => []);
+    delete = jest.fn();
+  },
+  createMMKV: () => ({
+    set: jest.fn(),
+    getString: jest.fn(),
+    getAllKeys: jest.fn(() => []),
+    remove: jest.fn(),
+  }),
+}));
+
+jest.mock('@app/lib/sentry', () => ({
+  recordError: jest.fn(),
+  recordInfo: jest.fn(),
+  recordWarning: jest.fn(),
+  startSpanAsync: jest.fn(
+    async (_name: string, _op: string, fn: () => Promise<unknown>) => fn(),
+  ),
+}));
+
+jest.mock('@app/utils/logger', () => ({
+  logger: {
+    chat: {
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+    main: {
+      info: jest.fn(),
+    },
+    stv: {
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+    stvWs: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@app/services/bttv-emote-service', () => ({
+  bttvEmoteService: {
+    getSanitisedChannelEmotes: jest.fn(),
+    getSanitisedGlobalEmotes: jest.fn(),
+  },
+}));
+
+jest.mock('@app/services/chatterino-service', () => ({
+  chatterinoService: {
+    listSanitisedBadges: jest.fn(),
+  },
+}));
+
+jest.mock('@app/services/ffz-service', () => ({
+  ffzService: {
+    getSanitisedChannelBadges: jest.fn(),
+    getSanitisedChannelEmotes: jest.fn(),
+    getSanitisedGlobalBadges: jest.fn(),
+    getSanitisedGlobalEmotes: jest.fn(),
+  },
+}));
+
+jest.mock('@app/services/seventv-service', () => ({
+  sevenTvService: {
+    get7tvUserId: jest.fn(),
+    getEmoteSetId: jest.fn(),
+    getSanitisedEmoteSet: jest.fn(),
+    sendPresence: jest.fn(),
+  },
+}));
+
+jest.mock('@app/services/twitch-badge-service', () => ({
+  twitchBadgeService: {
+    listSanitisedChannelBadges: jest.fn(),
+    listSanitisedGlobalBadges: jest.fn(),
+  },
+}));
+
+jest.mock('@app/services/twitch-emote-service', () => ({
+  twitchEmoteService: {
+    getChannelEmotes: jest.fn(),
+    getGlobalEmotes: jest.fn(),
+    getSubscriberEmotes: jest.fn(),
+  },
+}));
+
+const channelId = 'channel-1';
+const twitchUserId = 'user-1';
+
+function emote(id: string): SanitisedEmote {
+  return {
+    creator: null,
+    emote_link: `https://example.com/${id}`,
+    id,
+    name: id,
+    original_name: id,
+    site: 'BTTV',
+    static_url: `https://example.com/${id}.png`,
+    url: `https://example.com/${id}.webp`,
+  };
+}
+
+function badge(id: string): SanitisedBadgeSet {
+  return {
+    id,
+    set: id,
+    title: id,
+    type: 'FFZ Badge',
+    url: `https://example.com/${id}.png`,
+  };
+}
+
+const asProviderEmotes = <T extends (...args: never[]) => Promise<unknown>>(
+  items: SanitisedEmote[],
+): Awaited<ReturnType<T>> => items as unknown as Awaited<ReturnType<T>>;
+
+function ids(items: readonly { id: string }[]): string[] {
+  return items.map(item => item.id);
+}
+
+describe('loadChannelResources cache fallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, 'now').mockReturnValue(10_000);
+    chatStore$.persisted.channelCaches.set({});
+    chatStore$.currentChannelId.set(null);
+    chatStore$.loadingState.set('IDLE');
+
+    jest.mocked(sevenTvService.getEmoteSetId).mockResolvedValue('seven-set');
+    jest
+      .mocked(sevenTvService.getSanitisedEmoteSet)
+      .mockImplementation(id =>
+        Promise.resolve(
+          asProviderEmotes<typeof sevenTvService.getSanitisedEmoteSet>([
+            emote(`seven-${id}`),
+          ]),
+        ),
+      );
+    jest.mocked(sevenTvService.get7tvUserId).mockResolvedValue('');
+    jest.mocked(sevenTvService.sendPresence).mockResolvedValue(undefined);
+    jest
+      .mocked(twitchEmoteService.getChannelEmotes)
+      .mockResolvedValue(
+        asProviderEmotes<typeof twitchEmoteService.getChannelEmotes>([
+          emote('twitch-channel-new'),
+        ]),
+      );
+    jest
+      .mocked(twitchEmoteService.getGlobalEmotes)
+      .mockResolvedValue(
+        asProviderEmotes<typeof twitchEmoteService.getGlobalEmotes>([
+          emote('twitch-global-new'),
+        ]),
+      );
+    jest.mocked(twitchEmoteService.getSubscriberEmotes).mockResolvedValue([]);
+    jest
+      .mocked(bttvEmoteService.getSanitisedGlobalEmotes)
+      .mockResolvedValue(
+        asProviderEmotes<typeof bttvEmoteService.getSanitisedGlobalEmotes>([
+          emote('bttv-global-new'),
+        ]),
+      );
+    jest
+      .mocked(bttvEmoteService.getSanitisedChannelEmotes)
+      .mockResolvedValue(
+        asProviderEmotes<typeof bttvEmoteService.getSanitisedChannelEmotes>([
+          emote('bttv-channel-new'),
+        ]),
+      );
+    jest
+      .mocked(ffzService.getSanitisedChannelEmotes)
+      .mockResolvedValue(
+        asProviderEmotes<typeof ffzService.getSanitisedChannelEmotes>([
+          emote('ffz-channel-new'),
+        ]),
+      );
+    jest
+      .mocked(ffzService.getSanitisedGlobalEmotes)
+      .mockResolvedValue(
+        asProviderEmotes<typeof ffzService.getSanitisedGlobalEmotes>([
+          emote('ffz-global-new'),
+        ]),
+      );
+    jest
+      .mocked(twitchBadgeService.listSanitisedChannelBadges)
+      .mockResolvedValue([]);
+    jest
+      .mocked(twitchBadgeService.listSanitisedGlobalBadges)
+      .mockResolvedValue([]);
+    jest
+      .mocked(ffzService.getSanitisedChannelBadges)
+      .mockResolvedValue([badge('ffz-channel-badge-new')]);
+    jest
+      .mocked(ffzService.getSanitisedGlobalBadges)
+      .mockResolvedValue([badge('ffz-global-badge-new')]);
+    jest.mocked(chatterinoService.listSanitisedBadges).mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('keeps cached provider slices when full refresh provider requests reject', async () => {
+    chatStore$.persisted.channelCaches.set({
+      [channelId]: {
+        ...emptyEmoteData,
+        badges: [badge('ffz-global-badge-cached')],
+        badgesLastUpdated: 2_000,
+        bttvChannelEmotes: [emote('bttv-channel-cached')],
+        bttvGlobalEmotes: [emote('bttv-global-cached')],
+        emotes: [
+          emote('seven-channel-cached'),
+          emote('bttv-global-cached'),
+          emote('bttv-channel-cached'),
+          emote('ffz-channel-cached'),
+          emote('ffz-global-cached'),
+        ],
+        ffzChannelBadges: [badge('ffz-channel-badge-cached')],
+        ffzChannelEmotes: [emote('ffz-channel-cached')],
+        ffzGlobalBadges: [badge('ffz-global-badge-cached')],
+        ffzGlobalEmotes: [emote('ffz-global-cached')],
+        lastUpdated: 1_000,
+        sevenTvChannelEmotes: [emote('seven-channel-cached')],
+        sevenTvEmoteSetId: 'cached-seven-set',
+      },
+    });
+
+    jest
+      .mocked(sevenTvService.getEmoteSetId)
+      .mockRejectedValue(new Error('TimeoutError'));
+    jest
+      .mocked(sevenTvService.getSanitisedEmoteSet)
+      .mockImplementation(id =>
+        id === 'cached-seven-set'
+          ? Promise.reject(new Error('TimeoutError'))
+          : Promise.resolve(
+              asProviderEmotes<typeof sevenTvService.getSanitisedEmoteSet>([
+                emote(`seven-${id}-new`),
+              ]),
+            ),
+      );
+    jest
+      .mocked(bttvEmoteService.getSanitisedGlobalEmotes)
+      .mockRejectedValue(new Error('TimeoutError'));
+    jest
+      .mocked(bttvEmoteService.getSanitisedChannelEmotes)
+      .mockResolvedValue([]);
+    jest
+      .mocked(ffzService.getSanitisedChannelEmotes)
+      .mockRejectedValue(new Error('TimeoutError'));
+    jest
+      .mocked(ffzService.getSanitisedGlobalEmotes)
+      .mockRejectedValue(new Error('TimeoutError'));
+    jest
+      .mocked(ffzService.getSanitisedChannelBadges)
+      .mockRejectedValue(new Error('TimeoutError'));
+    jest
+      .mocked(ffzService.getSanitisedGlobalBadges)
+      .mockRejectedValue(new Error('TimeoutError'));
+
+    await expect(
+      loadChannelResources({ channelId, forceRefresh: true, twitchUserId }),
+    ).resolves.toBe(true);
+
+    const cache = chatStore$.persisted.channelCaches.peek()[channelId];
+    expect(cache).toBeDefined();
+
+    expect(sevenTvService.getSanitisedEmoteSet).toHaveBeenCalledWith(
+      'cached-seven-set',
+    );
+    expect(ids(cache!.sevenTvChannelEmotes)).toEqual(['seven-channel-cached']);
+    expect(ids(cache!.bttvGlobalEmotes)).toEqual(['bttv-global-cached']);
+    expect(cache!.bttvChannelEmotes).toEqual([]);
+    expect(ids(cache!.ffzChannelEmotes)).toEqual(['ffz-channel-cached']);
+    expect(ids(cache!.ffzGlobalEmotes)).toEqual(['ffz-global-cached']);
+    expect(ids(cache!.ffzChannelBadges)).toEqual(['ffz-channel-badge-cached']);
+    expect(ids(cache!.ffzGlobalBadges)).toEqual(['ffz-global-badge-cached']);
+    expect(ids(cache!.emotes)).toContain('bttv-global-cached');
+    expect(ids(cache!.emotes)).not.toContain('bttv-channel-cached');
+    expect(cache!.lastUpdated).toBe(1_000);
+    expect(cache!.badgesLastUpdated).toBe(2_000);
+  });
+
+  test('keeps cached badge slices when stale badge refresh requests reject', async () => {
+    chatStore$.persisted.channelCaches.set({
+      [channelId]: {
+        ...emptyEmoteData,
+        badges: [badge('ffz-global-badge-cached')],
+        badgesLastUpdated: 0,
+        emotes: [emote('existing-emote')],
+        ffzGlobalBadges: [badge('ffz-global-badge-cached')],
+        lastUpdated: 9_000,
+        twitchChannelEmotes: [emote('existing-emote')],
+      },
+    });
+
+    jest
+      .mocked(ffzService.getSanitisedGlobalBadges)
+      .mockRejectedValue(new Error('TimeoutError'));
+
+    await expect(loadChannelResources({ channelId })).resolves.toBe(true);
+
+    const cache = chatStore$.persisted.channelCaches.peek()[channelId];
+    expect(cache).toBeDefined();
+
+    expect(ids(cache!.ffzGlobalBadges)).toEqual(['ffz-global-badge-cached']);
+    expect(ids(cache!.badges)).toEqual(['ffz-global-badge-cached']);
+    expect(cache!.badgesLastUpdated).toBe(0);
+    expect(cache!.lastUpdated).toBe(9_000);
+  });
+
+  test('uses empty provider slices without crashing when provider requests reject with no cache', async () => {
+    jest
+      .mocked(sevenTvService.getEmoteSetId)
+      .mockRejectedValue(new Error('TimeoutError'));
+    jest
+      .mocked(sevenTvService.getSanitisedEmoteSet)
+      .mockRejectedValue(new Error('TimeoutError'));
+    jest
+      .mocked(bttvEmoteService.getSanitisedGlobalEmotes)
+      .mockRejectedValue(new Error('TimeoutError'));
+    jest
+      .mocked(bttvEmoteService.getSanitisedChannelEmotes)
+      .mockRejectedValue(new Error('TimeoutError'));
+    jest
+      .mocked(ffzService.getSanitisedChannelEmotes)
+      .mockRejectedValue(new Error('TimeoutError'));
+    jest
+      .mocked(ffzService.getSanitisedGlobalEmotes)
+      .mockRejectedValue(new Error('TimeoutError'));
+    jest
+      .mocked(ffzService.getSanitisedChannelBadges)
+      .mockRejectedValue(new Error('TimeoutError'));
+    jest
+      .mocked(ffzService.getSanitisedGlobalBadges)
+      .mockRejectedValue(new Error('TimeoutError'));
+
+    await expect(loadChannelResources({ channelId })).resolves.toBe(true);
+
+    const cache = chatStore$.persisted.channelCaches.peek()[channelId];
+    expect(cache).toBeDefined();
+    expect(cache!.sevenTvChannelEmotes).toEqual([]);
+    expect(cache!.bttvGlobalEmotes).toEqual([]);
+    expect(cache!.bttvChannelEmotes).toEqual([]);
+    expect(cache!.ffzChannelEmotes).toEqual([]);
+    expect(cache!.ffzGlobalEmotes).toEqual([]);
+    expect(cache!.ffzChannelBadges).toEqual([]);
+    expect(cache!.ffzGlobalBadges).toEqual([]);
+    expect(cache!.emotes).toEqual([
+      emote('twitch-channel-new'),
+      emote('twitch-global-new'),
+    ]);
+    expect(cache!.lastUpdated).toBe(10_000);
+    expect(cache!.badgesLastUpdated).toBe(10_000);
+  });
+});

--- a/src/store/chatStore/__tests__/state.test.ts
+++ b/src/store/chatStore/__tests__/state.test.ts
@@ -46,15 +46,25 @@ describe('limitChannelCaches', () => {
           'channel-8': makeCache(8),
           'channel-9': makeCache(9),
           'channel-10': makeCache(10),
+          'channel-11': makeCache(11),
+          'channel-12': makeCache(12),
+          'channel-13': makeCache(13),
+          'channel-14': makeCache(14),
+          'channel-15': makeCache(15),
+          'channel-16': makeCache(16),
+          'channel-17': makeCache(17),
+          'channel-18': makeCache(18),
+          'channel-19': makeCache(19),
+          'channel-20': makeCache(20),
           current: makeCache(-1),
         },
         'current',
       );
 
-      expect(Object.keys(result)).toHaveLength(10);
+      expect(Object.keys(result)).toHaveLength(20);
       expect(result.current).toBeDefined();
       expect(result['channel-0']).toBeUndefined();
-      expect(result['channel-10']).toBeDefined();
+      expect(result['channel-20']).toBeDefined();
     } finally {
       if (nativeToSorted) {
         arrayPrototype.toSorted = nativeToSorted;

--- a/src/store/chatStore/channelLoad.ts
+++ b/src/store/chatStore/channelLoad.ts
@@ -305,9 +305,54 @@ const getSettledValue = <T>(
   result: PromiseSettledResult<T[]> | undefined,
 ): T[] => (result?.status === 'fulfilled' ? result.value : []);
 
-const getDedupedSettledValue = <T extends Identifiable>(
-  result: PromiseSettledResult<T[]> | undefined,
-): T[] => deduplicateById(getSettledValue(result));
+const getDedupedSettledOrCachedValue = <
+  T extends Identifiable,
+  TKey extends keyof ChannelCacheType,
+>({
+  channelId,
+  existingCache,
+  key,
+  provider,
+  resourceName,
+  resourceType,
+  result,
+  scope,
+}: {
+  channelId: string;
+  existingCache: ChannelCacheType | undefined;
+  key: TKey;
+  provider: ProviderName;
+  resourceName: string;
+  resourceType: ProviderResourceType;
+  result: PromiseSettledResult<T[]>;
+  scope: ProviderResourceScope;
+}): T[] => {
+  if (result.status === 'fulfilled') {
+    return deduplicateById(result.value);
+  }
+
+  const cachedItems = (existingCache?.[key] ?? []) as unknown as T[];
+
+  if (cachedItems.length > 0) {
+    logger.chat.info(`Using cached ${resourceName} as fallback.`);
+    recordInfo({
+      name: 'chat_resources_info',
+      message: `Using cached ${resourceName} as fallback`,
+      params: {
+        action: 'provider_resource_cache_fallback_used',
+        cached_count: cachedItems.length,
+        channel_id: channelId,
+        provider,
+        resource_name: resourceName,
+        resource_type: resourceType,
+        scope,
+        screen: 'chat',
+      },
+    });
+  }
+
+  return deduplicateById(cachedItems);
+};
 
 const combineUniqueById = <T extends Identifiable>(
   ...itemGroups: readonly T[][]
@@ -382,9 +427,10 @@ const loadChannelResourcesInternal = async (
   }
   chatStore$.loadingState.set('LOADING');
   try {
+    const caches = chatStore$.persisted.channelCaches.peek();
+    const existingCache = caches?.[channelId];
+
     if (!shouldForceRefresh) {
-      const caches = chatStore$.persisted.channelCaches.peek();
-      const existingCache = caches?.[channelId];
       if (existingCache) {
         const cacheAge = Date.now() - existingCache.lastUpdated;
         const hasEmptyEmotes =
@@ -571,11 +617,56 @@ const loadChannelResourcesInternal = async (
             });
 
             const badgeResourceSets = {
-              twitchChannelBadges: getDedupedSettledValue(twitchChannelBadges),
-              twitchGlobalBadges: getDedupedSettledValue(twitchGlobalBadges),
-              ffzGlobalBadges: getDedupedSettledValue(ffzGlobalBadges),
-              ffzChannelBadges: getDedupedSettledValue(ffzChannelBadges),
-              chatterinoBadges: getDedupedSettledValue(chatterinoBadges),
+              twitchChannelBadges: getDedupedSettledOrCachedValue({
+                channelId,
+                existingCache,
+                key: 'twitchChannelBadges',
+                provider: 'twitch',
+                resourceName: 'Twitch channel badges',
+                resourceType: 'badges',
+                result: twitchChannelBadges,
+                scope: 'channel',
+              }),
+              twitchGlobalBadges: getDedupedSettledOrCachedValue({
+                channelId,
+                existingCache,
+                key: 'twitchGlobalBadges',
+                provider: 'twitch',
+                resourceName: 'Twitch global badges',
+                resourceType: 'badges',
+                result: twitchGlobalBadges,
+                scope: 'global',
+              }),
+              ffzGlobalBadges: getDedupedSettledOrCachedValue({
+                channelId,
+                existingCache,
+                key: 'ffzGlobalBadges',
+                provider: 'ffz',
+                resourceName: 'FFZ global badges',
+                resourceType: 'badges',
+                result: ffzGlobalBadges,
+                scope: 'global',
+              }),
+              ffzChannelBadges: getDedupedSettledOrCachedValue({
+                channelId,
+                existingCache,
+                key: 'ffzChannelBadges',
+                provider: 'ffz',
+                resourceName: 'FFZ channel badges',
+                resourceType: 'badges',
+                result: ffzChannelBadges,
+                scope: 'channel',
+              }),
+              chatterinoBadges: getDedupedSettledOrCachedValue({
+                channelId,
+                existingCache,
+                key: 'chatterinoBadges',
+                provider: 'chatterino',
+                resourceName: 'Chatterino badges',
+                resourceType: 'badges',
+                result: chatterinoBadges,
+                scope: 'local',
+              }),
             } satisfies BadgeResourceSets;
 
             const allBadges = combineUniqueById<SanitisedBadgeSet>(
@@ -589,10 +680,20 @@ const loadChannelResourcesInternal = async (
             const channelCache = chatStore$.persisted.channelCaches[channelId];
 
             if (channelCache) {
+              const hasBadgeResourceFailure = [
+                twitchChannelBadges,
+                twitchGlobalBadges,
+                ffzGlobalBadges,
+                ffzChannelBadges,
+                chatterinoBadges,
+              ].some(result => result.status === 'rejected');
+
               channelCache.assign({
                 badges: allBadges,
                 ...badgeResourceSets,
-                badgesLastUpdated: Date.now(),
+                badgesLastUpdated: hasBadgeResourceFailure
+                  ? existingCache.badgesLastUpdated
+                  : Date.now(),
               });
             }
             recordInfo({
@@ -637,7 +738,7 @@ const loadChannelResourcesInternal = async (
       return false;
     }
 
-    let sevenTvSetId = 'global';
+    let sevenTvSetId = existingCache?.sevenTvEmoteSetId ?? 'global';
 
     try {
       sevenTvSetId = await sevenTvService.getEmoteSetId(channelId);
@@ -826,23 +927,149 @@ const loadChannelResourcesInternal = async (
     });
 
     const emoteResourceSets = {
-      sevenTvChannelEmotes: getDedupedSettledValue(sevenTvChannelEmotes),
-      sevenTvGlobalEmotes: getDedupedSettledValue(sevenTvGlobalEmotes),
-      twitchChannelEmotes: getDedupedSettledValue(twitchChannelEmotes),
-      twitchGlobalEmotes: getDedupedSettledValue(twitchGlobalEmotes),
-      twitchSubscriberEmotes: getDedupedSettledValue(twitchSubscriberEmotes),
-      bttvGlobalEmotes: getDedupedSettledValue(bttvGlobalEmotes),
-      bttvChannelEmotes: getDedupedSettledValue(bttvChannelEmotes),
-      ffzChannelEmotes: getDedupedSettledValue(ffzChannelEmotes),
-      ffzGlobalEmotes: getDedupedSettledValue(ffzGlobalEmotes),
+      sevenTvChannelEmotes: getDedupedSettledOrCachedValue({
+        channelId,
+        existingCache,
+        key: 'sevenTvChannelEmotes',
+        provider: 'seven_tv',
+        resourceName: '7TV channel emotes',
+        resourceType: 'emotes',
+        result: sevenTvChannelEmotes,
+        scope: 'channel',
+      }),
+      sevenTvGlobalEmotes: getDedupedSettledOrCachedValue({
+        channelId,
+        existingCache,
+        key: 'sevenTvGlobalEmotes',
+        provider: 'seven_tv',
+        resourceName: '7TV global emotes',
+        resourceType: 'emotes',
+        result: sevenTvGlobalEmotes,
+        scope: 'global',
+      }),
+      twitchChannelEmotes: getDedupedSettledOrCachedValue({
+        channelId,
+        existingCache,
+        key: 'twitchChannelEmotes',
+        provider: 'twitch',
+        resourceName: 'Twitch channel emotes',
+        resourceType: 'emotes',
+        result: twitchChannelEmotes,
+        scope: 'channel',
+      }),
+      twitchGlobalEmotes: getDedupedSettledOrCachedValue({
+        channelId,
+        existingCache,
+        key: 'twitchGlobalEmotes',
+        provider: 'twitch',
+        resourceName: 'Twitch global emotes',
+        resourceType: 'emotes',
+        result: twitchGlobalEmotes,
+        scope: 'global',
+      }),
+      twitchSubscriberEmotes: getDedupedSettledOrCachedValue({
+        channelId,
+        existingCache,
+        key: 'twitchSubscriberEmotes',
+        provider: 'twitch',
+        resourceName: 'Twitch subscriber emotes',
+        resourceType: 'emotes',
+        result: twitchSubscriberEmotes,
+        scope: 'personal',
+      }),
+      bttvGlobalEmotes: getDedupedSettledOrCachedValue({
+        channelId,
+        existingCache,
+        key: 'bttvGlobalEmotes',
+        provider: 'bttv',
+        resourceName: 'BTTV global emotes',
+        resourceType: 'emotes',
+        result: bttvGlobalEmotes,
+        scope: 'global',
+      }),
+      bttvChannelEmotes: getDedupedSettledOrCachedValue({
+        channelId,
+        existingCache,
+        key: 'bttvChannelEmotes',
+        provider: 'bttv',
+        resourceName: 'BTTV channel emotes',
+        resourceType: 'emotes',
+        result: bttvChannelEmotes,
+        scope: 'channel',
+      }),
+      ffzChannelEmotes: getDedupedSettledOrCachedValue({
+        channelId,
+        existingCache,
+        key: 'ffzChannelEmotes',
+        provider: 'ffz',
+        resourceName: 'FFZ channel emotes',
+        resourceType: 'emotes',
+        result: ffzChannelEmotes,
+        scope: 'channel',
+      }),
+      ffzGlobalEmotes: getDedupedSettledOrCachedValue({
+        channelId,
+        existingCache,
+        key: 'ffzGlobalEmotes',
+        provider: 'ffz',
+        resourceName: 'FFZ global emotes',
+        resourceType: 'emotes',
+        result: ffzGlobalEmotes,
+        scope: 'global',
+      }),
     } satisfies EmoteResourceSets;
 
     const badgeResourceSets = {
-      twitchChannelBadges: getDedupedSettledValue(twitchChannelBadges),
-      twitchGlobalBadges: getDedupedSettledValue(twitchGlobalBadges),
-      ffzGlobalBadges: getDedupedSettledValue(ffzGlobalBadges),
-      ffzChannelBadges: getDedupedSettledValue(ffzChannelBadges),
-      chatterinoBadges: getDedupedSettledValue(chatterinoBadges),
+      twitchChannelBadges: getDedupedSettledOrCachedValue({
+        channelId,
+        existingCache,
+        key: 'twitchChannelBadges',
+        provider: 'twitch',
+        resourceName: 'Twitch channel badges',
+        resourceType: 'badges',
+        result: twitchChannelBadges,
+        scope: 'channel',
+      }),
+      twitchGlobalBadges: getDedupedSettledOrCachedValue({
+        channelId,
+        existingCache,
+        key: 'twitchGlobalBadges',
+        provider: 'twitch',
+        resourceName: 'Twitch global badges',
+        resourceType: 'badges',
+        result: twitchGlobalBadges,
+        scope: 'global',
+      }),
+      ffzGlobalBadges: getDedupedSettledOrCachedValue({
+        channelId,
+        existingCache,
+        key: 'ffzGlobalBadges',
+        provider: 'ffz',
+        resourceName: 'FFZ global badges',
+        resourceType: 'badges',
+        result: ffzGlobalBadges,
+        scope: 'global',
+      }),
+      ffzChannelBadges: getDedupedSettledOrCachedValue({
+        channelId,
+        existingCache,
+        key: 'ffzChannelBadges',
+        provider: 'ffz',
+        resourceName: 'FFZ channel badges',
+        resourceType: 'badges',
+        result: ffzChannelBadges,
+        scope: 'channel',
+      }),
+      chatterinoBadges: getDedupedSettledOrCachedValue({
+        channelId,
+        existingCache,
+        key: 'chatterinoBadges',
+        provider: 'chatterino',
+        resourceName: 'Chatterino badges',
+        resourceType: 'badges',
+        result: chatterinoBadges,
+        scope: 'local',
+      }),
     } satisfies BadgeResourceSets;
 
     const allEmotes = combineUniqueById<SanitisedEmote>(
@@ -869,11 +1096,37 @@ const loadChannelResourcesInternal = async (
       return false;
     }
 
+    const hasEmoteResourceFailure = [
+      sevenTvChannelEmotes,
+      sevenTvGlobalEmotes,
+      twitchChannelEmotes,
+      twitchGlobalEmotes,
+      twitchSubscriberEmotes,
+      bttvGlobalEmotes,
+      bttvChannelEmotes,
+      ffzChannelEmotes,
+      ffzGlobalEmotes,
+    ].some(result => result.status === 'rejected');
+    const hasBadgeResourceFailure = [
+      twitchChannelBadges,
+      twitchGlobalBadges,
+      ffzGlobalBadges,
+      ffzChannelBadges,
+      chatterinoBadges,
+    ].some(result => result.status === 'rejected');
+    const now = Date.now();
+
     const channelData: ChannelCacheType = {
       emotes: allEmotes,
       badges: allBadges,
-      lastUpdated: Date.now(),
-      badgesLastUpdated: Date.now(),
+      lastUpdated:
+        hasEmoteResourceFailure && existingCache
+          ? existingCache.lastUpdated
+          : now,
+      badgesLastUpdated:
+        hasBadgeResourceFailure && existingCache
+          ? existingCache.badgesLastUpdated
+          : now,
       ...emoteResourceSets,
       twitchSubscriberEmotesUserId: twitchUserId ?? undefined,
       ...badgeResourceSets,

--- a/src/store/chatStore/constants.ts
+++ b/src/store/chatStore/constants.ts
@@ -129,7 +129,7 @@ export interface ChannelCacheType {
   badgesLastUpdated?: number;
 }
 
-export const MAX_CACHED_CHANNELS = 10;
+export const MAX_CACHED_CHANNELS = 20;
 export const MAX_COSMETIC_ENTRIES = 500;
 export const CACHE_DURATION = 24 * 60 * 60 * 1000; // 1 day
 export const BADGE_CACHE_DURATION = 60 * 60 * 1000; // 1 hour

--- a/src/store/chatStore/state.ts
+++ b/src/store/chatStore/state.ts
@@ -84,6 +84,7 @@ const initialChatStoreState: ChatStoreState = {
 ensureObservablePersistenceConfig();
 
 export const chatStore$ = observable<ChatStoreState>(initialChatStoreState);
+
 persistObservable(chatStore$.persisted, {
   local: createObservablePersistenceLocalConfig(CHAT_STORE_PERSISTENCE_KEY),
 });

--- a/src/store/chatStore/types.ts
+++ b/src/store/chatStore/types.ts
@@ -127,7 +127,7 @@ export interface ChannelCacheType {
   badgesLastUpdated?: number;
 }
 
-export const MAX_CACHED_CHANNELS = 10;
+export const MAX_CACHED_CHANNELS = 20;
 export const MAX_COSMETIC_ENTRIES = 500;
 export const CACHE_DURATION = 24 * 60 * 60 * 1000; // 1 day
 export const BADGE_CACHE_DURATION = 60 * 60 * 1000; // 1 hour

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -8,7 +8,6 @@
 
 /* eslint-disable @typescript-eslint/no-require-imports */
 import '@testing-library/jest-native/extend-expect';
-import 'react-native-gesture-handler/jestSetup';
 import 'react-native-url-polyfill/auto';
 import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
 import * as ReactNative from 'react-native';
@@ -50,11 +49,173 @@ jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter', () => {
 
 jest.mock('react-native-worklets');
 
-jest.mock('react-native-reanimated', () => {
-  const Reanimated = require('react-native-reanimated/mock');
+const createReactNativeHostMock = (hostName: string) => {
+  const React = require('react');
 
-  Reanimated.default.call = () => {};
-  return Reanimated;
+  return React.forwardRef(
+    (
+      {
+        children,
+        ...props
+      }: {
+        children?: React.ReactNode;
+      },
+      ref: React.Ref<unknown>,
+    ) =>
+      React.createElement(
+        hostName,
+        ref == null ? props : { ...props, ref },
+        children,
+      ),
+  );
+};
+
+jest.mock('react-native/Libraries/Text/Text', () => ({
+  __esModule: true,
+  default: createReactNativeHostMock('Text'),
+}));
+
+jest.mock('react-native/Libraries/Components/Button', () => ({
+  __esModule: true,
+  default: createReactNativeHostMock('Button'),
+}));
+
+jest.mock('react-native/Libraries/Components/TextInput/TextInput', () => ({
+  __esModule: true,
+  default: createReactNativeHostMock('TextInput'),
+}));
+
+jest.mock('react-native-gesture-handler', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  const passthroughComponent = ({
+    children,
+    ...props
+  }: {
+    children?: React.ReactNode;
+  }) => React.createElement(View, props, children);
+  const createGesture = () => {
+    const gesture: Record<string, unknown> = {};
+    const chainable = () => gesture;
+    [
+      'activeOffsetX',
+      'activeOffsetY',
+      'direction',
+      'enabled',
+      'failOffsetX',
+      'failOffsetY',
+      'maxDuration',
+      'maxPointers',
+      'minPointers',
+      'numberOfTaps',
+      'onBegin',
+      'onEnd',
+      'onFinalize',
+      'onStart',
+      'onTouchesDown',
+      'onTouchesUp',
+      'onUpdate',
+      'requireExternalGestureToFail',
+      'runOnJS',
+      'simultaneousWithExternalGesture',
+    ].forEach(method => {
+      gesture[method] = chainable;
+    });
+    return gesture;
+  };
+
+  return {
+    __esModule: true,
+    Directions: {
+      DOWN: 4,
+      LEFT: 2,
+      RIGHT: 1,
+      UP: 8,
+    },
+    Gesture: {
+      Exclusive: (...gestures: unknown[]) => gestures,
+      Fling: createGesture,
+      Pan: createGesture,
+      Pinch: createGesture,
+      Race: (...gestures: unknown[]) => gestures,
+      Simultaneous: (...gestures: unknown[]) => gestures,
+      Tap: createGesture,
+    },
+    GestureDetector: passthroughComponent,
+    GestureHandlerRootView: passthroughComponent,
+    Pressable: passthroughComponent,
+    RectButton: passthroughComponent,
+    ScrollView: passthroughComponent,
+  };
+});
+
+jest.mock('react-native-reanimated', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  const animatedComponent = React.forwardRef(
+    (
+      {
+        children,
+        ...props
+      }: {
+        children?: React.ReactNode;
+      },
+      ref: React.Ref<unknown>,
+    ) => React.createElement(View, { ...props, ref }, children),
+  );
+  const identityAnimation = (
+    value: unknown,
+    _config?: unknown,
+    callback?: (finished?: boolean) => void,
+  ) => {
+    callback?.(true);
+    return value;
+  };
+
+  return {
+    __esModule: true,
+    default: {
+      call: () => {},
+      createAnimatedComponent: (component: unknown) => component,
+      FlatList: animatedComponent,
+      Image: animatedComponent,
+      ScrollView: animatedComponent,
+      Text: animatedComponent,
+      View: animatedComponent,
+    },
+    cancelAnimation: jest.fn(),
+    createAnimatedComponent: (component: unknown) => component,
+    Easing: {
+      bezier: jest.fn(() => jest.fn()),
+      cubic: jest.fn(),
+      in: jest.fn(easing => easing),
+      inOut: jest.fn(easing => easing),
+      linear: jest.fn(),
+      out: jest.fn(easing => easing),
+    },
+    Extrapolation: {
+      CLAMP: 'clamp',
+      EXTEND: 'extend',
+      IDENTITY: 'identity',
+    },
+    interpolate: jest.fn((value: unknown) => value),
+    interpolateColor: jest.fn((value: unknown) => value),
+    runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+    runOnUI: (fn: (...args: unknown[]) => unknown) => fn,
+    useAnimatedReaction: jest.fn(),
+    useAnimatedRef: () => ({ current: null }),
+    useAnimatedScrollHandler: (handler: unknown) => handler,
+    useAnimatedStyle: (updater: () => unknown) => updater(),
+    useDerivedValue: (updater: () => unknown) => ({ value: updater() }),
+    useSharedValue: (value: unknown) => ({ value }),
+    withDelay: (_delay: number, value: unknown) => value,
+    withRepeat: (value: unknown) => value,
+    withSequence: (...values: unknown[]) => values.at(-1),
+    withSpring: identityAnimation,
+    withTiming: identityAnimation,
+  };
 });
 
 jest.mock('react-native-webview', () => {
@@ -68,14 +229,38 @@ jest.mock('react-native-webview', () => {
 });
 
 jest.doMock('react-native', () => {
+  const React = require('react');
+  const createHostComponent = (hostName: string) =>
+    React.forwardRef(
+      (
+        {
+          children,
+          ...props
+        }: {
+          children?: React.ReactNode;
+        },
+        ref: React.Ref<unknown>,
+      ) =>
+        React.createElement(
+          hostName,
+          ref == null ? props : { ...props, ref },
+          children,
+        ),
+    );
+  const MockNativeView = createHostComponent('View');
+  const MockNativeText = createHostComponent('Text');
+  const MockNativeTextInput = createHostComponent('TextInput');
+
   return Object.setPrototypeOf(
     {
+      FlatList: MockNativeView,
       Share: {
-        ...ReactNative.Share,
         share: jest.fn(),
       },
+      ScrollView: MockNativeView,
+      Text: MockNativeText,
+      TextInput: MockNativeTextInput,
       Image: {
-        ...ReactNative.Image,
         resolveAssetSource: jest.fn(_source => mockFile),
         getSize: jest.fn(
           (
@@ -89,6 +274,102 @@ jest.doMock('react-native', () => {
     ReactNative,
   );
 });
+
+jest.mock('@shopify/flash-list', () => {
+  const React = require('react');
+
+  const FlashList = React.forwardRef(
+    (
+      {
+        data = [],
+        renderItem,
+        ListEmptyComponent,
+        ...props
+      }: {
+        data?: unknown[];
+        renderItem?: (args: {
+          item: unknown;
+          index: number;
+        }) => React.ReactNode;
+        ListEmptyComponent?: React.ComponentType | React.ReactNode;
+      },
+      ref: React.Ref<unknown>,
+    ) =>
+      React.createElement(
+        'View',
+        { ...props, ref },
+        data.length > 0
+          ? data.map((item, index) =>
+              React.createElement(
+                React.Fragment,
+                { key: String(index) },
+                renderItem?.({ item, index }),
+              ),
+            )
+          : typeof ListEmptyComponent === 'function'
+            ? React.createElement(ListEmptyComponent)
+            : ListEmptyComponent,
+      ),
+  );
+
+  return {
+    __esModule: true,
+    FlashList,
+    MasonryFlashList: FlashList,
+    useMappingHelper: () => ({
+      getMappingKey: (key: string, index: number) => `${key}-${index}`,
+    }),
+  };
+});
+
+jest.mock('react-native-screens', () => {
+  const React = require('react');
+
+  const ScreenComponent = ({
+    children,
+    ...props
+  }: {
+    children?: React.ReactNode;
+  }) => React.createElement('View', props, children);
+
+  return {
+    __esModule: true,
+    enableFreeze: jest.fn(),
+    enableScreens: jest.fn(),
+    Screen: ScreenComponent,
+    ScreenContainer: ScreenComponent,
+    ScreenStack: ScreenComponent,
+    ScreenStackItem: ScreenComponent,
+  };
+});
+
+jest.mock('expo-router', () => ({
+  __esModule: true,
+  router: {
+    back: jest.fn(),
+    navigate: jest.fn(),
+    push: jest.fn(),
+    replace: jest.fn(),
+    setParams: jest.fn(),
+  },
+  Stack: {
+    Screen: () => null,
+  },
+  useLocalSearchParams: jest.fn(() => ({})),
+  useNavigation: jest.fn(() => ({
+    addListener: jest.fn(() => jest.fn()),
+    goBack: jest.fn(),
+    setOptions: jest.fn(),
+  })),
+  usePathname: jest.fn(() => '/'),
+  useRouter: jest.fn(() => ({
+    back: jest.fn(),
+    navigate: jest.fn(),
+    push: jest.fn(),
+    replace: jest.fn(),
+    setParams: jest.fn(),
+  })),
+}));
 
 jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
 


### PR DESCRIPTION


This PR Resolves: 

* https://github.com/luke-h1/foam/issues/608 - composer being clipped in chat 
* https://github.com/luke-h1/foam/issues/596 - adds support for falling back to cache if upstream emote/badge provider requests fail due to downtime/ddos 
