### PR TITLE
feat(emote-menu): split subscriber emotes by channel with pfp icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **app:** Sentry initialization
 - **app:** Sentry initialization
+
 ## 0.0.42-testflight
 
 ### ♻️ Refactor
@@ -39,6 +40,7 @@
 
 - **app:** Update rozenite ([#612](https://github.com/lhowsam/foam/issues/612))
 - **infrastructure:** Update action versions ([#618](https://github.com/lhowsam/foam/issues/618))
+
 ## 0.0.41
 
 ### ♻️ Refactor
@@ -63,6 +65,7 @@
 - **app:** Refine observability standards ([#573](https://github.com/lhowsam/foam/issues/573))
 - **app:** Release 0.0.41
 - **tooling:** Update commitlint
+
 ## 0.0.40
 
 ### ♻️ Refactor
@@ -131,6 +134,7 @@
 - **security:** Add zizmor
 - **infrastructure:** Add sonarcube ([#560](https://github.com/lhowsam/foam/issues/560))
 - **documentation:** Simplify proxy server
+
 ## ota-c42ee437-f55f-4a6e-93b8-7fb765721c2d
 
 ### ♻️ Refactor
@@ -153,11 +157,13 @@
 
 - **app:** Upgrade deps ([#509](https://github.com/lhowsam/foam/issues/509))
 - **app:** Remove interactionManager
+
 ## ota-9dc97786-4ff2-40e0-83b9-19be83418ed1
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix crash on rotate
+
 ## ota-8b3783c1-ee13-4bf3-8d2d-b68cf79a0655
 
 ### ♻️ Refactor
@@ -174,6 +180,7 @@
 
 - **app:** Fix build
 - **app:** Fix build
+
 ## ota-1ffa7bd3-e434-4400-9364-90da567dcf68
 
 ### 🐛 Bug Fixes
@@ -184,22 +191,26 @@
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Update agent skills
+
 ## ota-0831b9f9-5fce-43bb-8b70-fe9c4633601b
 
 ### ✨ Features
 
 - **app:** Ensure chat + video is in sync ([#488](https://github.com/lhowsam/foam/issues/488))
+
 ## ota-a0aa7b2d-23b7-4b57-b1eb-f6f96acb3718
 
 ### 🔧 Miscellaneous Tasks
 
 - **infrastructure:** Refresh agents
+
 ## ota-aae23856-f62e-4417-aa6b-efcef6d920b6
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix inf re-render loop
 - **app:** Fix changelogs
+
 ## ota-09afb2ac-dbdf-4b7d-996c-6beeaef68082
 
 ### 🐛 Bug Fixes
@@ -212,6 +223,7 @@
 - **app:** Remove old native player
 - **app:** Improve gh release format
 - **infrastructure:** Improve slack msg
+
 ## ota-c3493b6f-a9f2-4896-9a64-fb2d956e8245
 
 ### 🐛 Bug Fixes
@@ -224,6 +236,7 @@
 - **app:** Refresh agent skills
 - **infrastructure:** Slack noti fix
 - **infrastructure:** Fix deploy-ota-or-native
+
 ## 0.0.39
 
 ### ♻️ Refactor
@@ -246,6 +259,7 @@
 - **app:** Update deps
 - **app:** Increase test speed
 - **infrastructure:** Slack notifications
+
 ## ota-0.0.38-27
 
 ### 🐛 Bug Fixes
@@ -255,11 +269,13 @@
 ### 🔧 Miscellaneous Tasks
 
 - **infrastructure:** Don't pr a changelog
+
 ## ota-b578613f-7fd1-4d05-a6fc-10a2c2fff773
 
 ### 🐛 Bug Fixes
 
 - **infrastructure:** Improve release notes generation
+
 ## ota-1054ebce-6b29-4342-ad1f-030bfca5d82b
 
 ### ♻️ Refactor
@@ -291,6 +307,7 @@
 - **infrastructure:** Optimise jest speed
 - **app:** Refresh agents
 - **app:** Automate changelog ([#474](https://github.com/lhowsam/foam/issues/474))
+
 ## 0.0.38
 
 ### ✨ Features
@@ -321,6 +338,7 @@
 - **app:** Testing native update
 - **app:** Testing native update
 - **app:** Testing ota
+
 ## 0.0.36
 
 ### ✨ Features
@@ -332,6 +350,7 @@
 - **infrastructure:** Ota
 - **infrastructure:** Ota
 - **infrastructure:** Ota
+
 ## 0.0.37
 
 ### ♻️ Refactor
@@ -379,6 +398,7 @@
 - **app:** Prompt to confirm logout ([#443](https://github.com/lhowsam/foam/issues/443))
 - **app:** Add .easignore
 - **infrastructure:** Test self hosted runner ([#454](https://github.com/lhowsam/foam/issues/454))
+
 ## 0.0.34
 
 ### ♻️ Refactor
@@ -402,6 +422,7 @@
 
 - **app:** Fix storybook
 - **app:** Install expo-insights
+
 ## 0.0.33
 
 ### ♻️ Refactor
@@ -437,6 +458,7 @@
 - **tooling:** Add hermes release profiler ([#416](https://github.com/lhowsam/foam/issues/416))
 - **tooling:** Patch expo-file-system tsc ([#418](https://github.com/lhowsam/foam/issues/418))
 - **sentry:** Adjust sentry rates ([#419](https://github.com/lhowsam/foam/issues/419))
+
 ## 0.0.32
 
 ### 🐛 Bug Fixes
@@ -453,6 +475,7 @@
 - **ci:** Add deploy-testflight self-hosted workflow
 - **ci:** Add deploy-testflight self-hosted workflow
 - **infrastructure:** Tidy up ci/cd ([#385](https://github.com/lhowsam/foam/issues/385))
+
 ## 0.0.31
 
 ### 🐛 Bug Fixes
@@ -465,6 +488,7 @@
 
 - **app:** Add expo-atlas
 - Add refined plugin
+
 ## 0.0.30
 
 ### ✨ Features
@@ -481,6 +505,7 @@
 
 - **infrastructure:** Preview set up
 - **infrastructure:** Remove dead code
+
 ## 0.0.29
 
 ### ✨ Features
@@ -500,6 +525,7 @@
 
 - **app:** Tidy up caching code
 - Revert deploy.sh
+
 ## 0.0.27
 
 ### ♻️ Refactor
@@ -519,6 +545,7 @@
 ### 🔧 Miscellaneous Tasks
 
 - **documentation:** Update setup docs ([#329](https://github.com/lhowsam/foam/issues/329))
+
 ## 0.0.26
 
 ### ✨ Features
@@ -532,6 +559,7 @@
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Remove auth loading screen ([#314](https://github.com/lhowsam/foam/issues/314))
+
 ## 0.0.25
 
 ### ♻️ Refactor
@@ -561,6 +589,7 @@
 - **app:** Remove unused deps ([#309](https://github.com/lhowsam/foam/issues/309))
 - **app:** Update deps ([#310](https://github.com/lhowsam/foam/issues/310))
 - **app:** Update core RN deps ([#311](https://github.com/lhowsam/foam/issues/311))
+
 ## 0.0.24
 
 ### ✨ Features
@@ -573,6 +602,7 @@
 
 - **app:** Fix diagnostics screen
 - **chat:** Improve sheet typography
+
 ## 0.0.23
 
 ### ✨ Features
@@ -582,6 +612,7 @@
 ### 🔧 Miscellaneous Tasks
 
 - Update .gitignore
+
 ## 0.0.22
 
 ### ✨ Features
@@ -599,6 +630,7 @@
 - Fix build
 - Fix build
 - **docs:** Update .env.example
+
 ## 0.0.21
 
 ### ✨ Features
@@ -613,6 +645,7 @@
 ### 🔧 Miscellaneous Tasks
 
 - **infrastructure:** Add OTA ci/cd
+
 ## 0.0.20
 
 ### ✨ Features
@@ -630,11 +663,13 @@
 - **app:** Lock orientation on search
 - **app:** Compress images
 - **app:** Compress Images
+
 ## 0.0.19
 
 ### ✨ Features
 
 - **app:** Add react-query devtools
+
 ## 0.0.18
 
 ### 🐛 Bug Fixes
@@ -644,11 +679,13 @@
 ### 🧪 Testing
 
 - **auth:** Improve auth tests
+
 ## 0.0.17
 
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Refactor online manager
+
 ## 0.0.16
 
 ### ✨ Features
@@ -658,11 +695,13 @@
 ### 🐛 Bug Fixes
 
 - **app:** Fix auth ctx persistence issues
+
 ## 0.0.15
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix auth crashes
+
 ## 0.0.14
 
 ### ✨ Features
@@ -681,6 +720,7 @@
 - **ci:** Test alternate ci/cd workflow
 - **ci:** Test alternate ci/cd workflow
 - **ci:** Test alternate ci/cd workflow
+
 ## 0.0.13
 
 ### ♻️ Refactor
@@ -697,16 +737,19 @@
 
 - **app:** Debug auth issues
 - **app:** Debug auth issues
+
 ## 0.0.12
 
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Debug auth
+
 ## 0.0.11
 
 ### 🐛 Bug Fixes
 
 - **app:** Speculative crash fix around fonts
+
 ## 0.0.9
 
 ### ✨ Features
@@ -718,11 +761,13 @@
 ### 🐛 Bug Fixes
 
 - **app:** Comment out fb
+
 ## 0.0.8
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix crash on start
+
 ## 0.0.7
 
 ### 🔧 Miscellaneous Tasks
@@ -730,31 +775,37 @@
 - **app:** Debug release
 - **app:** Debug release
 - **app:** Debug release
+
 ## 0.0.6
 
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Debug release
+
 ## 0.0.5
 
 ### 🐛 Bug Fixes
 
 - **app:** Navigation state in prod
+
 ## 0.0.4
 
 ### ✨ Features
 
 - **app:** Debug screen
+
 ## 0.0.3
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix commmitlint
+
 ## 0.0.2
 
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Gs services file
+
 ## 0.0.1
 
 ### ♻️ Refactor
@@ -826,7 +877,7 @@
 - **app:** Add styling to bar bar
 - **chat:** Improve chat message styling
 - **infra:** Add deploy ci/cd
-- **infra:** Add eas  build profiles
+- **infra:** Add eas build profiles
 - **app:** Offline view
 - **chat:** Enhance chat styling + parsing
 - **ci:** Deploy to test flight
@@ -923,4 +974,3 @@
 ### 🧪 Testing
 
 - **app:** Add missing util unit tests
-

--- a/src/components/Chat/components/EmoteSheet/SetHeader.tsx
+++ b/src/components/Chat/components/EmoteSheet/SetHeader.tsx
@@ -1,4 +1,5 @@
 import { Text } from '@app/components/ui/Text/Text';
+import { Image } from '@app/components/Image/Image';
 import { View } from 'react-native';
 import type { EmoteMenuSet } from './emoteMenuData';
 import { EmoteMenuIcon } from './EmoteMenuIcon';
@@ -8,11 +9,20 @@ export function SetHeader({ set }: { set: EmoteMenuSet }) {
   return (
     <View style={styles.setHeader}>
       <View style={styles.setHeaderIcon}>
-        <EmoteMenuIcon
-          icon={set.icon}
-          isActive
-          fallbackLabel={set.shortLabel}
-        />
+        {set.icon.startsWith('avatar:') ? (
+          <Image
+            source={set.icon.slice(7)}
+            style={styles.setHeaderAvatar}
+            containerStyle={styles.setHeaderAvatarContainer}
+            transition={100}
+          />
+        ) : (
+          <EmoteMenuIcon
+            icon={set.icon}
+            isActive
+            fallbackLabel={set.shortLabel}
+          />
+        )}
       </View>
       <Text numberOfLines={1} style={styles.setHeaderTitle}>
         {set.title}

--- a/src/components/Chat/components/EmoteSheet/SetRailButton.tsx
+++ b/src/components/Chat/components/EmoteSheet/SetRailButton.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@app/components/Button/Button';
+import { Image } from '@app/components/Image/Image';
 import { Text } from '@app/components/ui/Text/Text';
 import type { EmoteMenuSet } from './emoteMenuData';
 import { emoteSheetStyles as styles } from './emoteSheetStyles';
@@ -19,6 +20,13 @@ export function SetRailButton({
     >
       {set.icon.startsWith('emoji:') ? (
         <Text style={styles.setRailEmoji}>{set.icon.slice(6)}</Text>
+      ) : set.icon.startsWith('avatar:') ? (
+        <Image
+          source={set.icon.slice(7)}
+          style={styles.setRailAvatar}
+          containerStyle={styles.setRailAvatarContainer}
+          transition={100}
+        />
       ) : (
         <Text
           style={[styles.setRailLabel, isActive && styles.setRailLabelActive]}

--- a/src/components/Chat/components/EmoteSheet/__tests__/SetHeader.test.tsx
+++ b/src/components/Chat/components/EmoteSheet/__tests__/SetHeader.test.tsx
@@ -1,0 +1,56 @@
+import { render } from '@testing-library/react-native';
+import type { EmoteMenuSet } from '../emoteMenuData';
+import { SetHeader } from '../SetHeader';
+
+jest.mock('@app/components/Image/Image', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+
+  return {
+    Image: ({ source }: { source: string }) =>
+      React.createElement(Text, { testID: 'set-header-avatar' }, source),
+  };
+});
+
+jest.mock('../EmoteMenuIcon', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+
+  return {
+    EmoteMenuIcon: () =>
+      React.createElement(Text, { testID: 'set-header-icon' }, 'icon'),
+  };
+});
+
+function createSet(icon: EmoteMenuSet['icon']): EmoteMenuSet {
+  return {
+    id: 'twitch-sub-owner',
+    provider: 'Twitch',
+    title: 'Streamer A',
+    icon,
+    emotes: [],
+    shortLabel: 'SA',
+  };
+}
+
+describe('SetHeader', () => {
+  test('renders avatar image when set icon uses avatar prefix', () => {
+    const { getByTestId, queryByTestId } = render(
+      <SetHeader set={createSet('avatar:https://example.com/pfp.png')} />,
+    );
+
+    expect(getByTestId('set-header-avatar')).toHaveTextContent(
+      'https://example.com/pfp.png',
+    );
+    expect(queryByTestId('set-header-icon')).toBeNull();
+  });
+
+  test('renders emote menu icon for non-avatar set icons', () => {
+    const { getByTestId, queryByTestId } = render(
+      <SetHeader set={createSet('twitch')} />,
+    );
+
+    expect(getByTestId('set-header-icon')).toBeTruthy();
+    expect(queryByTestId('set-header-avatar')).toBeNull();
+  });
+});

--- a/src/components/Chat/components/EmoteSheet/__tests__/SetRailButton.test.tsx
+++ b/src/components/Chat/components/EmoteSheet/__tests__/SetRailButton.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import type { EmoteMenuSet } from '../emoteMenuData';
+import { SetRailButton } from '../SetRailButton';
+
+jest.mock('@app/components/Image/Image', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+
+  return {
+    Image: ({ source }: { source: string }) =>
+      React.createElement(Text, { testID: 'set-rail-avatar' }, source),
+  };
+});
+
+jest.mock('@app/components/Button/Button', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+
+  return {
+    Button: ({
+      children,
+      onPress,
+    }: {
+      children: React.ReactNode;
+      onPress: () => void;
+    }) =>
+      React.createElement(
+        Text,
+        { testID: 'set-rail-button', onPress },
+        children,
+      ),
+  };
+});
+
+function createSet(icon: EmoteMenuSet['icon']): EmoteMenuSet {
+  return {
+    id: 'twitch-sub-owner',
+    provider: 'Twitch',
+    title: 'Streamer A',
+    icon,
+    emotes: [],
+    shortLabel: 'SA',
+  };
+}
+
+describe('SetRailButton', () => {
+  test('renders avatar image when set icon uses avatar prefix', () => {
+    const { getByTestId } = render(
+      <SetRailButton
+        isActive={false}
+        onPress={jest.fn()}
+        set={createSet('avatar:https://example.com/pfp.png')}
+      />,
+    );
+
+    expect(getByTestId('set-rail-avatar')).toHaveTextContent(
+      'https://example.com/pfp.png',
+    );
+  });
+
+  test('renders emoji label for emoji set icons', () => {
+    const { getByText } = render(
+      <SetRailButton
+        isActive={false}
+        onPress={jest.fn()}
+        set={createSet('emoji:😀')}
+      />,
+    );
+
+    expect(getByText('😀')).toBeTruthy();
+  });
+
+  test('calls onPress when tapped', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <SetRailButton
+        isActive={false}
+        onPress={onPress}
+        set={createSet('twitch')}
+      />,
+    );
+
+    fireEvent.press(getByTestId('set-rail-button'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Chat/components/EmoteSheet/__tests__/__fixtures__/emoteMenuData.fixture.ts
+++ b/src/components/Chat/components/EmoteSheet/__tests__/__fixtures__/emoteMenuData.fixture.ts
@@ -46,7 +46,7 @@ export function createSevenTvMenuEmote(
 export function createTwitchMenuEmote(
   id: string,
   name: string,
-  site: 'Twitch Channel' | 'Twitch Global',
+  site: 'Twitch Channel' | 'Twitch Global' | 'Twitch Subscriber',
   overrides: Partial<TwitchSanitisedEmote> = {},
 ): TwitchSanitisedEmote {
   return {
@@ -76,7 +76,11 @@ export function createMenuEmote(
     );
   }
 
-  if (site === 'Twitch Channel' || site === 'Twitch Global') {
+  if (
+    site === 'Twitch Channel' ||
+    site === 'Twitch Global' ||
+    site === 'Twitch Subscriber'
+  ) {
     return createTwitchMenuEmote(
       id,
       name,

--- a/src/components/Chat/components/EmoteSheet/__tests__/emoteMenuData.test.ts
+++ b/src/components/Chat/components/EmoteSheet/__tests__/emoteMenuData.test.ts
@@ -88,6 +88,110 @@ describe('emoteMenuData', () => {
     ).toBe('Smile');
   });
 
+  test('groups subscriber emotes by channel with profile name and avatar icon', () => {
+    const providers = buildEmoteMenuProviders({
+      twitchSubscriberEmotes: [
+        createMenuEmote('1', 'SubA', 'Twitch Subscriber', {
+          owner_id: 'owner-a',
+        }),
+        createMenuEmote('2', 'SubB', 'Twitch Subscriber', {
+          owner_id: 'owner-b',
+        }),
+        createMenuEmote('3', 'SubA2', 'Twitch Subscriber', {
+          owner_id: 'owner-a',
+        }),
+      ],
+      twitchSubscriberChannelProfiles: {
+        'owner-a': {
+          name: 'Streamer A',
+          profileImageUrl: 'https://example.com/a.png',
+        },
+        'owner-b': {
+          name: 'Streamer B',
+          profileImageUrl: 'https://example.com/b.png',
+        },
+      },
+    });
+
+    const twitchProvider = providers.find(provider => provider.id === 'Twitch');
+    expect(twitchProvider?.sets).toEqual([
+      {
+        emotes: [
+          createMenuEmote('1', 'SubA', 'Twitch Subscriber', {
+            owner_id: 'owner-a',
+          }),
+          createMenuEmote('3', 'SubA2', 'Twitch Subscriber', {
+            owner_id: 'owner-a',
+          }),
+        ],
+        icon: 'avatar:https://example.com/a.png',
+        id: 'twitch-sub-owner-a',
+        provider: 'Twitch',
+        shortLabel: 'SA',
+        title: 'Streamer A',
+      },
+      {
+        emotes: [
+          createMenuEmote('2', 'SubB', 'Twitch Subscriber', {
+            owner_id: 'owner-b',
+          }),
+        ],
+        icon: 'avatar:https://example.com/b.png',
+        id: 'twitch-sub-owner-b',
+        provider: 'Twitch',
+        shortLabel: 'SB',
+        title: 'Streamer B',
+      },
+    ]);
+  });
+
+  test('falls back to subscribed emotes set when subscriber emotes lack owner_id', () => {
+    const providers = buildEmoteMenuProviders({
+      twitchSubscriberEmotes: [
+        createMenuEmote('1', 'LegacySub', 'Twitch Subscriber'),
+      ],
+    });
+
+    const twitchProvider = providers.find(provider => provider.id === 'Twitch');
+    expect(twitchProvider?.sets).toEqual([
+      {
+        emotes: [createMenuEmote('1', 'LegacySub', 'Twitch Subscriber')],
+        icon: 'twitch',
+        id: 'twitch-user',
+        provider: 'Twitch',
+        shortLabel: 'SE',
+        title: 'Subscribed Emotes',
+      },
+    ]);
+  });
+
+  test('uses fallback channel title and twitch icon when profile is missing', () => {
+    const providers = buildEmoteMenuProviders({
+      twitchSubscriberEmotes: [
+        createMenuEmote('1', 'SubA', 'Twitch Subscriber', {
+          owner_id: 'owner-unknown',
+        }),
+      ],
+      twitchSubscriberChannelProfiles: {},
+    });
+
+    const twitchProvider = providers.find(provider => provider.id === 'Twitch');
+    expect(twitchProvider?.sets).toEqual([
+      {
+        emotes: [
+          createMenuEmote('1', 'SubA', 'Twitch Subscriber', {
+            owner_id: 'owner-unknown',
+          }),
+        ],
+        icon: 'twitch',
+        id: 'twitch-sub-owner-unknown',
+        provider: 'Twitch',
+        shortLabel: 'SC',
+        title: 'Subscribed Channel',
+      },
+    ]);
+  });
+
   test('flattens sets into header and row items for virtualization', () => {
     const provider = buildEmoteMenuProviders({
       twitchChannelEmotes: [

--- a/src/components/Chat/components/EmoteSheet/emoteMenuData.ts
+++ b/src/components/Chat/components/EmoteSheet/emoteMenuData.ts
@@ -41,6 +41,10 @@ export interface EmoteMenuDataInput {
   twitchChannelEmotes?: SanitisedEmote[];
   twitchGlobalEmotes?: SanitisedEmote[];
   twitchSubscriberEmotes?: SanitisedEmote[];
+  twitchSubscriberChannelProfiles?: Record<
+    string,
+    { name: string; profileImageUrl: string }
+  >;
 }
 
 function chunk<TItem>(items: TItem[], size: number): TItem[][] {
@@ -224,14 +228,52 @@ export function buildEmoteMenuProviders(
     ...groupSevenTvSets('Channel', input.sevenTvChannelEmotes ?? []),
     ...groupSevenTvSets('Global', input.sevenTvGlobalEmotes ?? []),
   ];
+  const profiles = input.twitchSubscriberChannelProfiles ?? {};
+  const subscriberEmotes = input.twitchSubscriberEmotes ?? [];
+
+  const subscriberByChannel = new Map<string, SanitisedEmote[]>();
+  const subscriberNoOwner: SanitisedEmote[] = [];
+
+  for (const emote of subscriberEmotes) {
+    const ownerId =
+      'owner_id' in emote && typeof emote.owner_id === 'string'
+        ? emote.owner_id
+        : null;
+    if (ownerId) {
+      const bucket = subscriberByChannel.get(ownerId) ?? [];
+      bucket.push(emote);
+      subscriberByChannel.set(ownerId, bucket);
+    } else {
+      subscriberNoOwner.push(emote);
+    }
+  }
+
+  const perChannelSets: EmoteMenuSet[] = [];
+  subscriberByChannel.forEach((emotes, ownerId) => {
+    const profile = profiles[ownerId];
+    const title = profile?.name ?? 'Subscribed Channel';
+    const icon: EmoteMenuIcon = profile?.profileImageUrl
+      ? (`avatar:${profile.profileImageUrl}` as EmoteMenuIcon)
+      : 'twitch';
+    perChannelSets.push(
+      makeSet(`twitch-sub-${ownerId}`, 'Twitch', title, icon, emotes),
+    );
+  });
+
+  if (subscriberNoOwner.length > 0) {
+    perChannelSets.push(
+      makeSet(
+        'twitch-user',
+        'Twitch',
+        'Subscribed Emotes',
+        'twitch',
+        subscriberNoOwner,
+      ),
+    );
+  }
+
   const twitchSets = sortSets([
-    makeSet(
-      'twitch-user',
-      'Twitch',
-      'Subscribed Emotes',
-      'twitch',
-      input.twitchSubscriberEmotes ?? [],
-    ),
+    ...perChannelSets,
     makeSet(
       'twitch-channel',
       'Twitch',

--- a/src/components/Chat/components/EmoteSheet/emoteMenuData.ts
+++ b/src/components/Chat/components/EmoteSheet/emoteMenuData.ts
@@ -5,7 +5,11 @@ import type { SanitisedEmote } from '@app/types/emote';
 import type { EmotePickerItem } from './EmoteSheet';
 
 export type EmoteMenuProviderId = '7TV' | 'Twitch' | 'FFZ' | 'BTTV' | 'Emoji';
-export type EmoteMenuIcon = BrandIconName | 'ffz' | `emoji:${string}`;
+export type EmoteMenuIcon =
+  | BrandIconName
+  | 'ffz'
+  | `emoji:${string}`
+  | `avatar:${string}`;
 
 export interface EmoteMenuSet {
   emotes: EmotePickerItem[];
@@ -253,7 +257,7 @@ export function buildEmoteMenuProviders(
     const profile = profiles[ownerId];
     const title = profile?.name ?? 'Subscribed Channel';
     const icon: EmoteMenuIcon = profile?.profileImageUrl
-      ? (`avatar:${profile.profileImageUrl}` as EmoteMenuIcon)
+      ? `avatar:${profile.profileImageUrl}`
       : 'twitch';
     perChannelSets.push(
       makeSet(`twitch-sub-${ownerId}`, 'Twitch', title, icon, emotes),

--- a/src/components/Chat/components/EmoteSheet/emoteSheetStyles.ts
+++ b/src/components/Chat/components/EmoteSheet/emoteSheetStyles.ts
@@ -285,6 +285,17 @@ export const emoteSheetStyles = StyleSheet.create({
     justifyContent: 'center',
     width: 24,
   },
+  setHeaderAvatar: {
+    borderRadius: 12,
+    height: 24,
+    width: 24,
+  },
+  setHeaderAvatarContainer: {
+    borderRadius: 12,
+    height: 24,
+    overflow: 'hidden',
+    width: 24,
+  },
   setHeaderTitle: {
     color: theme.color.text.dark,
     flex: 1,
@@ -313,6 +324,17 @@ export const emoteSheetStyles = StyleSheet.create({
   },
   setRailEmoji: {
     fontSize: theme.fontSize16,
+  },
+  setRailAvatar: {
+    borderRadius: 12,
+    height: 24,
+    width: 24,
+  },
+  setRailAvatarContainer: {
+    borderRadius: 12,
+    height: 24,
+    overflow: 'hidden',
+    width: 24,
   },
   setRailLabel: {
     color: MENU_MUTED_TEXT,

--- a/src/components/Chat/components/EmoteSheet/useEmoteSheet.tsx
+++ b/src/components/Chat/components/EmoteSheet/useEmoteSheet.tsx
@@ -109,6 +109,7 @@ export function useEmoteSheet({
     twitchChannelEmotes,
     twitchGlobalEmotes,
     twitchSubscriberEmotes,
+    twitchSubscriberChannelProfiles,
   } = useCurrentEmoteData();
 
   const gridWidth = sheetWidth - GRID_HORIZONTAL_PADDING * 2 - RAIL_WIDTH;
@@ -138,6 +139,7 @@ export function useEmoteSheet({
     twitchChannelEmotes,
     twitchGlobalEmotes,
     twitchSubscriberEmotes,
+    twitchSubscriberChannelProfiles,
     emojiSets: EMOJI_MENU_SECTIONS,
   });
 

--- a/src/services/__tests__/twitch-emote-service.test.ts
+++ b/src/services/__tests__/twitch-emote-service.test.ts
@@ -30,7 +30,7 @@ describe('twitchEmoteService', () => {
         },
       ],
       pagination: {},
-    });
+    } as unknown as Awaited<ReturnType<typeof twitchApi.get>>);
 
     const emotes = await twitchEmoteService.getSubscriberEmotes('user-1');
 

--- a/src/services/__tests__/twitch-emote-service.test.ts
+++ b/src/services/__tests__/twitch-emote-service.test.ts
@@ -1,0 +1,63 @@
+import { twitchApi as _twitchApi } from '@app/services/api/clients';
+import { twitchEmoteService } from '@app/services/twitch-emote-service';
+
+jest.mock('@app/services/api/clients');
+jest.mock('@app/services/twitch-service', () => ({
+  twitchService: {
+    getUser: jest.fn(),
+  },
+}));
+
+const twitchApi = jest.mocked(_twitchApi);
+
+describe('twitchEmoteService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('getSubscriberEmotes preserves owner_id on sanitised emotes', async () => {
+    twitchApi.get.mockResolvedValue({
+      data: [
+        {
+          id: 'emote-1',
+          name: 'SubEmote',
+          emote_type: 'subscriptions',
+          emote_set_id: 'set-1',
+          owner_id: 'channel-owner',
+          format: ['static'],
+          scale: ['1.0'],
+          theme_mode: ['dark'],
+        },
+      ],
+      pagination: {},
+    });
+
+    const emotes = await twitchEmoteService.getSubscriberEmotes('user-1');
+
+    expect(emotes).toEqual([
+      {
+        name: 'SubEmote',
+        id: 'emote-1',
+        url: 'https://static-cdn.jtvnw.net/emoticons/v2/emote-1/default/dark/3.0',
+        static_url:
+          'https://static-cdn.jtvnw.net/emoticons/v2/emote-1/static/dark/3.0',
+        image_variants: {
+          animated: {
+            '2x': 'https://static-cdn.jtvnw.net/emoticons/v2/emote-1/default/dark/2.0',
+            '4x': 'https://static-cdn.jtvnw.net/emoticons/v2/emote-1/default/dark/3.0',
+          },
+          static: {
+            '2x': 'https://static-cdn.jtvnw.net/emoticons/v2/emote-1/static/dark/2.0',
+            '4x': 'https://static-cdn.jtvnw.net/emoticons/v2/emote-1/static/dark/3.0',
+          },
+        },
+        emote_link:
+          'https://static-cdn.jtvnw.net/emoticons/v2/emote-1/default/dark/3.0',
+        creator: null,
+        original_name: 'SubEmote',
+        site: 'Twitch Subscriber',
+        owner_id: 'channel-owner',
+      },
+    ]);
+  });
+});

--- a/src/services/twitch-emote-service.ts
+++ b/src/services/twitch-emote-service.ts
@@ -56,7 +56,7 @@ function toTwitchImageUrl(
 }
 
 function sanitiseTwitchEmote(
-  emote: Pick<TwitchEmote, 'id' | 'name'>,
+  emote: Pick<TwitchEmote, 'id' | 'name'> & { owner_id?: string },
   site: TwitchSanitisedEmote['site'],
   creator: string | null,
 ): TwitchSanitisedEmote {
@@ -81,6 +81,7 @@ function sanitiseTwitchEmote(
     creator,
     original_name: emote.name,
     site,
+    owner_id: emote.owner_id,
   };
 }
 

--- a/src/store/chat/__tests__/channelLoad.test.ts
+++ b/src/store/chat/__tests__/channelLoad.test.ts
@@ -12,7 +12,10 @@ import { ffzService } from '@app/services/ffz-service';
 import { sevenTvService } from '@app/services/seventv-service';
 import { twitchBadgeService } from '@app/services/twitch-badge-service';
 import { twitchEmoteService } from '@app/services/twitch-emote-service';
-import { twitchService } from '@app/services/twitch-service';
+import {
+  twitchService,
+  type UserInfoResponse,
+} from '@app/services/twitch-service';
 
 import { emptyEmoteData } from '../types/constants';
 import { loadChannelResources } from '../actions/channelLoad';
@@ -290,7 +293,18 @@ describe('loadChannelResources cache fallback', () => {
     mockGetFfzChannelBadges.mockResolvedValue([badge('ffz-channel-badge-new')]);
     mockGetFfzGlobalBadges.mockResolvedValue([badge('ffz-global-badge-new')]);
     mockListChatterinoBadges.mockReturnValue([]);
-    mockGetUser.mockResolvedValue(null);
+    mockGetUser.mockResolvedValue({
+      id: '',
+      broadcaster_type: '',
+      created_at: '',
+      description: '',
+      display_name: '',
+      login: '',
+      offline_image_url: '',
+      profile_image_url: '',
+      type: '',
+      view_count: 0,
+    } satisfies UserInfoResponse);
   });
 
   afterEach(() => {

--- a/src/store/chat/__tests__/channelLoad.test.ts
+++ b/src/store/chat/__tests__/channelLoad.test.ts
@@ -12,6 +12,7 @@ import { ffzService } from '@app/services/ffz-service';
 import { sevenTvService } from '@app/services/seventv-service';
 import { twitchBadgeService } from '@app/services/twitch-badge-service';
 import { twitchEmoteService } from '@app/services/twitch-emote-service';
+import { twitchService } from '@app/services/twitch-service';
 
 import { emptyEmoteData } from '../types/constants';
 import { loadChannelResources } from '../actions/channelLoad';
@@ -116,6 +117,12 @@ jest.mock('@app/services/twitch-emote-service', () => ({
   },
 }));
 
+jest.mock('@app/services/twitch-service', () => ({
+  twitchService: {
+    getUser: jest.fn(),
+  },
+}));
+
 const mockGetEmoteSetId = jest.mocked(sevenTvService.getEmoteSetId);
 const mockGetSanitisedEmoteSet = jest.mocked(
   sevenTvService.getSanitisedEmoteSet,
@@ -127,6 +134,7 @@ const mockGetGlobalEmotes = jest.mocked(twitchEmoteService.getGlobalEmotes);
 const mockGetSubscriberEmotes = jest.mocked(
   twitchEmoteService.getSubscriberEmotes,
 );
+const mockGetUser = jest.mocked(twitchService.getUser);
 const mockGetBttvGlobalEmotes = jest.mocked(
   bttvEmoteService.getSanitisedGlobalEmotes,
 );
@@ -282,6 +290,7 @@ describe('loadChannelResources cache fallback', () => {
     mockGetFfzChannelBadges.mockResolvedValue([badge('ffz-channel-badge-new')]);
     mockGetFfzGlobalBadges.mockResolvedValue([badge('ffz-global-badge-new')]);
     mockListChatterinoBadges.mockReturnValue([]);
+    mockGetUser.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -373,6 +382,49 @@ describe('loadChannelResources cache fallback', () => {
     expect(ids(cache!.badges)).toEqual(['ffz-global-badge-cached']);
     expect(cache!.badgesLastUpdated).toBe(0);
     expect(cache!.lastUpdated).toBe(9_000);
+  });
+
+  test('resolves subscriber channel profiles when cached emotes belong to another user', async () => {
+    chatStore$.persisted.channelCaches.set({
+      [channelId]: {
+        ...emptyEmoteData,
+        emotes: [twitchEmote('existing-emote')],
+        lastUpdated: 9_000,
+        twitchChannelEmotes: [twitchEmote('existing-emote')],
+        twitchGlobalEmotes: [twitchEmote('existing-global', 'Twitch Global')],
+        twitchSubscriberEmotes: [],
+        twitchSubscriberEmotesUserId: 'previous-user',
+        twitchSubscriberChannelProfiles: {},
+      },
+    });
+
+    mockGetSubscriberEmotes.mockResolvedValue([
+      {
+        ...twitchEmote('sub-emote', 'Twitch Subscriber'),
+        owner_id: 'owner-1',
+      },
+    ]);
+    mockGetUser.mockResolvedValue({
+      id: 'owner-1',
+      display_name: 'StreamerOne',
+      profile_image_url: 'https://example.com/owner-1.png',
+    } as Awaited<ReturnType<typeof twitchService.getUser>>);
+
+    await expect(
+      loadChannelResources({ channelId, twitchUserId }),
+    ).resolves.toBe(true);
+
+    const cache = chatStore$.persisted.channelCaches.peek()[channelId];
+    expect(cache).toBeDefined();
+    expect(cache!.twitchSubscriberEmotesUserId).toBe(twitchUserId);
+    expect(cache!.twitchSubscriberChannelProfiles).toEqual({
+      'owner-1': {
+        name: 'StreamerOne',
+        profileImageUrl: 'https://example.com/owner-1.png',
+      },
+    });
+    expect(ids(cache!.twitchSubscriberEmotes)).toEqual(['sub-emote']);
+    expect(mockGetUser).toHaveBeenCalledWith(undefined, 'owner-1');
   });
 
   test('uses empty provider slices without crashing when provider requests reject with no cache', async () => {

--- a/src/store/chat/actions/channelLoad.ts
+++ b/src/store/chat/actions/channelLoad.ts
@@ -5,6 +5,7 @@ import { sevenTvService } from '@app/services/seventv-service';
 import { twitchBadgeService } from '@app/services/twitch-badge-service';
 import type { SanitisedBadgeSet } from '@app/services/twitch-badge-service';
 import { twitchEmoteService } from '@app/services/twitch-emote-service';
+import { twitchService } from '@app/services/twitch-service';
 import type { SanitisedEmote } from '@app/types/emote';
 import { logger } from '@app/utils/logger';
 import {
@@ -532,9 +533,44 @@ const loadChannelResourcesInternal = async (
             const channelCache = chatStore$.persisted.channelCaches[channelId];
 
             if (channelCache) {
+              const ownerIds = [
+                ...new Set(
+                  subscriberEmotes
+                    .map(e =>
+                      'owner_id' in e
+                        ? (e as { owner_id?: string }).owner_id
+                        : undefined,
+                    )
+                    .filter((id): id is string => Boolean(id)),
+                ),
+              ];
+
+              const profileResults = await Promise.allSettled(
+                ownerIds.map(id => twitchService.getUser(undefined, id)),
+              );
+
+              const profiles: Record<
+                string,
+                { name: string; profileImageUrl: string }
+              > = {};
+              profileResults.forEach((result, idx) => {
+                const ownerId = ownerIds[idx];
+                if (
+                  result.status === 'fulfilled' &&
+                  result.value?.id &&
+                  ownerId
+                ) {
+                  profiles[ownerId] = {
+                    name: result.value.display_name,
+                    profileImageUrl: result.value.profile_image_url,
+                  };
+                }
+              });
+
               channelCache.assign({
                 twitchSubscriberEmotes: subscriberEmotes,
                 twitchSubscriberEmotesUserId: twitchUserId,
+                twitchSubscriberChannelProfiles: profiles,
                 emotes: deduplicateById([
                   ...subscriberEmotes,
                   ...(existingCache.emotes ?? []),
@@ -1126,6 +1162,8 @@ const loadChannelResourcesInternal = async (
           : now,
       ...emoteResourceSets,
       twitchSubscriberEmotesUserId: twitchUserId ?? undefined,
+      twitchSubscriberChannelProfiles:
+        existingCache?.twitchSubscriberChannelProfiles ?? {},
       ...badgeResourceSets,
       sevenTvPersonalBadges: {},
       sevenTvPersonalEmotes: {},

--- a/src/store/chat/react/selectors.ts
+++ b/src/store/chat/react/selectors.ts
@@ -21,6 +21,7 @@ type ChannelEmoteData = Pick<
   | 'twitchChannelEmotes'
   | 'twitchGlobalEmotes'
   | 'twitchSubscriberEmotes'
+  | 'twitchSubscriberChannelProfiles'
   | 'sevenTvChannelEmotes'
   | 'sevenTvGlobalEmotes'
   | 'ffzChannelEmotes'
@@ -36,6 +37,10 @@ type ChannelEmoteData = Pick<
 
 const EMPTY_EMOTES: SanitisedEmote[] = [];
 const EMPTY_BADGES: SanitisedBadgeSet[] = [];
+const EMPTY_PROFILES: Record<
+  string,
+  { name: string; profileImageUrl: string }
+> = {};
 
 function resolveEmoteData(
   cache: ChannelEmoteData | undefined,
@@ -55,6 +60,8 @@ function resolveEmoteData(
     twitchSubscriberEmotes: preferences.showTwitchEmotes
       ? (cache.twitchSubscriberEmotes ?? [])
       : [],
+    twitchSubscriberChannelProfiles:
+      cache.twitchSubscriberChannelProfiles ?? {},
     sevenTvChannelEmotes: preferences.show7TvEmotes
       ? (cache.sevenTvChannelEmotes ?? [])
       : [],
@@ -103,6 +110,8 @@ function getChannelEmoteData(channelId: string | null): ChannelEmoteData {
     twitchGlobalEmotes: cache$?.twitchGlobalEmotes.get() ?? EMPTY_EMOTES,
     twitchSubscriberEmotes:
       cache$?.twitchSubscriberEmotes.get() ?? EMPTY_EMOTES,
+    twitchSubscriberChannelProfiles:
+      cache$?.twitchSubscriberChannelProfiles.get() ?? EMPTY_PROFILES,
     sevenTvChannelEmotes: cache$?.sevenTvChannelEmotes.get() ?? EMPTY_EMOTES,
     sevenTvGlobalEmotes: cache$?.sevenTvGlobalEmotes.get() ?? EMPTY_EMOTES,
     ffzChannelEmotes: cache$?.ffzChannelEmotes.get() ?? EMPTY_EMOTES,

--- a/src/store/chat/types/constants.ts
+++ b/src/store/chat/types/constants.ts
@@ -131,6 +131,10 @@ export interface ChannelCacheType {
   twitchGlobalEmotes: SanitisedEmote[];
   twitchSubscriberEmotes: SanitisedEmote[];
   twitchSubscriberEmotesUserId?: string;
+  twitchSubscriberChannelProfiles: Record<
+    string,
+    { name: string; profileImageUrl: string }
+  >;
   sevenTvChannelEmotes: SanitisedEmote[];
   sevenTvGlobalEmotes: SanitisedEmote[];
   sevenTvPersonalEmotes: Record<string, SanitisedEmote[]>;
@@ -158,6 +162,7 @@ export const emptyEmoteData = {
   twitchGlobalEmotes: [],
   twitchSubscriberEmotes: [],
   twitchSubscriberEmotesUserId: undefined,
+  twitchSubscriberChannelProfiles: {},
   sevenTvChannelEmotes: [],
   sevenTvGlobalEmotes: [],
   sevenTvPersonalBadges: {},

--- a/src/types/emote.ts
+++ b/src/types/emote.ts
@@ -72,6 +72,7 @@ export interface TwitchSanitisedEmote extends SanitisedEmoteBase {
   width?: number;
   height?: number;
   actor?: StvUser;
+  owner_id?: string;
 }
 
 export interface EmojiSanitisedEmote extends SanitisedEmoteBase {


### PR DESCRIPTION
Resolves #434

### What changed
- `owner_id` is now stored on `TwitchSanitisedEmote` so each subscriber emote carries its channel ID
- After loading, channel profiles (display name + pfp) are batch-resolved for every unique `owner_id` and persisted in a new `twitchSubscriberChannelProfiles` map on the channel cache
- `buildEmoteMenuProviders` groups subscriber emotes by `owner_id` → one `EmoteMenuSet` per subscribed channel, named after the streamer
- `SetRailButton` and `SetHeader` render a circular avatar image when `set.icon` starts with `avatar:`
- Emotes with no `owner_id` fall back to the existing single `Subscribed Emotes` set