### PR TITLE
feat(settings): add emotes & badges viewer screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **app:** Sentry initialization
 - **app:** Sentry initialization
+
 ## 0.0.42-testflight
 
 ### ♻️ Refactor
@@ -39,6 +40,7 @@
 
 - **app:** Update rozenite ([#612](https://github.com/lhowsam/foam/issues/612))
 - **infrastructure:** Update action versions ([#618](https://github.com/lhowsam/foam/issues/618))
+
 ## 0.0.41
 
 ### ♻️ Refactor
@@ -63,6 +65,7 @@
 - **app:** Refine observability standards ([#573](https://github.com/lhowsam/foam/issues/573))
 - **app:** Release 0.0.41
 - **tooling:** Update commitlint
+
 ## 0.0.40
 
 ### ♻️ Refactor
@@ -131,6 +134,7 @@
 - **security:** Add zizmor
 - **infrastructure:** Add sonarcube ([#560](https://github.com/lhowsam/foam/issues/560))
 - **documentation:** Simplify proxy server
+
 ## ota-c42ee437-f55f-4a6e-93b8-7fb765721c2d
 
 ### ♻️ Refactor
@@ -153,11 +157,13 @@
 
 - **app:** Upgrade deps ([#509](https://github.com/lhowsam/foam/issues/509))
 - **app:** Remove interactionManager
+
 ## ota-9dc97786-4ff2-40e0-83b9-19be83418ed1
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix crash on rotate
+
 ## ota-8b3783c1-ee13-4bf3-8d2d-b68cf79a0655
 
 ### ♻️ Refactor
@@ -174,6 +180,7 @@
 
 - **app:** Fix build
 - **app:** Fix build
+
 ## ota-1ffa7bd3-e434-4400-9364-90da567dcf68
 
 ### 🐛 Bug Fixes
@@ -184,22 +191,26 @@
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Update agent skills
+
 ## ota-0831b9f9-5fce-43bb-8b70-fe9c4633601b
 
 ### ✨ Features
 
 - **app:** Ensure chat + video is in sync ([#488](https://github.com/lhowsam/foam/issues/488))
+
 ## ota-a0aa7b2d-23b7-4b57-b1eb-f6f96acb3718
 
 ### 🔧 Miscellaneous Tasks
 
 - **infrastructure:** Refresh agents
+
 ## ota-aae23856-f62e-4417-aa6b-efcef6d920b6
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix inf re-render loop
 - **app:** Fix changelogs
+
 ## ota-09afb2ac-dbdf-4b7d-996c-6beeaef68082
 
 ### 🐛 Bug Fixes
@@ -212,6 +223,7 @@
 - **app:** Remove old native player
 - **app:** Improve gh release format
 - **infrastructure:** Improve slack msg
+
 ## ota-c3493b6f-a9f2-4896-9a64-fb2d956e8245
 
 ### 🐛 Bug Fixes
@@ -224,6 +236,7 @@
 - **app:** Refresh agent skills
 - **infrastructure:** Slack noti fix
 - **infrastructure:** Fix deploy-ota-or-native
+
 ## 0.0.39
 
 ### ♻️ Refactor
@@ -246,6 +259,7 @@
 - **app:** Update deps
 - **app:** Increase test speed
 - **infrastructure:** Slack notifications
+
 ## ota-0.0.38-27
 
 ### 🐛 Bug Fixes
@@ -255,11 +269,13 @@
 ### 🔧 Miscellaneous Tasks
 
 - **infrastructure:** Don't pr a changelog
+
 ## ota-b578613f-7fd1-4d05-a6fc-10a2c2fff773
 
 ### 🐛 Bug Fixes
 
 - **infrastructure:** Improve release notes generation
+
 ## ota-1054ebce-6b29-4342-ad1f-030bfca5d82b
 
 ### ♻️ Refactor
@@ -291,6 +307,7 @@
 - **infrastructure:** Optimise jest speed
 - **app:** Refresh agents
 - **app:** Automate changelog ([#474](https://github.com/lhowsam/foam/issues/474))
+
 ## 0.0.38
 
 ### ✨ Features
@@ -321,6 +338,7 @@
 - **app:** Testing native update
 - **app:** Testing native update
 - **app:** Testing ota
+
 ## 0.0.36
 
 ### ✨ Features
@@ -332,6 +350,7 @@
 - **infrastructure:** Ota
 - **infrastructure:** Ota
 - **infrastructure:** Ota
+
 ## 0.0.37
 
 ### ♻️ Refactor
@@ -379,6 +398,7 @@
 - **app:** Prompt to confirm logout ([#443](https://github.com/lhowsam/foam/issues/443))
 - **app:** Add .easignore
 - **infrastructure:** Test self hosted runner ([#454](https://github.com/lhowsam/foam/issues/454))
+
 ## 0.0.34
 
 ### ♻️ Refactor
@@ -402,6 +422,7 @@
 
 - **app:** Fix storybook
 - **app:** Install expo-insights
+
 ## 0.0.33
 
 ### ♻️ Refactor
@@ -437,6 +458,7 @@
 - **tooling:** Add hermes release profiler ([#416](https://github.com/lhowsam/foam/issues/416))
 - **tooling:** Patch expo-file-system tsc ([#418](https://github.com/lhowsam/foam/issues/418))
 - **sentry:** Adjust sentry rates ([#419](https://github.com/lhowsam/foam/issues/419))
+
 ## 0.0.32
 
 ### 🐛 Bug Fixes
@@ -453,6 +475,7 @@
 - **ci:** Add deploy-testflight self-hosted workflow
 - **ci:** Add deploy-testflight self-hosted workflow
 - **infrastructure:** Tidy up ci/cd ([#385](https://github.com/lhowsam/foam/issues/385))
+
 ## 0.0.31
 
 ### 🐛 Bug Fixes
@@ -465,6 +488,7 @@
 
 - **app:** Add expo-atlas
 - Add refined plugin
+
 ## 0.0.30
 
 ### ✨ Features
@@ -481,6 +505,7 @@
 
 - **infrastructure:** Preview set up
 - **infrastructure:** Remove dead code
+
 ## 0.0.29
 
 ### ✨ Features
@@ -500,6 +525,7 @@
 
 - **app:** Tidy up caching code
 - Revert deploy.sh
+
 ## 0.0.27
 
 ### ♻️ Refactor
@@ -519,6 +545,7 @@
 ### 🔧 Miscellaneous Tasks
 
 - **documentation:** Update setup docs ([#329](https://github.com/lhowsam/foam/issues/329))
+
 ## 0.0.26
 
 ### ✨ Features
@@ -532,6 +559,7 @@
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Remove auth loading screen ([#314](https://github.com/lhowsam/foam/issues/314))
+
 ## 0.0.25
 
 ### ♻️ Refactor
@@ -561,6 +589,7 @@
 - **app:** Remove unused deps ([#309](https://github.com/lhowsam/foam/issues/309))
 - **app:** Update deps ([#310](https://github.com/lhowsam/foam/issues/310))
 - **app:** Update core RN deps ([#311](https://github.com/lhowsam/foam/issues/311))
+
 ## 0.0.24
 
 ### ✨ Features
@@ -573,6 +602,7 @@
 
 - **app:** Fix diagnostics screen
 - **chat:** Improve sheet typography
+
 ## 0.0.23
 
 ### ✨ Features
@@ -582,6 +612,7 @@
 ### 🔧 Miscellaneous Tasks
 
 - Update .gitignore
+
 ## 0.0.22
 
 ### ✨ Features
@@ -599,6 +630,7 @@
 - Fix build
 - Fix build
 - **docs:** Update .env.example
+
 ## 0.0.21
 
 ### ✨ Features
@@ -613,6 +645,7 @@
 ### 🔧 Miscellaneous Tasks
 
 - **infrastructure:** Add OTA ci/cd
+
 ## 0.0.20
 
 ### ✨ Features
@@ -630,11 +663,13 @@
 - **app:** Lock orientation on search
 - **app:** Compress images
 - **app:** Compress Images
+
 ## 0.0.19
 
 ### ✨ Features
 
 - **app:** Add react-query devtools
+
 ## 0.0.18
 
 ### 🐛 Bug Fixes
@@ -644,11 +679,13 @@
 ### 🧪 Testing
 
 - **auth:** Improve auth tests
+
 ## 0.0.17
 
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Refactor online manager
+
 ## 0.0.16
 
 ### ✨ Features
@@ -658,11 +695,13 @@
 ### 🐛 Bug Fixes
 
 - **app:** Fix auth ctx persistence issues
+
 ## 0.0.15
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix auth crashes
+
 ## 0.0.14
 
 ### ✨ Features
@@ -681,6 +720,7 @@
 - **ci:** Test alternate ci/cd workflow
 - **ci:** Test alternate ci/cd workflow
 - **ci:** Test alternate ci/cd workflow
+
 ## 0.0.13
 
 ### ♻️ Refactor
@@ -697,16 +737,19 @@
 
 - **app:** Debug auth issues
 - **app:** Debug auth issues
+
 ## 0.0.12
 
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Debug auth
+
 ## 0.0.11
 
 ### 🐛 Bug Fixes
 
 - **app:** Speculative crash fix around fonts
+
 ## 0.0.9
 
 ### ✨ Features
@@ -718,11 +761,13 @@
 ### 🐛 Bug Fixes
 
 - **app:** Comment out fb
+
 ## 0.0.8
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix crash on start
+
 ## 0.0.7
 
 ### 🔧 Miscellaneous Tasks
@@ -730,31 +775,37 @@
 - **app:** Debug release
 - **app:** Debug release
 - **app:** Debug release
+
 ## 0.0.6
 
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Debug release
+
 ## 0.0.5
 
 ### 🐛 Bug Fixes
 
 - **app:** Navigation state in prod
+
 ## 0.0.4
 
 ### ✨ Features
 
 - **app:** Debug screen
+
 ## 0.0.3
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix commmitlint
+
 ## 0.0.2
 
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Gs services file
+
 ## 0.0.1
 
 ### ♻️ Refactor
@@ -826,7 +877,7 @@
 - **app:** Add styling to bar bar
 - **chat:** Improve chat message styling
 - **infra:** Add deploy ci/cd
-- **infra:** Add eas  build profiles
+- **infra:** Add eas build profiles
 - **app:** Offline view
 - **chat:** Enhance chat styling + parsing
 - **ci:** Deploy to test flight
@@ -923,4 +974,3 @@
 ### 🧪 Testing
 
 - **app:** Add missing util unit tests
-

--- a/src/app/tabs/settings/_layout.tsx
+++ b/src/app/tabs/settings/_layout.tsx
@@ -72,6 +72,10 @@ export default function SettingsLayout() {
         options={{ title: 'Remote Config', headerBackTitle: 'Settings' }}
       />
       <Stack.Screen
+        name='emotes'
+        options={{ title: 'Emotes & Badges', headerBackTitle: 'Settings' }}
+      />
+      <Stack.Screen
         name='storybook'
         options={{ title: 'Storybook', headerBackTitle: 'Settings' }}
       />

--- a/src/app/tabs/settings/emotes.tsx
+++ b/src/app/tabs/settings/emotes.tsx
@@ -1,0 +1,3 @@
+import { SettingsEmotesScreen } from '@app/screens/SettingsScreen/SettingsEmotesScreen';
+
+export default SettingsEmotesScreen;

--- a/src/screens/SettingsScreen/SettingsEmotesScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsEmotesScreen.tsx
@@ -37,8 +37,6 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-
 type TabType = 'emotes' | 'badges';
 
 interface EmoteRowItem {
@@ -59,17 +57,20 @@ interface BadgeRowItem {
   provider?: string;
 }
 
-// ─── Data helpers ─────────────────────────────────────────────────────────────
+function dedupeBy<T>(items: T[], key: (item: T) => string): T[] {
+  const seen = new Set<string>();
+  return items.filter(item => {
+    const k = key(item);
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+}
 
 function buildEmoteList(cache: ChannelCacheType | undefined): EmoteRowItem[] {
-  if (!cache) {
-    return [];
-  }
+  if (!cache) return [];
 
-  const seen = new Set<string>();
-  const results: EmoteRowItem[] = [];
-
-  const allEmotes: SanitisedEmote[] = [
+  const all: SanitisedEmote[] = [
     ...(cache.twitchChannelEmotes ?? []),
     ...(cache.twitchGlobalEmotes ?? []),
     ...(cache.twitchSubscriberEmotes ?? []),
@@ -81,33 +82,20 @@ function buildEmoteList(cache: ChannelCacheType | undefined): EmoteRowItem[] {
     ...(cache.bttvGlobalEmotes ?? []),
   ];
 
-  for (const emote of allEmotes) {
-    const key = `${emote.site}:${emote.id}`;
-    if (!seen.has(key)) {
-      seen.add(key);
-      results.push({
-        id: emote.id,
-        name: emote.name,
-        url: emote.url,
-        site: emote.site,
-        creator: emote.creator,
-        emote_link: emote.emote_link,
-      });
-    }
-  }
-
-  return results;
+  return dedupeBy(all, e => `${e.site}:${e.id}`).map(e => ({
+    id: e.id,
+    name: e.name,
+    url: e.url,
+    site: e.site,
+    creator: e.creator,
+    emote_link: e.emote_link,
+  }));
 }
 
 function buildBadgeList(cache: ChannelCacheType | undefined): BadgeRowItem[] {
-  if (!cache) {
-    return [];
-  }
+  if (!cache) return [];
 
-  const seen = new Set<string>();
-  const results: BadgeRowItem[] = [];
-
-  const allBadges: SanitisedBadgeSet[] = [
+  const all: SanitisedBadgeSet[] = [
     ...(cache.twitchChannelBadges ?? []),
     ...(cache.twitchGlobalBadges ?? []),
     ...(cache.ffzChannelBadges ?? []),
@@ -115,106 +103,85 @@ function buildBadgeList(cache: ChannelCacheType | undefined): BadgeRowItem[] {
     ...(cache.chatterinoBadges ?? []),
   ];
 
-  for (const badge of allBadges) {
-    const key = `${badge.type}:${badge.id}`;
-    if (!seen.has(key)) {
-      seen.add(key);
-      results.push({
-        id: badge.id,
-        title: badge.title,
-        url: badge.url,
-        type: badge.type,
-        set: badge.set,
-        provider: badge.provider,
-      });
-    }
-  }
-
-  return results;
+  return dedupeBy(all, b => `${b.type}:${b.id}`).map(b => ({
+    id: b.id,
+    title: b.title,
+    url: b.url,
+    type: b.type,
+    set: b.set,
+    provider: b.provider,
+  }));
 }
 
-// ─── Row renderers ────────────────────────────────────────────────────────────
+function ItemRow({
+  url,
+  name,
+  tag,
+  meta,
+  detail,
+  link,
+}: {
+  url: string;
+  name: string;
+  tag?: string;
+  meta?: string;
+  detail: string;
+  link?: string;
+}) {
+  return (
+    <View style={styles.item}>
+      <View style={styles.thumbnailContainer}>
+        <Image source={{ uri: url }} style={styles.thumbnail} contentFit='contain' />
+      </View>
+      <View style={styles.itemInfo}>
+        <View style={styles.itemHeader}>
+          <Text style={styles.itemName} numberOfLines={1}>{name}</Text>
+          {tag ? (
+            <View style={styles.tagBadge}>
+              <Text style={styles.tagBadgeText}>{tag}</Text>
+            </View>
+          ) : null}
+        </View>
+        {meta ? (
+          <Text style={styles.itemMeta} numberOfLines={1}>{meta}</Text>
+        ) : null}
+        <Text style={styles.itemId} numberOfLines={1} selectable>{detail}</Text>
+        {link ? (
+          <Text
+            style={styles.itemLink}
+            numberOfLines={1}
+            onPress={() => void Linking.openURL(link)}
+          >
+            {link}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
 
 const renderEmoteItem: ListRenderItem<EmoteRowItem> = ({ item }) => (
-  <View style={styles.item}>
-    <View style={styles.thumbnailContainer}>
-      <Image
-        source={{ uri: item.url }}
-        style={styles.thumbnail}
-        contentFit='contain'
-      />
-    </View>
-    <View style={styles.itemInfo}>
-      <View style={styles.itemHeader}>
-        <Text style={styles.itemName} numberOfLines={1}>
-          {item.name}
-        </Text>
-        <View style={styles.tagBadge}>
-          <Text style={styles.tagBadgeText}>{item.site}</Text>
-        </View>
-      </View>
-      {item.creator ? (
-        <Text style={styles.itemMeta} numberOfLines={1}>
-          by {item.creator}
-        </Text>
-      ) : null}
-      <Text style={styles.itemId} numberOfLines={1} selectable>
-        {item.id}
-      </Text>
-      {item.emote_link ? (
-        <Text
-          style={styles.itemLink}
-          numberOfLines={1}
-          onPress={() => void Linking.openURL(item.emote_link)}
-        >
-          {item.emote_link}
-        </Text>
-      ) : null}
-    </View>
-  </View>
+  <ItemRow
+    url={item.url}
+    name={item.name}
+    tag={item.site}
+    meta={item.creator ? `by ${item.creator}` : undefined}
+    detail={item.id}
+    link={item.emote_link || undefined}
+  />
 );
 
 const renderBadgeItem: ListRenderItem<BadgeRowItem> = ({ item }) => (
-  <View style={styles.item}>
-    <View style={styles.thumbnailContainer}>
-      <Image
-        source={{ uri: item.url }}
-        style={styles.thumbnail}
-        contentFit='contain'
-      />
-    </View>
-    <View style={styles.itemInfo}>
-      <View style={styles.itemHeader}>
-        <Text style={styles.itemName} numberOfLines={1}>
-          {item.title}
-        </Text>
-        {item.provider ? (
-          <View style={styles.tagBadge}>
-            <Text style={styles.tagBadgeText}>
-              {item.provider.toUpperCase()}
-            </Text>
-          </View>
-        ) : null}
-      </View>
-      <Text style={styles.itemMeta} numberOfLines={1}>
-        {item.type}
-      </Text>
-      <Text style={styles.itemId} numberOfLines={1} selectable>
-        set: {item.set} · id: {item.id}
-      </Text>
-    </View>
-  </View>
+  <ItemRow
+    url={item.url}
+    name={item.title}
+    tag={item.provider?.toUpperCase()}
+    meta={item.type}
+    detail={`set: ${item.set} · id: ${item.id}`}
+  />
 );
 
-// ─── Empty / error states ─────────────────────────────────────────────────────
-
-function EmptyState({
-  message,
-  submessage,
-}: {
-  message: string;
-  submessage: string;
-}) {
+function EmptyState({ message, submessage }: { message: string; submessage: string }) {
   return (
     <View style={styles.emptyState}>
       <Text style={styles.emptyText}>{message}</Text>
@@ -223,41 +190,28 @@ function EmptyState({
   );
 }
 
-// ─── Followed streamer pill ───────────────────────────────────────────────────
-
-interface FollowedStreamer {
-  user_id: string;
-  user_login: string;
-  user_name: string;
-  thumbnail_url: string;
-}
-
 function FollowedStreamerPill({
   streamer,
   isSelected,
   onPress,
 }: {
-  streamer: FollowedStreamer;
+  streamer: { user_id: string; user_name: string; thumbnail_url: string };
   isSelected: boolean;
   onPress: () => void;
 }) {
-  const avatarUrl = streamer.thumbnail_url.replace('{width}', '40').replace('{height}', '40');
+  const avatarUrl = streamer.thumbnail_url
+    .replace('{width}', '40')
+    .replace('{height}', '40');
+
   return (
     <TouchableOpacity
       onPress={onPress}
       style={[styles.streamerPill, isSelected && styles.streamerPillActive]}
       activeOpacity={0.75}
     >
-      <Image
-        source={{ uri: avatarUrl }}
-        style={styles.streamerAvatar}
-        contentFit='cover'
-      />
+      <Image source={{ uri: avatarUrl }} style={styles.streamerAvatar} contentFit='cover' />
       <Text
-        style={[
-          styles.streamerName,
-          isSelected && styles.streamerNameActive,
-        ]}
+        style={[styles.streamerName, isSelected && styles.streamerNameActive]}
         numberOfLines={1}
       >
         {streamer.user_name}
@@ -266,15 +220,7 @@ function FollowedStreamerPill({
   );
 }
 
-// ─── Channel viewer (after channel is resolved) ───────────────────────────────
-
-function ChannelViewer({
-  channelId,
-  channelName,
-}: {
-  channelId: string;
-  channelName: string;
-}) {
+function ChannelViewer({ channelId, channelName }: { channelId: string; channelName: string }) {
   const [activeTab, setActiveTab] = useState<TabType>('emotes');
   const [isLoading, setIsLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
@@ -283,10 +229,7 @@ function ChannelViewer({
 
   useScrollToTop(listRef);
 
-  const cache = useSelector(
-    () => chatStore$.persisted.channelCaches[channelId]?.get(),
-  );
-
+  const cache = useSelector(() => chatStore$.persisted.channelCaches[channelId]?.get());
   const emoteList = buildEmoteList(cache);
   const badgeList = buildBadgeList(cache);
 
@@ -303,11 +246,7 @@ function ChannelViewer({
     }
   }, [channelId]);
 
-  const hasCache = cache !== undefined;
-  const hasContent = emoteList.length > 0 || badgeList.length > 0;
-
-  // Auto-load if no cache yet
-  if (!hasCache && !isLoading && !loaded && !error) {
+  if (!cache && !isLoading && !loaded && !error) {
     void handleLoad();
   }
 
@@ -325,16 +264,15 @@ function ChannelViewer({
       <View style={styles.centeredState}>
         <Text style={styles.emptyText}>Failed to load channel</Text>
         <Text style={styles.emptySubtext}>{error}</Text>
-        <Button onPress={handleLoad} style={styles.retryButton}>
-          <Text style={styles.retryButtonText}>Retry</Text>
+        <Button onPress={handleLoad} style={styles.actionButton}>
+          <Text style={styles.actionButtonText}>Retry</Text>
         </Button>
       </View>
     );
   }
 
   return (
-    <View style={styles.channelViewerContainer}>
-      {/* Tab bar */}
+    <View style={styles.flex}>
       <View style={styles.tabContainer}>
         <Button
           onPress={() => setActiveTab('emotes')}
@@ -344,12 +282,7 @@ function ChannelViewer({
             activeTab === 'emotes' && { backgroundColor: theme.colorPlum },
           ]}
         >
-          <Text
-            style={[
-              styles.tabButtonText,
-              activeTab === 'emotes' && styles.tabButtonTextActive,
-            ]}
-          >
+          <Text style={[styles.tabButtonText, activeTab === 'emotes' && styles.tabButtonTextActive]}>
             Emotes ({emoteList.length})
           </Text>
         </Button>
@@ -361,26 +294,17 @@ function ChannelViewer({
             activeTab === 'badges' && { backgroundColor: theme.colorOrange },
           ]}
         >
-          <Text
-            style={[
-              styles.tabButtonText,
-              activeTab === 'badges' && styles.tabButtonTextActive,
-            ]}
-          >
+          <Text style={[styles.tabButtonText, activeTab === 'badges' && styles.tabButtonTextActive]}>
             Badges ({badgeList.length})
           </Text>
         </Button>
-        {hasContent && (
-          <Button
-            onPress={handleLoad}
-            style={styles.refreshButton}
-          >
+        {(emoteList.length > 0 || badgeList.length > 0) && (
+          <Button onPress={handleLoad} style={styles.refreshButton}>
             <Text style={styles.refreshButtonText}>↻</Text>
           </Button>
         )}
       </View>
 
-      {/* List */}
       {activeTab === 'emotes' ? (
         <FlashList
           ref={listRef}
@@ -391,10 +315,7 @@ function ChannelViewer({
           keyExtractor={item => `${item.site}:${item.id}`}
           contentContainerStyle={styles.listContent}
           ListEmptyComponent={
-            <EmptyState
-              message='No emotes cached'
-              submessage='Tap refresh to fetch emotes for this channel'
-            />
+            <EmptyState message='No emotes cached' submessage='Tap refresh to fetch emotes for this channel' />
           }
         />
       ) : (
@@ -407,10 +328,7 @@ function ChannelViewer({
           keyExtractor={item => `${item.type}:${item.id}`}
           contentContainerStyle={styles.listContent}
           ListEmptyComponent={
-            <EmptyState
-              message='No badges cached'
-              submessage='Tap refresh to fetch badges for this channel'
-            />
+            <EmptyState message='No badges cached' submessage='Tap refresh to fetch badges for this channel' />
           }
         />
       )}
@@ -418,39 +336,23 @@ function ChannelViewer({
   );
 }
 
-// ─── Main screen ──────────────────────────────────────────────────────────────
-
 export function SettingsEmotesScreen() {
   const { user } = useAuthContext();
   const insets = useSafeAreaInsets();
 
-  // Channel search state
   const [inputValue, setInputValue] = useState('');
-  const [selectedChannel, setSelectedChannel] = useState<{
-    id: string;
-    name: string;
-  } | null>(null);
+  const [selectedChannel, setSelectedChannel] = useState<{ id: string; name: string } | null>(null);
   const [resolving, setResolving] = useState(false);
   const [resolveError, setResolveError] = useState<string | null>(null);
 
-  // Followed streamers (only when logged in)
   const followedQuery = useQuery({
     ...twitchQueries.getFollowedStreams(user?.id ?? ''),
     enabled: !!user?.id,
     staleTime: 5 * 60 * 1000,
   });
 
-  const followedStreamers: FollowedStreamer[] = (followedQuery.data ?? []).map(
-    s => ({
-      user_id: s.user_id,
-      user_login: s.user_login,
-      user_name: s.user_name,
-      thumbnail_url: s.thumbnail_url,
-    }),
-  );
-
   const handleSelectFollowed = useCallback(
-    (streamer: FollowedStreamer) => {
+    (streamer: { user_id: string; user_login: string; user_name: string }) => {
       setResolveError(null);
       setInputValue(streamer.user_login);
       setSelectedChannel({ id: streamer.user_id, name: streamer.user_name });
@@ -460,9 +362,7 @@ export function SettingsEmotesScreen() {
 
   const handleSearch = useCallback(async () => {
     const login = inputValue.trim().toLowerCase();
-    if (!login) {
-      return;
-    }
+    if (!login) return;
 
     setResolving(true);
     setResolveError(null);
@@ -484,9 +384,10 @@ export function SettingsEmotesScreen() {
     }
   }, [inputValue]);
 
+  const followedStreamers = followedQuery.data ?? [];
+
   return (
     <View style={[styles.screen, { paddingBottom: insets.bottom }]}>
-      {/* Search bar */}
       <View style={styles.searchSection}>
         <View style={styles.searchRow}>
           <Input
@@ -500,26 +401,23 @@ export function SettingsEmotesScreen() {
             }}
             onSubmitEditing={handleSearch}
             returnKeyType='search'
-            style={styles.searchInput}
+            style={styles.flex}
           />
           <Button
             onPress={handleSearch}
-            style={styles.searchButton}
+            style={styles.actionButton}
             disabled={resolving || !inputValue.trim()}
           >
             {resolving ? (
               <ActivityIndicator color='#fff' size='small' />
             ) : (
-              <Text style={styles.searchButtonText}>Go</Text>
+              <Text style={styles.actionButtonText}>Go</Text>
             )}
           </Button>
         </View>
-        {resolveError ? (
-          <Text style={styles.errorText}>{resolveError}</Text>
-        ) : null}
+        {resolveError ? <Text style={styles.errorText}>{resolveError}</Text> : null}
       </View>
 
-      {/* Followed streamers */}
       {user && followedStreamers.length > 0 && (
         <View style={styles.followedSection}>
           <Text style={styles.followedLabel}>Following</Text>
@@ -541,7 +439,6 @@ export function SettingsEmotesScreen() {
         </View>
       )}
 
-      {/* Viewer */}
       {selectedChannel ? (
         <ChannelViewer
           key={selectedChannel.id}
@@ -551,9 +448,7 @@ export function SettingsEmotesScreen() {
       ) : (
         <View style={styles.placeholder}>
           <Text style={styles.placeholderText}>
-            {user
-              ? 'Pick a followed channel or search by name'
-              : 'Search for a channel by name'}
+            {user ? 'Pick a followed channel or search by name' : 'Search for a channel by name'}
           </Text>
         </View>
       )}
@@ -561,18 +456,28 @@ export function SettingsEmotesScreen() {
   );
 }
 
-// ─── Styles ───────────────────────────────────────────────────────────────────
-
 const styles = StyleSheet.create({
+  actionButton: {
+    alignItems: 'center',
+    backgroundColor: theme.colorPrimary,
+    borderCurve: 'continuous',
+    borderRadius: 10,
+    justifyContent: 'center',
+    minWidth: 52,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  actionButtonText: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '700',
+  },
   centeredState: {
     alignItems: 'center',
     flex: 1,
     gap: 12,
     justifyContent: 'center',
     paddingHorizontal: 32,
-  },
-  channelViewerContainer: {
-    flex: 1,
   },
   emptyState: {
     alignItems: 'center',
@@ -602,6 +507,9 @@ const styles = StyleSheet.create({
     fontSize: 13,
     marginTop: 6,
     paddingHorizontal: 2,
+  },
+  flex: {
+    flex: 1,
   },
   followedLabel: {
     color: theme.color.textSecondary.dark,
@@ -707,41 +615,8 @@ const styles = StyleSheet.create({
     color: theme.color.text.dark,
     fontSize: 16,
   },
-  retryButton: {
-    alignItems: 'center',
-    backgroundColor: theme.colorPrimary,
-    borderCurve: 'continuous',
-    borderRadius: 10,
-    justifyContent: 'center',
-    marginTop: 4,
-    paddingHorizontal: 20,
-    paddingVertical: 10,
-  },
-  retryButtonText: {
-    color: '#fff',
-    fontSize: 14,
-    fontWeight: '600',
-  },
   screen: {
     backgroundColor: theme.color.background.dark,
-    flex: 1,
-  },
-  searchButton: {
-    alignItems: 'center',
-    backgroundColor: theme.colorPrimary,
-    borderCurve: 'continuous',
-    borderRadius: 10,
-    justifyContent: 'center',
-    minWidth: 52,
-    paddingHorizontal: 14,
-    paddingVertical: 10,
-  },
-  searchButtonText: {
-    color: '#fff',
-    fontSize: 15,
-    fontWeight: '700',
-  },
-  searchInput: {
     flex: 1,
   },
   searchRow: {

--- a/src/screens/SettingsScreen/SettingsEmotesScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsEmotesScreen.tsx
@@ -35,6 +35,29 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 type TabType = 'emotes' | 'badges';
 
+const CHANNEL_TABS: {
+  id: TabType;
+  label: string;
+  color: string;
+  emptyMessage: string;
+  emptySubmessage: string;
+}[] = [
+  {
+    id: 'emotes',
+    label: 'Emotes',
+    color: theme.colorPlum,
+    emptyMessage: 'No emotes cached',
+    emptySubmessage: 'Tap refresh to fetch emotes for this channel',
+  },
+  {
+    id: 'badges',
+    label: 'Badges',
+    color: theme.colorOrange,
+    emptyMessage: 'No badges cached',
+    emptySubmessage: 'Tap refresh to fetch badges for this channel',
+  },
+];
+
 interface EmoteRowItem {
   id: string;
   name: string;
@@ -244,6 +267,37 @@ function ResourceList<T>({
   );
 }
 
+function TabButton({
+  label,
+  count,
+  isActive,
+  activeColor,
+  onPress,
+}: {
+  label: string;
+  count: number;
+  isActive: boolean;
+  activeColor: string;
+  onPress: () => void;
+}) {
+  return (
+    <Button
+      onPress={onPress}
+      style={[
+        styles.tabButton,
+        isActive && styles.tabButtonActive,
+        isActive && { backgroundColor: activeColor },
+      ]}
+    >
+      <Text
+        style={[styles.tabButtonText, isActive && styles.tabButtonTextActive]}
+      >
+        {label} ({count})
+      </Text>
+    </Button>
+  );
+}
+
 function FollowedStreamerPill({
   streamer,
   isSelected,
@@ -275,6 +329,37 @@ function FollowedStreamerPill({
         {streamer.user_name}
       </Text>
     </TouchableOpacity>
+  );
+}
+
+function StatusPanel({
+  title,
+  subtitle,
+  actionLabel,
+  onAction,
+  loading,
+}: {
+  title: string;
+  subtitle?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  loading?: boolean;
+}) {
+  return (
+    <View style={styles.centeredState}>
+      {loading ? (
+        <ActivityIndicator color={theme.colorPrimary} size='large' />
+      ) : null}
+      <Text style={loading ? styles.loadingText : styles.emptyText}>
+        {title}
+      </Text>
+      {subtitle ? <Text style={styles.emptySubtext}>{subtitle}</Text> : null}
+      {actionLabel && onAction ? (
+        <Button onPress={onAction} style={styles.actionButton}>
+          <Text style={styles.actionButtonText}>{actionLabel}</Text>
+        </Button>
+      ) : null}
+    </View>
   );
 }
 
@@ -317,63 +402,37 @@ function ChannelViewer({
   }
 
   if (isLoading) {
-    return (
-      <View style={styles.centeredState}>
-        <ActivityIndicator color={theme.colorPrimary} size='large' />
-        <Text style={styles.loadingText}>Loading {channelName}…</Text>
-      </View>
-    );
+    return <StatusPanel title={`Loading ${channelName}…`} loading />;
   }
 
   if (error) {
     return (
-      <View style={styles.centeredState}>
-        <Text style={styles.emptyText}>Failed to load channel</Text>
-        <Text style={styles.emptySubtext}>{error}</Text>
-        <Button onPress={handleLoad} style={styles.actionButton}>
-          <Text style={styles.actionButtonText}>Retry</Text>
-        </Button>
-      </View>
+      <StatusPanel
+        title='Failed to load channel'
+        subtitle={error}
+        actionLabel='Retry'
+        onAction={handleLoad}
+      />
     );
   }
+
+  const activeTabConfig =
+    CHANNEL_TABS.find(entry => entry.id === activeTab) ?? CHANNEL_TABS[0];
+  const isEmotes = activeTab === 'emotes';
 
   return (
     <View style={styles.flex}>
       <View style={styles.tabContainer}>
-        <Button
-          onPress={() => setActiveTab('emotes')}
-          style={[
-            styles.tabButton,
-            activeTab === 'emotes' && styles.tabButtonActive,
-            activeTab === 'emotes' && { backgroundColor: theme.colorPlum },
-          ]}
-        >
-          <Text
-            style={[
-              styles.tabButtonText,
-              activeTab === 'emotes' && styles.tabButtonTextActive,
-            ]}
-          >
-            Emotes ({emoteList.length})
-          </Text>
-        </Button>
-        <Button
-          onPress={() => setActiveTab('badges')}
-          style={[
-            styles.tabButton,
-            activeTab === 'badges' && styles.tabButtonActive,
-            activeTab === 'badges' && { backgroundColor: theme.colorOrange },
-          ]}
-        >
-          <Text
-            style={[
-              styles.tabButtonText,
-              activeTab === 'badges' && styles.tabButtonTextActive,
-            ]}
-          >
-            Badges ({badgeList.length})
-          </Text>
-        </Button>
+        {CHANNEL_TABS.map(tab => (
+          <TabButton
+            key={tab.id}
+            label={tab.label}
+            count={tab.id === 'emotes' ? emoteList.length : badgeList.length}
+            isActive={activeTab === tab.id}
+            activeColor={tab.color}
+            onPress={() => setActiveTab(tab.id)}
+          />
+        ))}
         {(emoteList.length > 0 || badgeList.length > 0) && (
           <Button onPress={handleLoad} style={styles.refreshButton}>
             <Text style={styles.refreshButtonText}>↻</Text>
@@ -381,25 +440,20 @@ function ChannelViewer({
         )}
       </View>
 
-      {activeTab === 'emotes' ? (
-        <ResourceList
-          ref={listRef}
-          data={emoteList}
-          renderItem={renderEmoteItem}
-          keyExtractor={item => `${item.site}:${item.id}`}
-          emptyMessage='No emotes cached'
-          emptySubmessage='Tap refresh to fetch emotes for this channel'
-        />
-      ) : (
-        <ResourceList
-          ref={listRef as RefObject<FlashListRef<BadgeRowItem> | null>}
-          data={badgeList}
-          renderItem={renderBadgeItem}
-          keyExtractor={item => `${item.type}:${item.id}`}
-          emptyMessage='No badges cached'
-          emptySubmessage='Tap refresh to fetch badges for this channel'
-        />
-      )}
+      <ResourceList
+        ref={
+          listRef as RefObject<FlashListRef<EmoteRowItem | BadgeRowItem> | null>
+        }
+        data={isEmotes ? emoteList : badgeList}
+        renderItem={isEmotes ? renderEmoteItem : renderBadgeItem}
+        keyExtractor={item =>
+          isEmotes
+            ? `${(item as EmoteRowItem).site}:${(item as EmoteRowItem).id}`
+            : `${(item as BadgeRowItem).type}:${(item as BadgeRowItem).id}`
+        }
+        emptyMessage={activeTabConfig.emptyMessage}
+        emptySubmessage={activeTabConfig.emptySubmessage}
+      />
     </View>
   );
 }

--- a/src/screens/SettingsScreen/SettingsEmotesScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsEmotesScreen.tsx
@@ -13,11 +13,7 @@ import { twitchQueries } from '@app/queries/twitchQueries';
 import { twitchService } from '@app/services/twitch-service';
 import { loadChannelResources } from '@app/store/chat/actions/channelLoad';
 import { chatStore$ } from '@app/store/chat/observables/chatStore';
-import type {
-  ChannelCacheType,
-  SanitisedBadgeSet,
-  SanitisedEmote,
-} from '@app/store/chat/types/constants';
+import type { ChannelCacheType } from '@app/store/chat/types/constants';
 import { theme } from '@app/styles/themes';
 import { useSelector } from '@legendapp/state/react';
 import { useQuery } from '@tanstack/react-query';
@@ -67,50 +63,62 @@ function dedupeBy<T>(items: T[], key: (item: T) => string): T[] {
   });
 }
 
-function buildEmoteList(cache: ChannelCacheType | undefined): EmoteRowItem[] {
+function buildResourceList<TSource, TRow>(
+  cache: ChannelCacheType | undefined,
+  sources: (channelCache: ChannelCacheType) => TSource[],
+  key: (item: TSource) => string,
+  map: (item: TSource) => TRow,
+): TRow[] {
   if (!cache) return [];
+  return dedupeBy(sources(cache), key).map(map);
+}
 
-  const all: SanitisedEmote[] = [
-    ...(cache.twitchChannelEmotes ?? []),
-    ...(cache.twitchGlobalEmotes ?? []),
-    ...(cache.twitchSubscriberEmotes ?? []),
-    ...(cache.sevenTvChannelEmotes ?? []),
-    ...(cache.sevenTvGlobalEmotes ?? []),
-    ...(cache.ffzChannelEmotes ?? []),
-    ...(cache.ffzGlobalEmotes ?? []),
-    ...(cache.bttvChannelEmotes ?? []),
-    ...(cache.bttvGlobalEmotes ?? []),
-  ];
-
-  return dedupeBy(all, e => `${e.site}:${e.id}`).map(e => ({
-    id: e.id,
-    name: e.name,
-    url: e.url,
-    site: e.site,
-    creator: e.creator,
-    emote_link: e.emote_link,
-  }));
+function buildEmoteList(cache: ChannelCacheType | undefined): EmoteRowItem[] {
+  return buildResourceList(
+    cache,
+    channelCache => [
+      ...(channelCache.twitchChannelEmotes ?? []),
+      ...(channelCache.twitchGlobalEmotes ?? []),
+      ...(channelCache.twitchSubscriberEmotes ?? []),
+      ...(channelCache.sevenTvChannelEmotes ?? []),
+      ...(channelCache.sevenTvGlobalEmotes ?? []),
+      ...(channelCache.ffzChannelEmotes ?? []),
+      ...(channelCache.ffzGlobalEmotes ?? []),
+      ...(channelCache.bttvChannelEmotes ?? []),
+      ...(channelCache.bttvGlobalEmotes ?? []),
+    ],
+    emote => `${emote.site}:${emote.id}`,
+    emote => ({
+      id: emote.id,
+      name: emote.name,
+      url: emote.url,
+      site: emote.site,
+      creator: emote.creator,
+      emote_link: emote.emote_link,
+    }),
+  );
 }
 
 function buildBadgeList(cache: ChannelCacheType | undefined): BadgeRowItem[] {
-  if (!cache) return [];
-
-  const all: SanitisedBadgeSet[] = [
-    ...(cache.twitchChannelBadges ?? []),
-    ...(cache.twitchGlobalBadges ?? []),
-    ...(cache.ffzChannelBadges ?? []),
-    ...(cache.ffzGlobalBadges ?? []),
-    ...(cache.chatterinoBadges ?? []),
-  ];
-
-  return dedupeBy(all, b => `${b.type}:${b.id}`).map(b => ({
-    id: b.id,
-    title: b.title,
-    url: b.url,
-    type: b.type,
-    set: b.set,
-    provider: b.provider,
-  }));
+  return buildResourceList(
+    cache,
+    channelCache => [
+      ...(channelCache.twitchChannelBadges ?? []),
+      ...(channelCache.twitchGlobalBadges ?? []),
+      ...(channelCache.ffzChannelBadges ?? []),
+      ...(channelCache.ffzGlobalBadges ?? []),
+      ...(channelCache.chatterinoBadges ?? []),
+    ],
+    badge => `${badge.type}:${badge.id}`,
+    badge => ({
+      id: badge.id,
+      title: badge.title,
+      url: badge.url,
+      type: badge.type,
+      set: badge.set,
+      provider: badge.provider,
+    }),
+  );
 }
 
 function ItemRow({
@@ -131,11 +139,17 @@ function ItemRow({
   return (
     <View style={styles.item}>
       <View style={styles.thumbnailContainer}>
-        <Image source={{ uri: url }} style={styles.thumbnail} contentFit='contain' />
+        <Image
+          source={{ uri: url }}
+          style={styles.thumbnail}
+          contentFit='contain'
+        />
       </View>
       <View style={styles.itemInfo}>
         <View style={styles.itemHeader}>
-          <Text style={styles.itemName} numberOfLines={1}>{name}</Text>
+          <Text style={styles.itemName} numberOfLines={1}>
+            {name}
+          </Text>
           {tag ? (
             <View style={styles.tagBadge}>
               <Text style={styles.tagBadgeText}>{tag}</Text>
@@ -143,9 +157,13 @@ function ItemRow({
           ) : null}
         </View>
         {meta ? (
-          <Text style={styles.itemMeta} numberOfLines={1}>{meta}</Text>
+          <Text style={styles.itemMeta} numberOfLines={1}>
+            {meta}
+          </Text>
         ) : null}
-        <Text style={styles.itemId} numberOfLines={1} selectable>{detail}</Text>
+        <Text style={styles.itemId} numberOfLines={1} selectable>
+          {detail}
+        </Text>
         {link ? (
           <Text
             style={styles.itemLink}
@@ -181,12 +199,48 @@ const renderBadgeItem: ListRenderItem<BadgeRowItem> = ({ item }) => (
   />
 );
 
-function EmptyState({ message, submessage }: { message: string; submessage: string }) {
+function EmptyState({
+  message,
+  submessage,
+}: {
+  message: string;
+  submessage: string;
+}) {
   return (
     <View style={styles.emptyState}>
       <Text style={styles.emptyText}>{message}</Text>
       <Text style={styles.emptySubtext}>{submessage}</Text>
     </View>
+  );
+}
+
+function ResourceList<T>({
+  ref,
+  data,
+  renderItem,
+  keyExtractor,
+  emptyMessage,
+  emptySubmessage,
+}: {
+  ref?: RefObject<FlashListRef<T> | null>;
+  data: T[];
+  renderItem: ListRenderItem<T>;
+  keyExtractor: (item: T) => string;
+  emptyMessage: string;
+  emptySubmessage: string;
+}) {
+  return (
+    <FlashList
+      ref={ref}
+      data={data}
+      contentInsetAdjustmentBehavior='automatic'
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      contentContainerStyle={styles.listContent}
+      ListEmptyComponent={
+        <EmptyState message={emptyMessage} submessage={emptySubmessage} />
+      }
+    />
   );
 }
 
@@ -209,7 +263,11 @@ function FollowedStreamerPill({
       style={[styles.streamerPill, isSelected && styles.streamerPillActive]}
       activeOpacity={0.75}
     >
-      <Image source={{ uri: avatarUrl }} style={styles.streamerAvatar} contentFit='cover' />
+      <Image
+        source={{ uri: avatarUrl }}
+        style={styles.streamerAvatar}
+        contentFit='cover'
+      />
       <Text
         style={[styles.streamerName, isSelected && styles.streamerNameActive]}
         numberOfLines={1}
@@ -220,7 +278,13 @@ function FollowedStreamerPill({
   );
 }
 
-function ChannelViewer({ channelId, channelName }: { channelId: string; channelName: string }) {
+function ChannelViewer({
+  channelId,
+  channelName,
+}: {
+  channelId: string;
+  channelName: string;
+}) {
   const [activeTab, setActiveTab] = useState<TabType>('emotes');
   const [isLoading, setIsLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
@@ -229,7 +293,9 @@ function ChannelViewer({ channelId, channelName }: { channelId: string; channelN
 
   useScrollToTop(listRef);
 
-  const cache = useSelector(() => chatStore$.persisted.channelCaches[channelId]?.get());
+  const cache = useSelector(() =>
+    chatStore$.persisted.channelCaches[channelId]?.get(),
+  );
   const emoteList = buildEmoteList(cache);
   const badgeList = buildBadgeList(cache);
 
@@ -282,7 +348,12 @@ function ChannelViewer({ channelId, channelName }: { channelId: string; channelN
             activeTab === 'emotes' && { backgroundColor: theme.colorPlum },
           ]}
         >
-          <Text style={[styles.tabButtonText, activeTab === 'emotes' && styles.tabButtonTextActive]}>
+          <Text
+            style={[
+              styles.tabButtonText,
+              activeTab === 'emotes' && styles.tabButtonTextActive,
+            ]}
+          >
             Emotes ({emoteList.length})
           </Text>
         </Button>
@@ -294,7 +365,12 @@ function ChannelViewer({ channelId, channelName }: { channelId: string; channelN
             activeTab === 'badges' && { backgroundColor: theme.colorOrange },
           ]}
         >
-          <Text style={[styles.tabButtonText, activeTab === 'badges' && styles.tabButtonTextActive]}>
+          <Text
+            style={[
+              styles.tabButtonText,
+              activeTab === 'badges' && styles.tabButtonTextActive,
+            ]}
+          >
             Badges ({badgeList.length})
           </Text>
         </Button>
@@ -306,30 +382,22 @@ function ChannelViewer({ channelId, channelName }: { channelId: string; channelN
       </View>
 
       {activeTab === 'emotes' ? (
-        <FlashList
+        <ResourceList
           ref={listRef}
           data={emoteList}
-          estimatedItemSize={90}
-          contentInsetAdjustmentBehavior='automatic'
           renderItem={renderEmoteItem}
           keyExtractor={item => `${item.site}:${item.id}`}
-          contentContainerStyle={styles.listContent}
-          ListEmptyComponent={
-            <EmptyState message='No emotes cached' submessage='Tap refresh to fetch emotes for this channel' />
-          }
+          emptyMessage='No emotes cached'
+          emptySubmessage='Tap refresh to fetch emotes for this channel'
         />
       ) : (
-        <FlashList
+        <ResourceList
           ref={listRef as RefObject<FlashListRef<BadgeRowItem> | null>}
           data={badgeList}
-          estimatedItemSize={90}
-          contentInsetAdjustmentBehavior='automatic'
           renderItem={renderBadgeItem}
           keyExtractor={item => `${item.type}:${item.id}`}
-          contentContainerStyle={styles.listContent}
-          ListEmptyComponent={
-            <EmptyState message='No badges cached' submessage='Tap refresh to fetch badges for this channel' />
-          }
+          emptyMessage='No badges cached'
+          emptySubmessage='Tap refresh to fetch badges for this channel'
         />
       )}
     </View>
@@ -341,7 +409,10 @@ export function SettingsEmotesScreen() {
   const insets = useSafeAreaInsets();
 
   const [inputValue, setInputValue] = useState('');
-  const [selectedChannel, setSelectedChannel] = useState<{ id: string; name: string } | null>(null);
+  const [selectedChannel, setSelectedChannel] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
   const [resolving, setResolving] = useState(false);
   const [resolveError, setResolveError] = useState<string | null>(null);
 
@@ -378,7 +449,9 @@ export function SettingsEmotesScreen() {
         setSelectedChannel({ id: userInfo.id, name: userInfo.display_name });
       });
     } catch {
-      setResolveError('Could not find that channel. Check the name and try again.');
+      setResolveError(
+        'Could not find that channel. Check the name and try again.',
+      );
     } finally {
       setResolving(false);
     }
@@ -415,7 +488,9 @@ export function SettingsEmotesScreen() {
             )}
           </Button>
         </View>
-        {resolveError ? <Text style={styles.errorText}>{resolveError}</Text> : null}
+        {resolveError ? (
+          <Text style={styles.errorText}>{resolveError}</Text>
+        ) : null}
       </View>
 
       {user && followedStreamers.length > 0 && (
@@ -424,7 +499,6 @@ export function SettingsEmotesScreen() {
           <FlashList
             data={followedStreamers}
             horizontal
-            estimatedItemSize={100}
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={styles.followedListContent}
             keyExtractor={item => item.user_id}
@@ -448,7 +522,9 @@ export function SettingsEmotesScreen() {
       ) : (
         <View style={styles.placeholder}>
           <Text style={styles.placeholderText}>
-            {user ? 'Pick a followed channel or search by name' : 'Search for a channel by name'}
+            {user
+              ? 'Pick a followed channel or search by name'
+              : 'Search for a channel by name'}
           </Text>
         </View>
       )}

--- a/src/screens/SettingsScreen/SettingsEmotesScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsEmotesScreen.tsx
@@ -35,29 +35,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 type TabType = 'emotes' | 'badges';
 
-const CHANNEL_TABS: {
-  id: TabType;
-  label: string;
-  color: string;
-  emptyMessage: string;
-  emptySubmessage: string;
-}[] = [
-  {
-    id: 'emotes',
-    label: 'Emotes',
-    color: theme.colorPlum,
-    emptyMessage: 'No emotes cached',
-    emptySubmessage: 'Tap refresh to fetch emotes for this channel',
-  },
-  {
-    id: 'badges',
-    label: 'Badges',
-    color: theme.colorOrange,
-    emptyMessage: 'No badges cached',
-    emptySubmessage: 'Tap refresh to fetch badges for this channel',
-  },
-];
-
 interface EmoteRowItem {
   id: string;
   name: string;
@@ -267,37 +244,6 @@ function ResourceList<T>({
   );
 }
 
-function TabButton({
-  label,
-  count,
-  isActive,
-  activeColor,
-  onPress,
-}: {
-  label: string;
-  count: number;
-  isActive: boolean;
-  activeColor: string;
-  onPress: () => void;
-}) {
-  return (
-    <Button
-      onPress={onPress}
-      style={[
-        styles.tabButton,
-        isActive && styles.tabButtonActive,
-        isActive && { backgroundColor: activeColor },
-      ]}
-    >
-      <Text
-        style={[styles.tabButtonText, isActive && styles.tabButtonTextActive]}
-      >
-        {label} ({count})
-      </Text>
-    </Button>
-  );
-}
-
 function FollowedStreamerPill({
   streamer,
   isSelected,
@@ -329,37 +275,6 @@ function FollowedStreamerPill({
         {streamer.user_name}
       </Text>
     </TouchableOpacity>
-  );
-}
-
-function StatusPanel({
-  title,
-  subtitle,
-  actionLabel,
-  onAction,
-  loading,
-}: {
-  title: string;
-  subtitle?: string;
-  actionLabel?: string;
-  onAction?: () => void;
-  loading?: boolean;
-}) {
-  return (
-    <View style={styles.centeredState}>
-      {loading ? (
-        <ActivityIndicator color={theme.colorPrimary} size='large' />
-      ) : null}
-      <Text style={loading ? styles.loadingText : styles.emptyText}>
-        {title}
-      </Text>
-      {subtitle ? <Text style={styles.emptySubtext}>{subtitle}</Text> : null}
-      {actionLabel && onAction ? (
-        <Button onPress={onAction} style={styles.actionButton}>
-          <Text style={styles.actionButtonText}>{actionLabel}</Text>
-        </Button>
-      ) : null}
-    </View>
   );
 }
 
@@ -402,37 +317,63 @@ function ChannelViewer({
   }
 
   if (isLoading) {
-    return <StatusPanel title={`Loading ${channelName}…`} loading />;
+    return (
+      <View style={styles.centeredState}>
+        <ActivityIndicator color={theme.colorPrimary} size='large' />
+        <Text style={styles.loadingText}>Loading {channelName}…</Text>
+      </View>
+    );
   }
 
   if (error) {
     return (
-      <StatusPanel
-        title='Failed to load channel'
-        subtitle={error}
-        actionLabel='Retry'
-        onAction={handleLoad}
-      />
+      <View style={styles.centeredState}>
+        <Text style={styles.emptyText}>Failed to load channel</Text>
+        <Text style={styles.emptySubtext}>{error}</Text>
+        <Button onPress={handleLoad} style={styles.actionButton}>
+          <Text style={styles.actionButtonText}>Retry</Text>
+        </Button>
+      </View>
     );
   }
-
-  const activeTabConfig =
-    CHANNEL_TABS.find(entry => entry.id === activeTab) ?? CHANNEL_TABS[0];
-  const isEmotes = activeTab === 'emotes';
 
   return (
     <View style={styles.flex}>
       <View style={styles.tabContainer}>
-        {CHANNEL_TABS.map(tab => (
-          <TabButton
-            key={tab.id}
-            label={tab.label}
-            count={tab.id === 'emotes' ? emoteList.length : badgeList.length}
-            isActive={activeTab === tab.id}
-            activeColor={tab.color}
-            onPress={() => setActiveTab(tab.id)}
-          />
-        ))}
+        <Button
+          onPress={() => setActiveTab('emotes')}
+          style={[
+            styles.tabButton,
+            activeTab === 'emotes' && styles.tabButtonActive,
+            activeTab === 'emotes' && { backgroundColor: theme.colorPlum },
+          ]}
+        >
+          <Text
+            style={[
+              styles.tabButtonText,
+              activeTab === 'emotes' && styles.tabButtonTextActive,
+            ]}
+          >
+            Emotes ({emoteList.length})
+          </Text>
+        </Button>
+        <Button
+          onPress={() => setActiveTab('badges')}
+          style={[
+            styles.tabButton,
+            activeTab === 'badges' && styles.tabButtonActive,
+            activeTab === 'badges' && { backgroundColor: theme.colorOrange },
+          ]}
+        >
+          <Text
+            style={[
+              styles.tabButtonText,
+              activeTab === 'badges' && styles.tabButtonTextActive,
+            ]}
+          >
+            Badges ({badgeList.length})
+          </Text>
+        </Button>
         {(emoteList.length > 0 || badgeList.length > 0) && (
           <Button onPress={handleLoad} style={styles.refreshButton}>
             <Text style={styles.refreshButtonText}>↻</Text>
@@ -440,20 +381,25 @@ function ChannelViewer({
         )}
       </View>
 
-      <ResourceList
-        ref={
-          listRef as RefObject<FlashListRef<EmoteRowItem | BadgeRowItem> | null>
-        }
-        data={isEmotes ? emoteList : badgeList}
-        renderItem={isEmotes ? renderEmoteItem : renderBadgeItem}
-        keyExtractor={item =>
-          isEmotes
-            ? `${(item as EmoteRowItem).site}:${(item as EmoteRowItem).id}`
-            : `${(item as BadgeRowItem).type}:${(item as BadgeRowItem).id}`
-        }
-        emptyMessage={activeTabConfig.emptyMessage}
-        emptySubmessage={activeTabConfig.emptySubmessage}
-      />
+      {activeTab === 'emotes' ? (
+        <ResourceList
+          ref={listRef}
+          data={emoteList}
+          renderItem={renderEmoteItem}
+          keyExtractor={item => `${item.site}:${item.id}`}
+          emptyMessage='No emotes cached'
+          emptySubmessage='Tap refresh to fetch emotes for this channel'
+        />
+      ) : (
+        <ResourceList
+          ref={listRef as RefObject<FlashListRef<BadgeRowItem> | null>}
+          data={badgeList}
+          renderItem={renderBadgeItem}
+          keyExtractor={item => `${item.type}:${item.id}`}
+          emptyMessage='No badges cached'
+          emptySubmessage='Tap refresh to fetch badges for this channel'
+        />
+      )}
     </View>
   );
 }

--- a/src/screens/SettingsScreen/SettingsEmotesScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsEmotesScreen.tsx
@@ -6,16 +6,38 @@ import {
 import { Image } from '@app/components/Image/Image';
 import { Text } from '@app/components/ui/Text/Text';
 import { Button } from '@app/components/Button/Button';
+import { Input } from '@app/components/ui/Input/Input';
 import { useScrollToTop } from '@app/hooks/useScrollToTop';
+import { useAuthContext } from '@app/context/AuthContext';
+import { twitchQueries } from '@app/queries/twitchQueries';
+import { twitchService } from '@app/services/twitch-service';
+import { loadChannelResources } from '@app/store/chat/actions/channelLoad';
 import { chatStore$ } from '@app/store/chat/observables/chatStore';
 import type {
+  ChannelCacheType,
   SanitisedBadgeSet,
   SanitisedEmote,
 } from '@app/store/chat/types/constants';
 import { theme } from '@app/styles/themes';
 import { useSelector } from '@legendapp/state/react';
-import { useRef, useState, type RefObject } from 'react';
-import { Linking, StyleSheet, View } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
+import {
+  useCallback,
+  useRef,
+  useState,
+  startTransition,
+  type RefObject,
+} from 'react';
+import {
+  ActivityIndicator,
+  Linking,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 type TabType = 'emotes' | 'badges';
 
@@ -37,72 +59,74 @@ interface BadgeRowItem {
   provider?: string;
 }
 
-function buildEmoteList(
-  channelCaches: Record<string, import('@app/store/chat/types/constants').ChannelCacheType>,
-): EmoteRowItem[] {
+// ─── Data helpers ─────────────────────────────────────────────────────────────
+
+function buildEmoteList(cache: ChannelCacheType | undefined): EmoteRowItem[] {
+  if (!cache) {
+    return [];
+  }
+
   const seen = new Set<string>();
   const results: EmoteRowItem[] = [];
 
-  for (const cache of Object.values(channelCaches)) {
-    const allEmotes: SanitisedEmote[] = [
-      ...(cache.twitchChannelEmotes ?? []),
-      ...(cache.twitchGlobalEmotes ?? []),
-      ...(cache.twitchSubscriberEmotes ?? []),
-      ...(cache.sevenTvChannelEmotes ?? []),
-      ...(cache.sevenTvGlobalEmotes ?? []),
-      ...(cache.ffzChannelEmotes ?? []),
-      ...(cache.ffzGlobalEmotes ?? []),
-      ...(cache.bttvChannelEmotes ?? []),
-      ...(cache.bttvGlobalEmotes ?? []),
-    ];
+  const allEmotes: SanitisedEmote[] = [
+    ...(cache.twitchChannelEmotes ?? []),
+    ...(cache.twitchGlobalEmotes ?? []),
+    ...(cache.twitchSubscriberEmotes ?? []),
+    ...(cache.sevenTvChannelEmotes ?? []),
+    ...(cache.sevenTvGlobalEmotes ?? []),
+    ...(cache.ffzChannelEmotes ?? []),
+    ...(cache.ffzGlobalEmotes ?? []),
+    ...(cache.bttvChannelEmotes ?? []),
+    ...(cache.bttvGlobalEmotes ?? []),
+  ];
 
-    for (const emote of allEmotes) {
-      const key = `${emote.site}:${emote.id}`;
-      if (!seen.has(key)) {
-        seen.add(key);
-        results.push({
-          id: emote.id,
-          name: emote.name,
-          url: emote.url,
-          site: emote.site,
-          creator: emote.creator,
-          emote_link: emote.emote_link,
-        });
-      }
+  for (const emote of allEmotes) {
+    const key = `${emote.site}:${emote.id}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      results.push({
+        id: emote.id,
+        name: emote.name,
+        url: emote.url,
+        site: emote.site,
+        creator: emote.creator,
+        emote_link: emote.emote_link,
+      });
     }
   }
 
   return results;
 }
 
-function buildBadgeList(
-  channelCaches: Record<string, import('@app/store/chat/types/constants').ChannelCacheType>,
-): BadgeRowItem[] {
+function buildBadgeList(cache: ChannelCacheType | undefined): BadgeRowItem[] {
+  if (!cache) {
+    return [];
+  }
+
   const seen = new Set<string>();
   const results: BadgeRowItem[] = [];
 
-  for (const cache of Object.values(channelCaches)) {
-    const allBadges: SanitisedBadgeSet[] = [
-      ...(cache.twitchChannelBadges ?? []),
-      ...(cache.twitchGlobalBadges ?? []),
-      ...(cache.ffzChannelBadges ?? []),
-      ...(cache.ffzGlobalBadges ?? []),
-      ...(cache.chatterinoBadges ?? []),
-    ];
+  const allBadges: SanitisedBadgeSet[] = [
+    ...(cache.twitchChannelBadges ?? []),
+    ...(cache.twitchGlobalBadges ?? []),
+    ...(cache.ffzChannelBadges ?? []),
+    ...(cache.ffzGlobalBadges ?? []),
+    ...(cache.chatterinoBadges ?? []),
+  ];
 
-    for (const badge of allBadges) {
-      const key = `${badge.type}:${badge.id}`;
-      if (!seen.has(key)) {
-        seen.add(key);
-        results.push({
-          id: badge.id,
-          title: badge.title,
-          url: badge.url,
-          type: badge.type,
-          set: badge.set,
-          provider: badge.provider,
-        });
-      }
+  for (const badge of allBadges) {
+    const key = `${badge.type}:${badge.id}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      results.push({
+        id: badge.id,
+        title: badge.title,
+        url: badge.url,
+        type: badge.type,
+        set: badge.set,
+        provider: badge.provider,
+      });
     }
   }
 
@@ -125,8 +149,8 @@ const renderEmoteItem: ListRenderItem<EmoteRowItem> = ({ item }) => (
         <Text style={styles.itemName} numberOfLines={1}>
           {item.name}
         </Text>
-        <View style={styles.siteBadge}>
-          <Text style={styles.siteBadgeText}>{item.site}</Text>
+        <View style={styles.tagBadge}>
+          <Text style={styles.tagBadgeText}>{item.site}</Text>
         </View>
       </View>
       {item.creator ? (
@@ -141,7 +165,7 @@ const renderEmoteItem: ListRenderItem<EmoteRowItem> = ({ item }) => (
         <Text
           style={styles.itemLink}
           numberOfLines={1}
-          onPress={() => Linking.openURL(item.emote_link)}
+          onPress={() => void Linking.openURL(item.emote_link)}
         >
           {item.emote_link}
         </Text>
@@ -165,8 +189,8 @@ const renderBadgeItem: ListRenderItem<BadgeRowItem> = ({ item }) => (
           {item.title}
         </Text>
         {item.provider ? (
-          <View style={styles.siteBadge}>
-            <Text style={styles.siteBadgeText}>
+          <View style={styles.tagBadge}>
+            <Text style={styles.tagBadgeText}>
               {item.provider.toUpperCase()}
             </Text>
           </View>
@@ -182,7 +206,7 @@ const renderBadgeItem: ListRenderItem<BadgeRowItem> = ({ item }) => (
   </View>
 );
 
-// ─── Empty state ──────────────────────────────────────────────────────────────
+// ─── Empty / error states ─────────────────────────────────────────────────────
 
 function EmptyState({
   message,
@@ -199,76 +223,121 @@ function EmptyState({
   );
 }
 
-// ─── Tab content ──────────────────────────────────────────────────────────────
+// ─── Followed streamer pill ───────────────────────────────────────────────────
 
-function TabContent({
-  activeTab,
-  emoteList,
-  badgeList,
-  listRef,
+interface FollowedStreamer {
+  user_id: string;
+  user_login: string;
+  user_name: string;
+  thumbnail_url: string;
+}
+
+function FollowedStreamerPill({
+  streamer,
+  isSelected,
+  onPress,
 }: {
-  activeTab: TabType;
-  emoteList: EmoteRowItem[];
-  badgeList: BadgeRowItem[];
-  listRef: RefObject<FlashListRef<EmoteRowItem> | null>;
+  streamer: FollowedStreamer;
+  isSelected: boolean;
+  onPress: () => void;
 }) {
-  if (activeTab === 'emotes') {
-    return (
-      <FlashList
-        ref={listRef}
-        data={emoteList}
-        estimatedItemSize={90}
-        contentInsetAdjustmentBehavior='automatic'
-        renderItem={renderEmoteItem}
-        keyExtractor={item => `${item.site}:${item.id}`}
-        contentContainerStyle={styles.listContent}
-        ListEmptyComponent={
-          <EmptyState
-            message='No cached emotes'
-            submessage='Emotes will appear here after you visit a stream chat'
-          />
-        }
+  const avatarUrl = streamer.thumbnail_url.replace('{width}', '40').replace('{height}', '40');
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      style={[styles.streamerPill, isSelected && styles.streamerPillActive]}
+      activeOpacity={0.75}
+    >
+      <Image
+        source={{ uri: avatarUrl }}
+        style={styles.streamerAvatar}
+        contentFit='cover'
       />
+      <Text
+        style={[
+          styles.streamerName,
+          isSelected && styles.streamerNameActive,
+        ]}
+        numberOfLines={1}
+      >
+        {streamer.user_name}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+// ─── Channel viewer (after channel is resolved) ───────────────────────────────
+
+function ChannelViewer({
+  channelId,
+  channelName,
+}: {
+  channelId: string;
+  channelName: string;
+}) {
+  const [activeTab, setActiveTab] = useState<TabType>('emotes');
+  const [isLoading, setIsLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const listRef = useRef<FlashListRef<EmoteRowItem>>(null);
+
+  useScrollToTop(listRef);
+
+  const cache = useSelector(
+    () => chatStore$.persisted.channelCaches[channelId]?.get(),
+  );
+
+  const emoteList = buildEmoteList(cache);
+  const badgeList = buildBadgeList(cache);
+
+  const handleLoad = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await loadChannelResources({ channelId, forceRefresh: true });
+      setLoaded(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load channel');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [channelId]);
+
+  const hasCache = cache !== undefined;
+  const hasContent = emoteList.length > 0 || badgeList.length > 0;
+
+  // Auto-load if no cache yet
+  if (!hasCache && !isLoading && !loaded && !error) {
+    void handleLoad();
+  }
+
+  if (isLoading) {
+    return (
+      <View style={styles.centeredState}>
+        <ActivityIndicator color={theme.colorPrimary} size='large' />
+        <Text style={styles.loadingText}>Loading {channelName}…</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.centeredState}>
+        <Text style={styles.emptyText}>Failed to load channel</Text>
+        <Text style={styles.emptySubtext}>{error}</Text>
+        <Button onPress={handleLoad} style={styles.retryButton}>
+          <Text style={styles.retryButtonText}>Retry</Text>
+        </Button>
+      </View>
     );
   }
 
   return (
-    <FlashList
-      ref={listRef as RefObject<FlashListRef<BadgeRowItem> | null>}
-      data={badgeList}
-      estimatedItemSize={90}
-      contentInsetAdjustmentBehavior='automatic'
-      renderItem={renderBadgeItem}
-      keyExtractor={item => `${item.type}:${item.id}`}
-      contentContainerStyle={styles.listContent}
-      ListEmptyComponent={
-        <EmptyState
-          message='No cached badges'
-          submessage='Badges will appear here after you visit a stream chat'
-        />
-      }
-    />
-  );
-}
-
-// ─── Header ───────────────────────────────────────────────────────────────────
-
-function Header({
-  activeTab,
-  emoteCount,
-  badgeCount,
-  onSelectTab,
-}: {
-  activeTab: TabType;
-  emoteCount: number;
-  badgeCount: number;
-  onSelectTab: (tab: TabType) => void;
-}) {
-  return (
-    <View style={styles.headerContainer}>
+    <View style={styles.channelViewerContainer}>
+      {/* Tab bar */}
       <View style={styles.tabContainer}>
         <Button
-          onPress={() => onSelectTab('emotes')}
+          onPress={() => setActiveTab('emotes')}
           style={[
             styles.tabButton,
             activeTab === 'emotes' && styles.tabButtonActive,
@@ -281,11 +350,11 @@ function Header({
               activeTab === 'emotes' && styles.tabButtonTextActive,
             ]}
           >
-            Emotes ({emoteCount})
+            Emotes ({emoteList.length})
           </Text>
         </Button>
         <Button
-          onPress={() => onSelectTab('badges')}
+          onPress={() => setActiveTab('badges')}
           style={[
             styles.tabButton,
             activeTab === 'badges' && styles.tabButtonActive,
@@ -298,45 +367,196 @@ function Header({
               activeTab === 'badges' && styles.tabButtonTextActive,
             ]}
           >
-            Badges ({badgeCount})
+            Badges ({badgeList.length})
           </Text>
         </Button>
+        {hasContent && (
+          <Button
+            onPress={handleLoad}
+            style={styles.refreshButton}
+          >
+            <Text style={styles.refreshButtonText}>↻</Text>
+          </Button>
+        )}
       </View>
+
+      {/* List */}
+      {activeTab === 'emotes' ? (
+        <FlashList
+          ref={listRef}
+          data={emoteList}
+          estimatedItemSize={90}
+          contentInsetAdjustmentBehavior='automatic'
+          renderItem={renderEmoteItem}
+          keyExtractor={item => `${item.site}:${item.id}`}
+          contentContainerStyle={styles.listContent}
+          ListEmptyComponent={
+            <EmptyState
+              message='No emotes cached'
+              submessage='Tap refresh to fetch emotes for this channel'
+            />
+          }
+        />
+      ) : (
+        <FlashList
+          ref={listRef as RefObject<FlashListRef<BadgeRowItem> | null>}
+          data={badgeList}
+          estimatedItemSize={90}
+          contentInsetAdjustmentBehavior='automatic'
+          renderItem={renderBadgeItem}
+          keyExtractor={item => `${item.type}:${item.id}`}
+          contentContainerStyle={styles.listContent}
+          ListEmptyComponent={
+            <EmptyState
+              message='No badges cached'
+              submessage='Tap refresh to fetch badges for this channel'
+            />
+          }
+        />
+      )}
     </View>
   );
 }
 
-// ─── Screen ───────────────────────────────────────────────────────────────────
+// ─── Main screen ──────────────────────────────────────────────────────────────
 
 export function SettingsEmotesScreen() {
-  const [activeTab, setActiveTab] = useState<TabType>('emotes');
-  const listRef = useRef<FlashListRef<EmoteRowItem>>(null);
+  const { user } = useAuthContext();
+  const insets = useSafeAreaInsets();
 
-  useScrollToTop(listRef);
+  // Channel search state
+  const [inputValue, setInputValue] = useState('');
+  const [selectedChannel, setSelectedChannel] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [resolving, setResolving] = useState(false);
+  const [resolveError, setResolveError] = useState<string | null>(null);
 
-  const channelCaches = useSelector(
-    chatStore$.persisted.channelCaches,
+  // Followed streamers (only when logged in)
+  const followedQuery = useQuery({
+    ...twitchQueries.getFollowedStreams(user?.id ?? ''),
+    enabled: !!user?.id,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const followedStreamers: FollowedStreamer[] = (followedQuery.data ?? []).map(
+    s => ({
+      user_id: s.user_id,
+      user_login: s.user_login,
+      user_name: s.user_name,
+      thumbnail_url: s.thumbnail_url,
+    }),
   );
 
-  const emoteList = buildEmoteList(channelCaches);
-  const badgeList = buildBadgeList(channelCaches);
+  const handleSelectFollowed = useCallback(
+    (streamer: FollowedStreamer) => {
+      setResolveError(null);
+      setInputValue(streamer.user_login);
+      setSelectedChannel({ id: streamer.user_id, name: streamer.user_name });
+    },
+    [],
+  );
+
+  const handleSearch = useCallback(async () => {
+    const login = inputValue.trim().toLowerCase();
+    if (!login) {
+      return;
+    }
+
+    setResolving(true);
+    setResolveError(null);
+    setSelectedChannel(null);
+
+    try {
+      const userInfo = await twitchService.getUser(login);
+      if (!userInfo?.id) {
+        setResolveError(`Channel "${login}" not found`);
+        return;
+      }
+      startTransition(() => {
+        setSelectedChannel({ id: userInfo.id, name: userInfo.display_name });
+      });
+    } catch {
+      setResolveError('Could not find that channel. Check the name and try again.');
+    } finally {
+      setResolving(false);
+    }
+  }, [inputValue]);
 
   return (
-    <View style={styles.screenContainer}>
-      <View style={styles.container}>
-        <Header
-          activeTab={activeTab}
-          emoteCount={emoteList.length}
-          badgeCount={badgeList.length}
-          onSelectTab={setActiveTab}
-        />
-        <TabContent
-          activeTab={activeTab}
-          emoteList={emoteList}
-          badgeList={badgeList}
-          listRef={listRef}
-        />
+    <View style={[styles.screen, { paddingBottom: insets.bottom }]}>
+      {/* Search bar */}
+      <View style={styles.searchSection}>
+        <View style={styles.searchRow}>
+          <Input
+            autoCapitalize='none'
+            autoCorrect={false}
+            placeholder='Enter channel name…'
+            value={inputValue}
+            onChangeText={text => {
+              setInputValue(text);
+              setResolveError(null);
+            }}
+            onSubmitEditing={handleSearch}
+            returnKeyType='search'
+            style={styles.searchInput}
+          />
+          <Button
+            onPress={handleSearch}
+            style={styles.searchButton}
+            disabled={resolving || !inputValue.trim()}
+          >
+            {resolving ? (
+              <ActivityIndicator color='#fff' size='small' />
+            ) : (
+              <Text style={styles.searchButtonText}>Go</Text>
+            )}
+          </Button>
+        </View>
+        {resolveError ? (
+          <Text style={styles.errorText}>{resolveError}</Text>
+        ) : null}
       </View>
+
+      {/* Followed streamers */}
+      {user && followedStreamers.length > 0 && (
+        <View style={styles.followedSection}>
+          <Text style={styles.followedLabel}>Following</Text>
+          <FlashList
+            data={followedStreamers}
+            horizontal
+            estimatedItemSize={100}
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.followedListContent}
+            keyExtractor={item => item.user_id}
+            renderItem={({ item }) => (
+              <FollowedStreamerPill
+                streamer={item}
+                isSelected={selectedChannel?.id === item.user_id}
+                onPress={() => handleSelectFollowed(item)}
+              />
+            )}
+          />
+        </View>
+      )}
+
+      {/* Viewer */}
+      {selectedChannel ? (
+        <ChannelViewer
+          key={selectedChannel.id}
+          channelId={selectedChannel.id}
+          channelName={selectedChannel.name}
+        />
+      ) : (
+        <View style={styles.placeholder}>
+          <Text style={styles.placeholderText}>
+            {user
+              ? 'Pick a followed channel or search by name'
+              : 'Search for a channel by name'}
+          </Text>
+        </View>
+      )}
     </View>
   );
 }
@@ -344,7 +564,14 @@ export function SettingsEmotesScreen() {
 // ─── Styles ───────────────────────────────────────────────────────────────────
 
 const styles = StyleSheet.create({
-  container: {
+  centeredState: {
+    alignItems: 'center',
+    flex: 1,
+    gap: 12,
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+  channelViewerContainer: {
     flex: 1,
   },
   emptyState: {
@@ -368,10 +595,31 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     letterSpacing: -0.3,
     marginBottom: 10,
+    textAlign: 'center',
   },
-  headerContainer: {
-    backgroundColor: theme.color.background.dark,
-    paddingBottom: 8,
+  errorText: {
+    color: theme.colorRed,
+    fontSize: 13,
+    marginTop: 6,
+    paddingHorizontal: 2,
+  },
+  followedLabel: {
+    color: theme.color.textSecondary.dark,
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    marginBottom: 8,
+    paddingHorizontal: 16,
+    textTransform: 'uppercase',
+  },
+  followedListContent: {
+    paddingHorizontal: 16,
+  },
+  followedSection: {
+    borderBottomColor: theme.color.border.dark,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    paddingBottom: 12,
+    paddingTop: 4,
   },
   item: {
     alignItems: 'flex-start',
@@ -426,22 +674,119 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 8,
   },
-  screenContainer: {
+  loadingText: {
+    color: theme.color.textSecondary.dark,
+    fontSize: 14,
+    marginTop: 12,
+  },
+  placeholder: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 40,
+  },
+  placeholderText: {
+    color: theme.color.textSecondary.dark,
+    fontSize: 15,
+    lineHeight: 22,
+    opacity: 0.7,
+    textAlign: 'center',
+  },
+  refreshButton: {
+    alignItems: 'center',
+    backgroundColor: theme.color.backgroundSecondary.dark,
+    borderColor: theme.color.border.dark,
+    borderCurve: 'continuous',
+    borderRadius: 10,
+    borderWidth: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  refreshButtonText: {
+    color: theme.color.text.dark,
+    fontSize: 16,
+  },
+  retryButton: {
+    alignItems: 'center',
+    backgroundColor: theme.colorPrimary,
+    borderCurve: 'continuous',
+    borderRadius: 10,
+    justifyContent: 'center',
+    marginTop: 4,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+  },
+  retryButtonText: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  screen: {
     backgroundColor: theme.color.background.dark,
     flex: 1,
   },
-  siteBadge: {
-    backgroundColor: theme.color.background.dark,
+  searchButton: {
+    alignItems: 'center',
+    backgroundColor: theme.colorPrimary,
     borderCurve: 'continuous',
-    borderRadius: 4,
-    paddingHorizontal: 6,
-    paddingVertical: 3,
+    borderRadius: 10,
+    justifyContent: 'center',
+    minWidth: 52,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
   },
-  siteBadgeText: {
-    color: theme.color.textSecondary.dark,
-    fontSize: 9,
+  searchButtonText: {
+    color: '#fff',
+    fontSize: 15,
     fontWeight: '700',
-    letterSpacing: 0.5,
+  },
+  searchInput: {
+    flex: 1,
+  },
+  searchRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 10,
+  },
+  searchSection: {
+    borderBottomColor: theme.color.border.dark,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    paddingBottom: 12,
+    paddingHorizontal: 16,
+    paddingTop: 12,
+  },
+  streamerAvatar: {
+    borderCurve: 'continuous',
+    borderRadius: 16,
+    height: 32,
+    width: 32,
+  },
+  streamerName: {
+    color: theme.color.text.dark,
+    fontSize: 12,
+    fontWeight: '500',
+    maxWidth: 72,
+  },
+  streamerNameActive: {
+    color: '#fff',
+  },
+  streamerPill: {
+    alignItems: 'center',
+    backgroundColor: theme.color.backgroundSecondary.dark,
+    borderColor: theme.color.border.dark,
+    borderCurve: 'continuous',
+    borderRadius: 12,
+    borderWidth: 1,
+    gap: 6,
+    marginRight: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    width: 88,
+  },
+  streamerPillActive: {
+    backgroundColor: theme.colorTeal,
+    borderColor: 'transparent',
   },
   tabButton: {
     alignItems: 'center',
@@ -473,6 +818,19 @@ const styles = StyleSheet.create({
     paddingBottom: 8,
     paddingHorizontal: 16,
     paddingTop: 12,
+  },
+  tagBadge: {
+    backgroundColor: theme.color.background.dark,
+    borderCurve: 'continuous',
+    borderRadius: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 3,
+  },
+  tagBadgeText: {
+    color: theme.color.textSecondary.dark,
+    fontSize: 9,
+    fontWeight: '700',
+    letterSpacing: 0.5,
   },
   thumbnail: {
     borderCurve: 'continuous',

--- a/src/screens/SettingsScreen/SettingsEmotesScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsEmotesScreen.tsx
@@ -1,0 +1,489 @@
+import {
+  FlashList,
+  FlashListRef,
+  ListRenderItem,
+} from '@app/components/FlashList/FlashList';
+import { Image } from '@app/components/Image/Image';
+import { Text } from '@app/components/ui/Text/Text';
+import { Button } from '@app/components/Button/Button';
+import { useScrollToTop } from '@app/hooks/useScrollToTop';
+import { chatStore$ } from '@app/store/chat/observables/chatStore';
+import type {
+  SanitisedBadgeSet,
+  SanitisedEmote,
+} from '@app/store/chat/types/constants';
+import { theme } from '@app/styles/themes';
+import { useSelector } from '@legendapp/state/react';
+import { useRef, useState, type RefObject } from 'react';
+import { Linking, StyleSheet, View } from 'react-native';
+
+type TabType = 'emotes' | 'badges';
+
+interface EmoteRowItem {
+  id: string;
+  name: string;
+  url: string;
+  site: string;
+  creator: string | null;
+  emote_link: string;
+}
+
+interface BadgeRowItem {
+  id: string;
+  title: string;
+  url: string;
+  type: string;
+  set: string;
+  provider?: string;
+}
+
+function buildEmoteList(
+  channelCaches: Record<string, import('@app/store/chat/types/constants').ChannelCacheType>,
+): EmoteRowItem[] {
+  const seen = new Set<string>();
+  const results: EmoteRowItem[] = [];
+
+  for (const cache of Object.values(channelCaches)) {
+    const allEmotes: SanitisedEmote[] = [
+      ...(cache.twitchChannelEmotes ?? []),
+      ...(cache.twitchGlobalEmotes ?? []),
+      ...(cache.twitchSubscriberEmotes ?? []),
+      ...(cache.sevenTvChannelEmotes ?? []),
+      ...(cache.sevenTvGlobalEmotes ?? []),
+      ...(cache.ffzChannelEmotes ?? []),
+      ...(cache.ffzGlobalEmotes ?? []),
+      ...(cache.bttvChannelEmotes ?? []),
+      ...(cache.bttvGlobalEmotes ?? []),
+    ];
+
+    for (const emote of allEmotes) {
+      const key = `${emote.site}:${emote.id}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        results.push({
+          id: emote.id,
+          name: emote.name,
+          url: emote.url,
+          site: emote.site,
+          creator: emote.creator,
+          emote_link: emote.emote_link,
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+function buildBadgeList(
+  channelCaches: Record<string, import('@app/store/chat/types/constants').ChannelCacheType>,
+): BadgeRowItem[] {
+  const seen = new Set<string>();
+  const results: BadgeRowItem[] = [];
+
+  for (const cache of Object.values(channelCaches)) {
+    const allBadges: SanitisedBadgeSet[] = [
+      ...(cache.twitchChannelBadges ?? []),
+      ...(cache.twitchGlobalBadges ?? []),
+      ...(cache.ffzChannelBadges ?? []),
+      ...(cache.ffzGlobalBadges ?? []),
+      ...(cache.chatterinoBadges ?? []),
+    ];
+
+    for (const badge of allBadges) {
+      const key = `${badge.type}:${badge.id}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        results.push({
+          id: badge.id,
+          title: badge.title,
+          url: badge.url,
+          type: badge.type,
+          set: badge.set,
+          provider: badge.provider,
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+// ─── Row renderers ────────────────────────────────────────────────────────────
+
+const renderEmoteItem: ListRenderItem<EmoteRowItem> = ({ item }) => (
+  <View style={styles.item}>
+    <View style={styles.thumbnailContainer}>
+      <Image
+        source={{ uri: item.url }}
+        style={styles.thumbnail}
+        contentFit='contain'
+      />
+    </View>
+    <View style={styles.itemInfo}>
+      <View style={styles.itemHeader}>
+        <Text style={styles.itemName} numberOfLines={1}>
+          {item.name}
+        </Text>
+        <View style={styles.siteBadge}>
+          <Text style={styles.siteBadgeText}>{item.site}</Text>
+        </View>
+      </View>
+      {item.creator ? (
+        <Text style={styles.itemMeta} numberOfLines={1}>
+          by {item.creator}
+        </Text>
+      ) : null}
+      <Text style={styles.itemId} numberOfLines={1} selectable>
+        {item.id}
+      </Text>
+      {item.emote_link ? (
+        <Text
+          style={styles.itemLink}
+          numberOfLines={1}
+          onPress={() => Linking.openURL(item.emote_link)}
+        >
+          {item.emote_link}
+        </Text>
+      ) : null}
+    </View>
+  </View>
+);
+
+const renderBadgeItem: ListRenderItem<BadgeRowItem> = ({ item }) => (
+  <View style={styles.item}>
+    <View style={styles.thumbnailContainer}>
+      <Image
+        source={{ uri: item.url }}
+        style={styles.thumbnail}
+        contentFit='contain'
+      />
+    </View>
+    <View style={styles.itemInfo}>
+      <View style={styles.itemHeader}>
+        <Text style={styles.itemName} numberOfLines={1}>
+          {item.title}
+        </Text>
+        {item.provider ? (
+          <View style={styles.siteBadge}>
+            <Text style={styles.siteBadgeText}>
+              {item.provider.toUpperCase()}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+      <Text style={styles.itemMeta} numberOfLines={1}>
+        {item.type}
+      </Text>
+      <Text style={styles.itemId} numberOfLines={1} selectable>
+        set: {item.set} · id: {item.id}
+      </Text>
+    </View>
+  </View>
+);
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+function EmptyState({
+  message,
+  submessage,
+}: {
+  message: string;
+  submessage: string;
+}) {
+  return (
+    <View style={styles.emptyState}>
+      <Text style={styles.emptyText}>{message}</Text>
+      <Text style={styles.emptySubtext}>{submessage}</Text>
+    </View>
+  );
+}
+
+// ─── Tab content ──────────────────────────────────────────────────────────────
+
+function TabContent({
+  activeTab,
+  emoteList,
+  badgeList,
+  listRef,
+}: {
+  activeTab: TabType;
+  emoteList: EmoteRowItem[];
+  badgeList: BadgeRowItem[];
+  listRef: RefObject<FlashListRef<EmoteRowItem> | null>;
+}) {
+  if (activeTab === 'emotes') {
+    return (
+      <FlashList
+        ref={listRef}
+        data={emoteList}
+        estimatedItemSize={90}
+        contentInsetAdjustmentBehavior='automatic'
+        renderItem={renderEmoteItem}
+        keyExtractor={item => `${item.site}:${item.id}`}
+        contentContainerStyle={styles.listContent}
+        ListEmptyComponent={
+          <EmptyState
+            message='No cached emotes'
+            submessage='Emotes will appear here after you visit a stream chat'
+          />
+        }
+      />
+    );
+  }
+
+  return (
+    <FlashList
+      ref={listRef as RefObject<FlashListRef<BadgeRowItem> | null>}
+      data={badgeList}
+      estimatedItemSize={90}
+      contentInsetAdjustmentBehavior='automatic'
+      renderItem={renderBadgeItem}
+      keyExtractor={item => `${item.type}:${item.id}`}
+      contentContainerStyle={styles.listContent}
+      ListEmptyComponent={
+        <EmptyState
+          message='No cached badges'
+          submessage='Badges will appear here after you visit a stream chat'
+        />
+      }
+    />
+  );
+}
+
+// ─── Header ───────────────────────────────────────────────────────────────────
+
+function Header({
+  activeTab,
+  emoteCount,
+  badgeCount,
+  onSelectTab,
+}: {
+  activeTab: TabType;
+  emoteCount: number;
+  badgeCount: number;
+  onSelectTab: (tab: TabType) => void;
+}) {
+  return (
+    <View style={styles.headerContainer}>
+      <View style={styles.tabContainer}>
+        <Button
+          onPress={() => onSelectTab('emotes')}
+          style={[
+            styles.tabButton,
+            activeTab === 'emotes' && styles.tabButtonActive,
+            activeTab === 'emotes' && { backgroundColor: theme.colorPlum },
+          ]}
+        >
+          <Text
+            style={[
+              styles.tabButtonText,
+              activeTab === 'emotes' && styles.tabButtonTextActive,
+            ]}
+          >
+            Emotes ({emoteCount})
+          </Text>
+        </Button>
+        <Button
+          onPress={() => onSelectTab('badges')}
+          style={[
+            styles.tabButton,
+            activeTab === 'badges' && styles.tabButtonActive,
+            activeTab === 'badges' && { backgroundColor: theme.colorOrange },
+          ]}
+        >
+          <Text
+            style={[
+              styles.tabButtonText,
+              activeTab === 'badges' && styles.tabButtonTextActive,
+            ]}
+          >
+            Badges ({badgeCount})
+          </Text>
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+// ─── Screen ───────────────────────────────────────────────────────────────────
+
+export function SettingsEmotesScreen() {
+  const [activeTab, setActiveTab] = useState<TabType>('emotes');
+  const listRef = useRef<FlashListRef<EmoteRowItem>>(null);
+
+  useScrollToTop(listRef);
+
+  const channelCaches = useSelector(
+    chatStore$.persisted.channelCaches,
+  );
+
+  const emoteList = buildEmoteList(channelCaches);
+  const badgeList = buildBadgeList(channelCaches);
+
+  return (
+    <View style={styles.screenContainer}>
+      <View style={styles.container}>
+        <Header
+          activeTab={activeTab}
+          emoteCount={emoteList.length}
+          badgeCount={badgeList.length}
+          onSelectTab={setActiveTab}
+        />
+        <TabContent
+          activeTab={activeTab}
+          emoteList={emoteList}
+          badgeList={badgeList}
+          listRef={listRef}
+        />
+      </View>
+    </View>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  emptyState: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    paddingBottom: 40,
+    paddingHorizontal: 32,
+    paddingTop: 80,
+  },
+  emptySubtext: {
+    color: theme.color.textSecondary.dark,
+    fontSize: 14,
+    lineHeight: 21,
+    opacity: 0.8,
+    textAlign: 'center',
+  },
+  emptyText: {
+    color: theme.color.textSecondary.dark,
+    fontSize: 19,
+    fontWeight: '700',
+    letterSpacing: -0.3,
+    marginBottom: 10,
+  },
+  headerContainer: {
+    backgroundColor: theme.color.background.dark,
+    paddingBottom: 8,
+  },
+  item: {
+    alignItems: 'flex-start',
+    backgroundColor: theme.color.backgroundSecondary.dark,
+    borderColor: theme.color.border.dark,
+    borderCurve: 'continuous',
+    borderRadius: 14,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: 14,
+    marginBottom: 12,
+    padding: 16,
+  },
+  itemHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 2,
+  },
+  itemId: {
+    color: theme.color.textSecondary.dark,
+    fontFamily: 'monospace',
+    fontSize: 10,
+    marginTop: 2,
+    opacity: 0.7,
+  },
+  itemInfo: {
+    flex: 1,
+    flexShrink: 1,
+    gap: 4,
+  },
+  itemLink: {
+    color: theme.colorBlue,
+    fontSize: 11,
+    marginTop: 2,
+    textDecorationLine: 'underline',
+  },
+  itemMeta: {
+    color: theme.color.textSecondary.dark,
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  itemName: {
+    color: theme.color.text.dark,
+    flex: 1,
+    fontSize: 15,
+    fontWeight: '600',
+    letterSpacing: -0.2,
+  },
+  listContent: {
+    paddingBottom: 16,
+    paddingHorizontal: 16,
+    paddingTop: 8,
+  },
+  screenContainer: {
+    backgroundColor: theme.color.background.dark,
+    flex: 1,
+  },
+  siteBadge: {
+    backgroundColor: theme.color.background.dark,
+    borderCurve: 'continuous',
+    borderRadius: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 3,
+  },
+  siteBadgeText: {
+    color: theme.color.textSecondary.dark,
+    fontSize: 9,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+  },
+  tabButton: {
+    alignItems: 'center',
+    backgroundColor: theme.color.backgroundSecondary.dark,
+    borderColor: theme.color.border.dark,
+    borderCurve: 'continuous',
+    borderRadius: 10,
+    borderWidth: 1,
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  tabButtonActive: {
+    borderColor: 'transparent',
+  },
+  tabButtonText: {
+    color: theme.color.text.dark,
+    fontSize: 13,
+    fontWeight: '600',
+    letterSpacing: 0.2,
+  },
+  tabButtonTextActive: {
+    color: '#fff',
+  },
+  tabContainer: {
+    flexDirection: 'row',
+    gap: 8,
+    paddingBottom: 8,
+    paddingHorizontal: 16,
+    paddingTop: 12,
+  },
+  thumbnail: {
+    borderCurve: 'continuous',
+    borderRadius: 10,
+    height: 56,
+    width: 56,
+  },
+  thumbnailContainer: {
+    backgroundColor: theme.color.background.dark,
+    borderCurve: 'continuous',
+    borderRadius: 10,
+    overflow: 'hidden',
+  },
+});

--- a/src/screens/SettingsScreen/SettingsIndexScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsIndexScreen.tsx
@@ -45,6 +45,11 @@ export function SettingsIndexScreen() {
               onPress={() => router.push('/tabs/settings/chat-preferences')}
             />
             <Button
+              label='Emotes & Badges'
+              systemImage='face.smiling'
+              onPress={() => router.push('/tabs/settings/emotes')}
+            />
+            <Button
               label='Cache'
               systemImage='externaldrive'
               onPress={() => router.push('/tabs/settings/cache')}
@@ -138,6 +143,12 @@ export function SettingsIndexScreen() {
               color: theme.colorPlum,
             }}
             onPress={() => router.push('/tabs/settings/chat-preferences')}
+          />
+          <SettingsLinkRow
+            title='Emotes & Badges'
+            subtitle='Browse cached emotes and badges with metadata'
+            icon={{ icon: 'face.smiling', color: theme.colorTeal }}
+            onPress={() => router.push('/tabs/settings/emotes')}
           />
           <SettingsLinkRow
             title='Cache'


### PR DESCRIPTION
Resolves #360

Adds a new **Emotes & Badges** screen in Settings → Stream Experience.

### Features
- **Channel search** — enter any channel name to look up and browse its emotes/badges
- **Followed streamers** — signed-in users see a scrollable pill row of channels they follow; tap to select instantly
- **Per-channel viewer** — tabbed emotes / badges lists with image, name, site/provider, creator, ID, and tappable links
- Auto-fetches on open; ↻ refresh button for subsequent reloads
- Loading, error, and empty states throughout

### Files changed
- `src/screens/SettingsScreen/SettingsEmotesScreen.tsx` — new screen
- `src/app/tabs/settings/emotes.tsx` — Expo Router route
- `src/app/tabs/settings/_layout.tsx` — Stack.Screen registration
- `src/screens/SettingsScreen/SettingsIndexScreen.tsx` — nav entry in Stream Experience section