### PR TITLE
feat(chat): blocked terms CRUD in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **app:** Sentry initialization
 - **app:** Sentry initialization
+
 ## 0.0.42-testflight
 
 ### ♻️ Refactor
@@ -39,6 +40,7 @@
 
 - **app:** Update rozenite ([#612](https://github.com/lhowsam/foam/issues/612))
 - **infrastructure:** Update action versions ([#618](https://github.com/lhowsam/foam/issues/618))
+
 ## 0.0.41
 
 ### ♻️ Refactor
@@ -63,6 +65,7 @@
 - **app:** Refine observability standards ([#573](https://github.com/lhowsam/foam/issues/573))
 - **app:** Release 0.0.41
 - **tooling:** Update commitlint
+
 ## 0.0.40
 
 ### ♻️ Refactor
@@ -131,6 +134,7 @@
 - **security:** Add zizmor
 - **infrastructure:** Add sonarcube ([#560](https://github.com/lhowsam/foam/issues/560))
 - **documentation:** Simplify proxy server
+
 ## ota-c42ee437-f55f-4a6e-93b8-7fb765721c2d
 
 ### ♻️ Refactor
@@ -153,11 +157,13 @@
 
 - **app:** Upgrade deps ([#509](https://github.com/lhowsam/foam/issues/509))
 - **app:** Remove interactionManager
+
 ## ota-9dc97786-4ff2-40e0-83b9-19be83418ed1
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix crash on rotate
+
 ## ota-8b3783c1-ee13-4bf3-8d2d-b68cf79a0655
 
 ### ♻️ Refactor
@@ -174,6 +180,7 @@
 
 - **app:** Fix build
 - **app:** Fix build
+
 ## ota-1ffa7bd3-e434-4400-9364-90da567dcf68
 
 ### 🐛 Bug Fixes
@@ -184,22 +191,26 @@
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Update agent skills
+
 ## ota-0831b9f9-5fce-43bb-8b70-fe9c4633601b
 
 ### ✨ Features
 
 - **app:** Ensure chat + video is in sync ([#488](https://github.com/lhowsam/foam/issues/488))
+
 ## ota-a0aa7b2d-23b7-4b57-b1eb-f6f96acb3718
 
 ### 🔧 Miscellaneous Tasks
 
 - **infrastructure:** Refresh agents
+
 ## ota-aae23856-f62e-4417-aa6b-efcef6d920b6
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix inf re-render loop
 - **app:** Fix changelogs
+
 ## ota-09afb2ac-dbdf-4b7d-996c-6beeaef68082
 
 ### 🐛 Bug Fixes
@@ -212,6 +223,7 @@
 - **app:** Remove old native player
 - **app:** Improve gh release format
 - **infrastructure:** Improve slack msg
+
 ## ota-c3493b6f-a9f2-4896-9a64-fb2d956e8245
 
 ### 🐛 Bug Fixes
@@ -224,6 +236,7 @@
 - **app:** Refresh agent skills
 - **infrastructure:** Slack noti fix
 - **infrastructure:** Fix deploy-ota-or-native
+
 ## 0.0.39
 
 ### ♻️ Refactor
@@ -246,6 +259,7 @@
 - **app:** Update deps
 - **app:** Increase test speed
 - **infrastructure:** Slack notifications
+
 ## ota-0.0.38-27
 
 ### 🐛 Bug Fixes
@@ -255,11 +269,13 @@
 ### 🔧 Miscellaneous Tasks
 
 - **infrastructure:** Don't pr a changelog
+
 ## ota-b578613f-7fd1-4d05-a6fc-10a2c2fff773
 
 ### 🐛 Bug Fixes
 
 - **infrastructure:** Improve release notes generation
+
 ## ota-1054ebce-6b29-4342-ad1f-030bfca5d82b
 
 ### ♻️ Refactor
@@ -291,6 +307,7 @@
 - **infrastructure:** Optimise jest speed
 - **app:** Refresh agents
 - **app:** Automate changelog ([#474](https://github.com/lhowsam/foam/issues/474))
+
 ## 0.0.38
 
 ### ✨ Features
@@ -321,6 +338,7 @@
 - **app:** Testing native update
 - **app:** Testing native update
 - **app:** Testing ota
+
 ## 0.0.36
 
 ### ✨ Features
@@ -332,6 +350,7 @@
 - **infrastructure:** Ota
 - **infrastructure:** Ota
 - **infrastructure:** Ota
+
 ## 0.0.37
 
 ### ♻️ Refactor
@@ -379,6 +398,7 @@
 - **app:** Prompt to confirm logout ([#443](https://github.com/lhowsam/foam/issues/443))
 - **app:** Add .easignore
 - **infrastructure:** Test self hosted runner ([#454](https://github.com/lhowsam/foam/issues/454))
+
 ## 0.0.34
 
 ### ♻️ Refactor
@@ -402,6 +422,7 @@
 
 - **app:** Fix storybook
 - **app:** Install expo-insights
+
 ## 0.0.33
 
 ### ♻️ Refactor
@@ -437,6 +458,7 @@
 - **tooling:** Add hermes release profiler ([#416](https://github.com/lhowsam/foam/issues/416))
 - **tooling:** Patch expo-file-system tsc ([#418](https://github.com/lhowsam/foam/issues/418))
 - **sentry:** Adjust sentry rates ([#419](https://github.com/lhowsam/foam/issues/419))
+
 ## 0.0.32
 
 ### 🐛 Bug Fixes
@@ -453,6 +475,7 @@
 - **ci:** Add deploy-testflight self-hosted workflow
 - **ci:** Add deploy-testflight self-hosted workflow
 - **infrastructure:** Tidy up ci/cd ([#385](https://github.com/lhowsam/foam/issues/385))
+
 ## 0.0.31
 
 ### 🐛 Bug Fixes
@@ -465,6 +488,7 @@
 
 - **app:** Add expo-atlas
 - Add refined plugin
+
 ## 0.0.30
 
 ### ✨ Features
@@ -481,6 +505,7 @@
 
 - **infrastructure:** Preview set up
 - **infrastructure:** Remove dead code
+
 ## 0.0.29
 
 ### ✨ Features
@@ -500,6 +525,7 @@
 
 - **app:** Tidy up caching code
 - Revert deploy.sh
+
 ## 0.0.27
 
 ### ♻️ Refactor
@@ -519,6 +545,7 @@
 ### 🔧 Miscellaneous Tasks
 
 - **documentation:** Update setup docs ([#329](https://github.com/lhowsam/foam/issues/329))
+
 ## 0.0.26
 
 ### ✨ Features
@@ -532,6 +559,7 @@
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Remove auth loading screen ([#314](https://github.com/lhowsam/foam/issues/314))
+
 ## 0.0.25
 
 ### ♻️ Refactor
@@ -561,6 +589,7 @@
 - **app:** Remove unused deps ([#309](https://github.com/lhowsam/foam/issues/309))
 - **app:** Update deps ([#310](https://github.com/lhowsam/foam/issues/310))
 - **app:** Update core RN deps ([#311](https://github.com/lhowsam/foam/issues/311))
+
 ## 0.0.24
 
 ### ✨ Features
@@ -573,6 +602,7 @@
 
 - **app:** Fix diagnostics screen
 - **chat:** Improve sheet typography
+
 ## 0.0.23
 
 ### ✨ Features
@@ -582,6 +612,7 @@
 ### 🔧 Miscellaneous Tasks
 
 - Update .gitignore
+
 ## 0.0.22
 
 ### ✨ Features
@@ -599,6 +630,7 @@
 - Fix build
 - Fix build
 - **docs:** Update .env.example
+
 ## 0.0.21
 
 ### ✨ Features
@@ -613,6 +645,7 @@
 ### 🔧 Miscellaneous Tasks
 
 - **infrastructure:** Add OTA ci/cd
+
 ## 0.0.20
 
 ### ✨ Features
@@ -630,11 +663,13 @@
 - **app:** Lock orientation on search
 - **app:** Compress images
 - **app:** Compress Images
+
 ## 0.0.19
 
 ### ✨ Features
 
 - **app:** Add react-query devtools
+
 ## 0.0.18
 
 ### 🐛 Bug Fixes
@@ -644,11 +679,13 @@
 ### 🧪 Testing
 
 - **auth:** Improve auth tests
+
 ## 0.0.17
 
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Refactor online manager
+
 ## 0.0.16
 
 ### ✨ Features
@@ -658,11 +695,13 @@
 ### 🐛 Bug Fixes
 
 - **app:** Fix auth ctx persistence issues
+
 ## 0.0.15
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix auth crashes
+
 ## 0.0.14
 
 ### ✨ Features
@@ -681,6 +720,7 @@
 - **ci:** Test alternate ci/cd workflow
 - **ci:** Test alternate ci/cd workflow
 - **ci:** Test alternate ci/cd workflow
+
 ## 0.0.13
 
 ### ♻️ Refactor
@@ -697,16 +737,19 @@
 
 - **app:** Debug auth issues
 - **app:** Debug auth issues
+
 ## 0.0.12
 
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Debug auth
+
 ## 0.0.11
 
 ### 🐛 Bug Fixes
 
 - **app:** Speculative crash fix around fonts
+
 ## 0.0.9
 
 ### ✨ Features
@@ -718,11 +761,13 @@
 ### 🐛 Bug Fixes
 
 - **app:** Comment out fb
+
 ## 0.0.8
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix crash on start
+
 ## 0.0.7
 
 ### 🔧 Miscellaneous Tasks
@@ -730,31 +775,37 @@
 - **app:** Debug release
 - **app:** Debug release
 - **app:** Debug release
+
 ## 0.0.6
 
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Debug release
+
 ## 0.0.5
 
 ### 🐛 Bug Fixes
 
 - **app:** Navigation state in prod
+
 ## 0.0.4
 
 ### ✨ Features
 
 - **app:** Debug screen
+
 ## 0.0.3
 
 ### 🐛 Bug Fixes
 
 - **app:** Fix commmitlint
+
 ## 0.0.2
 
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Gs services file
+
 ## 0.0.1
 
 ### ♻️ Refactor
@@ -826,7 +877,7 @@
 - **app:** Add styling to bar bar
 - **chat:** Improve chat message styling
 - **infra:** Add deploy ci/cd
-- **infra:** Add eas  build profiles
+- **infra:** Add eas build profiles
 - **app:** Offline view
 - **chat:** Enhance chat styling + parsing
 - **ci:** Deploy to test flight
@@ -923,4 +974,3 @@
 ### 🧪 Testing
 
 - **app:** Add missing util unit tests
-

--- a/src/app/tabs/settings/_layout.tsx
+++ b/src/app/tabs/settings/_layout.tsx
@@ -32,6 +32,10 @@ export default function SettingsLayout() {
         options={{ title: 'Changelog', headerBackTitle: 'Settings' }}
       />
       <Stack.Screen
+        name='blocked-terms'
+        options={{ title: 'Blocked Terms', headerBackTitle: 'Settings' }}
+      />
+      <Stack.Screen
         name='channel-surfing'
         options={{ title: 'Channel Surfing', headerBackTitle: 'Settings' }}
       />

--- a/src/app/tabs/settings/blocked-terms.tsx
+++ b/src/app/tabs/settings/blocked-terms.tsx
@@ -1,0 +1,3 @@
+import { BlockedTermsScreen } from '@app/screens/Preferences/BlockedTermsScreen';
+
+export default BlockedTermsScreen;

--- a/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
+++ b/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
@@ -1,5 +1,6 @@
 import {
   useChatRenderPreferences,
+  usePreference,
   usePreferences,
   useUpdatePreferences,
 } from '@app/store/preferenceStore';
@@ -142,6 +143,7 @@ jest.mock('@app/store/chat/actions/messages', () => ({
 
 jest.mock('@app/store/preferenceStore', () => ({
   useChatRenderPreferences: jest.fn(),
+  usePreference: jest.fn(),
   usePreferences: jest.fn(),
   useUpdatePreferences: jest.fn(),
 }));
@@ -294,6 +296,7 @@ jest.mock('../hooks/useEmoteReprocessing', () => ({
 }));
 
 const mockedUsePreferences = jest.mocked(usePreferences);
+const mockedUsePreference = jest.mocked(usePreference);
 const mockedUseChatRenderPreferences = jest.mocked(useChatRenderPreferences);
 const mockedUseUpdatePreferences = jest.mocked(useUpdatePreferences);
 const mockedGetRecentMessages = jest.mocked(
@@ -340,10 +343,12 @@ const setPreferences = (showRecentMessages = true) => {
     showTwitchEmotes: true,
     showTwitchBadges: true,
     showUnreadJumpPill: true,
+    blockedTerms: [],
     update: jest.fn(),
   } satisfies ReturnType<typeof usePreferences>;
 
   mockedUsePreferences.mockReturnValue(preferences);
+  mockedUsePreference.mockReturnValue([]);
   mockedUseChatRenderPreferences.mockReturnValue(preferences);
   mockedUseUpdatePreferences.mockReturnValue(preferences.update);
 };

--- a/src/components/Chat/hooks/useChat.ts
+++ b/src/components/Chat/hooks/useChat.ts
@@ -4,6 +4,7 @@ import { useTwitchChat } from '@app/services/twitch-chat-service';
 import { chatStore$ } from '@app/store/chat/observables/chatStore';
 import {
   useChatRenderPreferences,
+  usePreference,
   useUpdatePreferences,
 } from '@app/store/preferenceStore';
 import { parseBadges } from '@app/utils/chat/parseBadges';
@@ -40,6 +41,7 @@ export function useChat(channelId: string, channelName: string) {
   const { user } = useAuthContext();
   const preferences = useChatRenderPreferences();
   const updatePreferences = useUpdatePreferences();
+  const blockedTerms = usePreference('blockedTerms');
   const showRecentMessages = preferences.showRecentMessages !== false;
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
@@ -448,7 +450,7 @@ export function useChat(channelId: string, channelName: string) {
     handleToggleShowOnlyMentions,
     handleUnpinPinnedMessage,
     handleViewableMessagesChange,
-    hiddenPhrases,
+    hiddenPhrases: [...hiddenPhrases, ...blockedTerms],
     hiddenUsers,
     hidePhraseFromView,
     hideUserFromView,

--- a/src/screens/Preferences/BlockedTermsScreen.tsx
+++ b/src/screens/Preferences/BlockedTermsScreen.tsx
@@ -9,15 +9,12 @@ import {
 import { theme } from '@app/styles/themes';
 import { SymbolView } from 'expo-symbols';
 import { useCallback, useRef, useState } from 'react';
-import {
-  Alert,
-  ScrollView,
-  StyleSheet,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { Alert, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import type { FlashListRef, ListRenderItem } from '@app/components/FlashList/FlashList';
+import type {
+  FlashListRef,
+  ListRenderItem,
+} from '@app/components/FlashList/FlashList';
 
 function SectionHeader({ count }: { count?: number }) {
   return (
@@ -71,18 +68,13 @@ function TermRow({
       <Text type='md' style={styles.termText} numberOfLines={1}>
         {term}
       </Text>
-      <TouchableOpacity
-        onPress={handleRemove}
-        style={styles.removeButton}
-        hitSlop={8}
-        activeOpacity={0.7}
-      >
+      <Pressable onPress={handleRemove} style={styles.removeButton} hitSlop={8}>
         <SymbolView
           name='minus.circle.fill'
           size={22}
           tintColor={theme.colorRed}
         />
-      </TouchableOpacity>
+      </Pressable>
     </View>
   );
 }
@@ -176,17 +168,16 @@ export function BlockedTermsScreen() {
           returnKeyType='done'
           style={styles.input}
         />
-        <TouchableOpacity
+        <Pressable
           onPress={handleAdd}
           style={[
             styles.addButton,
             !inputValue.trim() && styles.addButtonDisabled,
           ]}
           disabled={!inputValue.trim()}
-          activeOpacity={0.75}
         >
           <SymbolView name='plus' size={16} tintColor='#fff' />
-        </TouchableOpacity>
+        </Pressable>
       </View>
 
       {blockedTerms.length === 0 ? (
@@ -198,7 +189,6 @@ export function BlockedTermsScreen() {
             data={blockedTerms}
             renderItem={renderItem}
             keyExtractor={item => item}
-            estimatedItemSize={56}
             contentInsetAdjustmentBehavior='automatic'
             contentContainerStyle={styles.listContent}
             ListHeaderComponent={<SectionHeader count={blockedTerms.length} />}

--- a/src/screens/Preferences/BlockedTermsScreen.tsx
+++ b/src/screens/Preferences/BlockedTermsScreen.tsx
@@ -1,45 +1,28 @@
 import { FlashList } from '@app/components/FlashList/FlashList';
 import { Text } from '@app/components/ui/Text/Text';
-import { Input } from '@app/components/ui/Input/Input';
 import { useScrollToTop } from '@app/hooks/useScrollToTop';
+import { impact } from '@app/lib/haptics';
+import { Color } from '@app/styles/pallete';
 import {
   usePreference,
   useUpdatePreferences,
 } from '@app/store/preferenceStore';
 import { theme } from '@app/styles/themes';
 import { SymbolView } from 'expo-symbols';
+import { PressableScale } from 'pressto';
 import { useCallback, useRef, useState } from 'react';
-import { Alert, Pressable, ScrollView, StyleSheet, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Alert, StyleSheet, TextInput, View } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import type {
   FlashListRef,
   ListRenderItem,
 } from '@app/components/FlashList/FlashList';
 
-function SectionHeader({ count }: { count?: number }) {
-  return (
-    <View style={styles.sectionHeader}>
-      <Text type='xxs' weight='semibold' style={styles.sectionTitle}>
-        Blocked Terms
-      </Text>
-      {typeof count === 'number' ? (
-        <Text type='xxs' color='gray.textLow' style={styles.sectionCount}>
-          {count}
-        </Text>
-      ) : null}
-    </View>
-  );
-}
-
 function TermRow({
   term,
-  index,
-  count,
   onRemove,
 }: {
   term: string;
-  index: number;
-  count: number;
   onRemove: (term: string) => void;
 }) {
   const handleRemove = useCallback(() => {
@@ -58,64 +41,76 @@ function TermRow({
   }, [term, onRemove]);
 
   return (
-    <View
-      style={[
-        styles.row,
-        index === 0 && styles.rowFirst,
-        index === count - 1 && styles.rowLast,
-      ]}
-    >
+    <View style={styles.row}>
       <Text type='md' style={styles.termText} numberOfLines={1}>
         {term}
       </Text>
-      <Pressable onPress={handleRemove} style={styles.removeButton} hitSlop={8}>
+      <PressableScale onPress={handleRemove} hitSlop={8}>
         <SymbolView
           name='minus.circle.fill'
           size={22}
-          tintColor={theme.colorRed}
+          tintColor={Color.zinc[600]}
         />
-      </Pressable>
+      </PressableScale>
     </View>
   );
 }
 
 function EmptyState() {
   return (
-    <ScrollView
-      contentContainerStyle={styles.emptyContent}
-      contentInsetAdjustmentBehavior='automatic'
-    >
-      <View style={styles.sectionHeaderEmpty}>
-        <Text type='xxs' weight='semibold' style={styles.sectionTitle}>
-          Blocked Terms
-        </Text>
-      </View>
-      <View style={styles.emptyPanel}>
-        <View style={styles.emptyIcon}>
-          <SymbolView
-            name='text.badge.xmark'
-            size={28}
-            tintColor={theme.colorGreyHoverAlpha}
-          />
-        </View>
-        <Text type='lg' weight='bold' align='center'>
-          No blocked terms
-        </Text>
-        <Text
-          type='xs'
-          color='gray.textLow'
-          align='center'
-          style={styles.emptyDescription}
-        >
-          Messages containing a blocked term will be hidden from chat.
-        </Text>
-      </View>
-    </ScrollView>
+    <View style={styles.emptyState}>
+      <SymbolView
+        name='text.badge.xmark'
+        size={48}
+        tintColor={Color.zinc[600]}
+      />
+      <Text type='lg' weight='medium' style={styles.emptyTitle}>
+        No blocked terms
+      </Text>
+      <Text type='sm' style={styles.emptySubtitle}>
+        Messages containing a blocked term will be hidden from chat.
+      </Text>
+    </View>
+  );
+}
+
+interface InputSectionProps {
+  value: string;
+  onChangeText: (text: string) => void;
+  onAdd: () => void;
+}
+
+function InputSection({ value, onChangeText, onAdd }: InputSectionProps) {
+  const canAdd = value.trim().length > 0;
+
+  return (
+    <View style={styles.inputSection}>
+      <TextInput
+        autoCapitalize='none'
+        autoCorrect={false}
+        placeholder='Add a term to block…'
+        placeholderTextColor={Color.zinc[500]}
+        value={value}
+        onChangeText={onChangeText}
+        onSubmitEditing={onAdd}
+        returnKeyType='done'
+        style={styles.input}
+      />
+      <PressableScale
+        onPress={canAdd ? onAdd : undefined}
+        style={[styles.addButton, canAdd ? styles.addButtonEnabled : null]}
+      >
+        <SymbolView
+          name='plus'
+          size={16}
+          tintColor={canAdd ? Color.zinc[950] : Color.zinc[500]}
+        />
+      </PressableScale>
+    </View>
   );
 }
 
 export function BlockedTermsScreen() {
-  const insets = useSafeAreaInsets();
   const blockedTerms = usePreference('blockedTerms');
   const updatePreferences = useUpdatePreferences();
   const [inputValue, setInputValue] = useState('');
@@ -132,6 +127,7 @@ export function BlockedTermsScreen() {
     }
     updatePreferences({ blockedTerms: [...blockedTerms, normalised] });
     setInputValue('');
+    void impact('light');
   }, [inputValue, blockedTerms, updatePreferences]);
 
   const handleRemove = useCallback(
@@ -144,180 +140,128 @@ export function BlockedTermsScreen() {
   );
 
   const renderItem: ListRenderItem<string> = useCallback(
-    ({ item, index }) => (
-      <TermRow
-        term={item}
-        index={index}
-        count={blockedTerms.length}
-        onRemove={handleRemove}
-      />
-    ),
-    [blockedTerms.length, handleRemove],
+    ({ item }) => <TermRow term={item} onRemove={handleRemove} />,
+    [handleRemove],
   );
 
-  return (
-    <View style={[styles.container, { paddingBottom: insets.bottom }]}>
-      <View style={styles.inputSection}>
-        <Input
-          autoCapitalize='none'
-          autoCorrect={false}
-          placeholder='Add a term to block…'
-          value={inputValue}
-          onChangeText={setInputValue}
-          onSubmitEditing={handleAdd}
-          returnKeyType='done'
-          style={styles.input}
-        />
-        <Pressable
-          onPress={handleAdd}
-          style={[
-            styles.addButton,
-            !inputValue.trim() && styles.addButtonDisabled,
-          ]}
-          disabled={!inputValue.trim()}
-        >
-          <SymbolView name='plus' size={16} tintColor='#fff' />
-        </Pressable>
-      </View>
+  const inputSection = (
+    <InputSection
+      value={inputValue}
+      onChangeText={setInputValue}
+      onAdd={handleAdd}
+    />
+  );
 
-      {blockedTerms.length === 0 ? (
-        <EmptyState />
-      ) : (
-        <View style={styles.listContainer}>
-          <FlashList
-            ref={listRef}
-            data={blockedTerms}
-            renderItem={renderItem}
-            keyExtractor={item => item}
-            contentInsetAdjustmentBehavior='automatic'
-            contentContainerStyle={styles.listContent}
-            ListHeaderComponent={<SectionHeader count={blockedTerms.length} />}
-            ListFooterComponent={
-              <Text type='xxs' color='gray.textLow' style={styles.footer}>
-                Messages containing these terms will be hidden from chat.
-              </Text>
-            }
-          />
-        </View>
-      )}
-    </View>
+  const hasTerms = blockedTerms.length > 0;
+
+  return (
+    <KeyboardAvoidingView behavior='padding' style={styles.keyboardAvoid}>
+      <FlashList
+        ref={listRef}
+        data={blockedTerms}
+        renderItem={renderItem}
+        keyExtractor={item => item}
+        contentInsetAdjustmentBehavior='automatic'
+        keyboardShouldPersistTaps='handled'
+        contentContainerStyle={[
+          styles.listContent,
+          !hasTerms && styles.listContentEmpty,
+        ]}
+        ListHeaderComponent={inputSection}
+        ListEmptyComponent={EmptyState}
+        ListFooterComponent={
+          hasTerms ? (
+            <Text type='xs' style={styles.footer}>
+              {blockedTerms.length}{' '}
+              {blockedTerms.length === 1 ? 'term' : 'terms'} · Messages
+              containing these will be hidden from chat.
+            </Text>
+          ) : null
+        }
+      />
+    </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
   addButton: {
     alignItems: 'center',
-    backgroundColor: theme.colorPrimary,
+    backgroundColor: Color.zinc[800],
     borderCurve: 'continuous',
-    borderRadius: 10,
-    height: 42,
+    borderRadius: 18,
+    height: 36,
     justifyContent: 'center',
-    width: 42,
+    width: 36,
   },
-  addButtonDisabled: {
-    opacity: 0.4,
+  addButtonEnabled: {
+    backgroundColor: Color.zinc[50],
   },
-  container: {
-    backgroundColor: theme.color.background.dark,
-    flex: 1,
-  },
-  emptyContent: {
-    flexGrow: 1,
-    paddingBottom: theme.space24,
-  },
-  emptyDescription: {
-    lineHeight: 20,
-    maxWidth: 280,
-  },
-  emptyIcon: {
+  emptyState: {
     alignItems: 'center',
-    backgroundColor: theme.color.backgroundSecondary.dark,
-    borderCurve: 'continuous',
-    borderRadius: theme.borderRadius20,
-    height: 64,
-    justifyContent: 'center',
-    marginBottom: theme.space4,
-    width: 64,
-  },
-  emptyPanel: {
-    alignItems: 'center',
-    backgroundColor: theme.color.backgroundSecondary.dark,
-    borderColor: theme.colorBorderSecondary,
-    borderCurve: 'continuous',
-    borderRadius: theme.borderRadius12,
-    borderWidth: StyleSheet.hairlineWidth,
     gap: theme.space12,
-    marginHorizontal: theme.space16,
-    paddingHorizontal: theme.space20,
-    paddingVertical: theme.space36,
+    justifyContent: 'center',
+    minHeight: 280,
+    paddingHorizontal: 40,
+  },
+  emptySubtitle: {
+    color: Color.zinc[500],
+    lineHeight: 20,
+    textAlign: 'center',
+  },
+  emptyTitle: {
+    color: Color.zinc[400],
+    marginTop: theme.space4,
   },
   footer: {
+    color: Color.zinc[500],
     lineHeight: 18,
-    paddingHorizontal: theme.space16,
-    paddingTop: theme.space8,
+    paddingHorizontal: theme.space4,
+    paddingTop: theme.space16,
   },
   input: {
+    backgroundColor: Color.zinc[900],
+    borderColor: Color.zinc[800],
+    borderCurve: 'continuous',
+    borderRadius: theme.borderRadius12,
+    borderWidth: 1,
+    color: theme.colorWhite,
     flex: 1,
+    fontSize: 16,
+    height: 44,
+    paddingHorizontal: theme.space16,
   },
   inputSection: {
     alignItems: 'center',
-    borderBottomColor: theme.color.border.dark,
-    borderBottomWidth: StyleSheet.hairlineWidth,
     flexDirection: 'row',
     gap: theme.space8,
-    paddingHorizontal: theme.space16,
-    paddingVertical: theme.space12,
+    paddingBottom: theme.space16,
+    paddingTop: theme.space12,
   },
-  listContainer: {
+  keyboardAvoid: {
+    backgroundColor: theme.color.background.dark,
     flex: 1,
   },
   listContent: {
     paddingBottom: theme.space24,
+    paddingHorizontal: theme.space16,
   },
-  removeButton: {
-    flexShrink: 0,
-    padding: 4,
+  listContentEmpty: {
+    flexGrow: 1,
   },
   row: {
     alignItems: 'center',
-    borderBottomColor: theme.colorBorderSecondary,
+    borderBottomColor: Color.zinc[800],
     borderBottomWidth: StyleSheet.hairlineWidth,
     flexDirection: 'row',
     gap: theme.space12,
-    marginHorizontal: theme.space16,
-    minHeight: 56,
-    paddingVertical: theme.space12,
-  },
-  rowFirst: {
-    borderTopLeftRadius: theme.borderRadius12,
-    borderTopRightRadius: theme.borderRadius12,
-  },
-  rowLast: {
-    borderBottomLeftRadius: theme.borderRadius12,
-    borderBottomRightRadius: theme.borderRadius12,
-    borderBottomWidth: 0,
-  },
-  sectionCount: {
-    paddingHorizontal: theme.space16,
-  },
-  sectionHeader: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    paddingBottom: theme.space8,
-  },
-  sectionHeaderEmpty: {
-    paddingBottom: theme.space8,
-  },
-  sectionTitle: {
-    color: theme.colorGreyAlpha,
-    letterSpacing: 0.5,
-    paddingHorizontal: theme.space16,
-    textTransform: 'uppercase',
+    paddingHorizontal: theme.space4,
+    paddingVertical: 14,
   },
   termText: {
-    color: theme.color.text.dark,
+    color: theme.colorWhite,
     flex: 1,
+    fontSize: 15,
+    lineHeight: 20,
     minWidth: 0,
   },
 });

--- a/src/screens/Preferences/BlockedTermsScreen.tsx
+++ b/src/screens/Preferences/BlockedTermsScreen.tsx
@@ -1,0 +1,333 @@
+import { FlashList } from '@app/components/FlashList/FlashList';
+import { Text } from '@app/components/ui/Text/Text';
+import { Input } from '@app/components/ui/Input/Input';
+import { useScrollToTop } from '@app/hooks/useScrollToTop';
+import {
+  usePreference,
+  useUpdatePreferences,
+} from '@app/store/preferenceStore';
+import { theme } from '@app/styles/themes';
+import { SymbolView } from 'expo-symbols';
+import { useCallback, useRef, useState } from 'react';
+import {
+  Alert,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { FlashListRef, ListRenderItem } from '@app/components/FlashList/FlashList';
+
+function SectionHeader({ count }: { count?: number }) {
+  return (
+    <View style={styles.sectionHeader}>
+      <Text type='xxs' weight='semibold' style={styles.sectionTitle}>
+        Blocked Terms
+      </Text>
+      {typeof count === 'number' ? (
+        <Text type='xxs' color='gray.textLow' style={styles.sectionCount}>
+          {count}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+function TermRow({
+  term,
+  index,
+  count,
+  onRemove,
+}: {
+  term: string;
+  index: number;
+  count: number;
+  onRemove: (term: string) => void;
+}) {
+  const handleRemove = useCallback(() => {
+    Alert.alert(
+      'Remove blocked term',
+      `Remove "${term}" from your blocked terms?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Remove',
+          style: 'destructive',
+          onPress: () => onRemove(term),
+        },
+      ],
+    );
+  }, [term, onRemove]);
+
+  return (
+    <View
+      style={[
+        styles.row,
+        index === 0 && styles.rowFirst,
+        index === count - 1 && styles.rowLast,
+      ]}
+    >
+      <Text type='md' style={styles.termText} numberOfLines={1}>
+        {term}
+      </Text>
+      <TouchableOpacity
+        onPress={handleRemove}
+        style={styles.removeButton}
+        hitSlop={8}
+        activeOpacity={0.7}
+      >
+        <SymbolView
+          name='minus.circle.fill'
+          size={22}
+          tintColor={theme.colorRed}
+        />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+function EmptyState() {
+  return (
+    <ScrollView
+      contentContainerStyle={styles.emptyContent}
+      contentInsetAdjustmentBehavior='automatic'
+    >
+      <View style={styles.sectionHeaderEmpty}>
+        <Text type='xxs' weight='semibold' style={styles.sectionTitle}>
+          Blocked Terms
+        </Text>
+      </View>
+      <View style={styles.emptyPanel}>
+        <View style={styles.emptyIcon}>
+          <SymbolView
+            name='text.badge.xmark'
+            size={28}
+            tintColor={theme.colorGreyHoverAlpha}
+          />
+        </View>
+        <Text type='lg' weight='bold' align='center'>
+          No blocked terms
+        </Text>
+        <Text
+          type='xs'
+          color='gray.textLow'
+          align='center'
+          style={styles.emptyDescription}
+        >
+          Messages containing a blocked term will be hidden from chat.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+export function BlockedTermsScreen() {
+  const insets = useSafeAreaInsets();
+  const blockedTerms = usePreference('blockedTerms');
+  const updatePreferences = useUpdatePreferences();
+  const [inputValue, setInputValue] = useState('');
+  const listRef = useRef<FlashListRef<string>>(null);
+
+  useScrollToTop(listRef);
+
+  const handleAdd = useCallback(() => {
+    const normalised = inputValue.trim().toLowerCase();
+    if (!normalised) return;
+    if (blockedTerms.includes(normalised)) {
+      setInputValue('');
+      return;
+    }
+    updatePreferences({ blockedTerms: [...blockedTerms, normalised] });
+    setInputValue('');
+  }, [inputValue, blockedTerms, updatePreferences]);
+
+  const handleRemove = useCallback(
+    (term: string) => {
+      updatePreferences({
+        blockedTerms: blockedTerms.filter(t => t !== term),
+      });
+    },
+    [blockedTerms, updatePreferences],
+  );
+
+  const renderItem: ListRenderItem<string> = useCallback(
+    ({ item, index }) => (
+      <TermRow
+        term={item}
+        index={index}
+        count={blockedTerms.length}
+        onRemove={handleRemove}
+      />
+    ),
+    [blockedTerms.length, handleRemove],
+  );
+
+  return (
+    <View style={[styles.container, { paddingBottom: insets.bottom }]}>
+      <View style={styles.inputSection}>
+        <Input
+          autoCapitalize='none'
+          autoCorrect={false}
+          placeholder='Add a term to block…'
+          value={inputValue}
+          onChangeText={setInputValue}
+          onSubmitEditing={handleAdd}
+          returnKeyType='done'
+          style={styles.input}
+        />
+        <TouchableOpacity
+          onPress={handleAdd}
+          style={[
+            styles.addButton,
+            !inputValue.trim() && styles.addButtonDisabled,
+          ]}
+          disabled={!inputValue.trim()}
+          activeOpacity={0.75}
+        >
+          <SymbolView name='plus' size={16} tintColor='#fff' />
+        </TouchableOpacity>
+      </View>
+
+      {blockedTerms.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <View style={styles.listContainer}>
+          <FlashList
+            ref={listRef}
+            data={blockedTerms}
+            renderItem={renderItem}
+            keyExtractor={item => item}
+            estimatedItemSize={56}
+            contentInsetAdjustmentBehavior='automatic'
+            contentContainerStyle={styles.listContent}
+            ListHeaderComponent={<SectionHeader count={blockedTerms.length} />}
+            ListFooterComponent={
+              <Text type='xxs' color='gray.textLow' style={styles.footer}>
+                Messages containing these terms will be hidden from chat.
+              </Text>
+            }
+          />
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  addButton: {
+    alignItems: 'center',
+    backgroundColor: theme.colorPrimary,
+    borderCurve: 'continuous',
+    borderRadius: 10,
+    height: 42,
+    justifyContent: 'center',
+    width: 42,
+  },
+  addButtonDisabled: {
+    opacity: 0.4,
+  },
+  container: {
+    backgroundColor: theme.color.background.dark,
+    flex: 1,
+  },
+  emptyContent: {
+    flexGrow: 1,
+    paddingBottom: theme.space24,
+  },
+  emptyDescription: {
+    lineHeight: 20,
+    maxWidth: 280,
+  },
+  emptyIcon: {
+    alignItems: 'center',
+    backgroundColor: theme.color.backgroundSecondary.dark,
+    borderCurve: 'continuous',
+    borderRadius: theme.borderRadius20,
+    height: 64,
+    justifyContent: 'center',
+    marginBottom: theme.space4,
+    width: 64,
+  },
+  emptyPanel: {
+    alignItems: 'center',
+    backgroundColor: theme.color.backgroundSecondary.dark,
+    borderColor: theme.colorBorderSecondary,
+    borderCurve: 'continuous',
+    borderRadius: theme.borderRadius12,
+    borderWidth: StyleSheet.hairlineWidth,
+    gap: theme.space12,
+    marginHorizontal: theme.space16,
+    paddingHorizontal: theme.space20,
+    paddingVertical: theme.space36,
+  },
+  footer: {
+    lineHeight: 18,
+    paddingHorizontal: theme.space16,
+    paddingTop: theme.space8,
+  },
+  input: {
+    flex: 1,
+  },
+  inputSection: {
+    alignItems: 'center',
+    borderBottomColor: theme.color.border.dark,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: theme.space8,
+    paddingHorizontal: theme.space16,
+    paddingVertical: theme.space12,
+  },
+  listContainer: {
+    flex: 1,
+  },
+  listContent: {
+    paddingBottom: theme.space24,
+  },
+  removeButton: {
+    flexShrink: 0,
+    padding: 4,
+  },
+  row: {
+    alignItems: 'center',
+    borderBottomColor: theme.colorBorderSecondary,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: theme.space12,
+    marginHorizontal: theme.space16,
+    minHeight: 56,
+    paddingVertical: theme.space12,
+  },
+  rowFirst: {
+    borderTopLeftRadius: theme.borderRadius12,
+    borderTopRightRadius: theme.borderRadius12,
+  },
+  rowLast: {
+    borderBottomLeftRadius: theme.borderRadius12,
+    borderBottomRightRadius: theme.borderRadius12,
+    borderBottomWidth: 0,
+  },
+  sectionCount: {
+    paddingHorizontal: theme.space16,
+  },
+  sectionHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingBottom: theme.space8,
+  },
+  sectionHeaderEmpty: {
+    paddingBottom: theme.space8,
+  },
+  sectionTitle: {
+    color: theme.colorGreyAlpha,
+    letterSpacing: 0.5,
+    paddingHorizontal: theme.space16,
+    textTransform: 'uppercase',
+  },
+  termText: {
+    color: theme.color.text.dark,
+    flex: 1,
+    minWidth: 0,
+  },
+});

--- a/src/screens/Preferences/__tests__/ChatPreferenceScreen.test.tsx
+++ b/src/screens/Preferences/__tests__/ChatPreferenceScreen.test.tsx
@@ -30,6 +30,7 @@ const mockPreferences: Preferences = {
   show7tvBadges: true,
   showFFzBadges: true,
   showBttvBadges: true,
+  blockedTerms: [],
 };
 
 jest.mock('@app/store/preferenceStore', () => ({

--- a/src/screens/SettingsScreen/SettingsIndexScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsIndexScreen.tsx
@@ -45,6 +45,11 @@ export function SettingsIndexScreen() {
               onPress={() => router.push('/tabs/settings/chat-preferences')}
             />
             <Button
+              label='Blocked Terms'
+              systemImage='text.badge.xmark'
+              onPress={() => router.push('/tabs/settings/blocked-terms')}
+            />
+            <Button
               label='Cache'
               systemImage='externaldrive'
               onPress={() => router.push('/tabs/settings/cache')}
@@ -138,6 +143,12 @@ export function SettingsIndexScreen() {
               color: theme.colorPlum,
             }}
             onPress={() => router.push('/tabs/settings/chat-preferences')}
+          />
+          <SettingsLinkRow
+            title='Blocked Terms'
+            subtitle='Hide chat messages containing specific words or phrases'
+            icon={{ icon: 'text.badge.xmark', color: theme.colorRed }}
+            onPress={() => router.push('/tabs/settings/blocked-terms')}
           />
           <SettingsLinkRow
             title='Cache'

--- a/src/store/__tests__/preferenceStore.test.tsx
+++ b/src/store/__tests__/preferenceStore.test.tsx
@@ -28,6 +28,7 @@ const basePreferences = {
   show7tvBadges: true,
   showFFzBadges: true,
   showBttvBadges: true,
+  blockedTerms: [] as string[],
 } as const;
 
 describe('usePreferences', () => {

--- a/src/store/preferenceStore.ts
+++ b/src/store/preferenceStore.ts
@@ -34,6 +34,7 @@ export interface Preferences {
   show7tvBadges: boolean;
   showFFzBadges: boolean;
   showBttvBadges: boolean;
+  blockedTerms: string[];
 }
 
 const initialPreferences: Preferences = {
@@ -62,6 +63,7 @@ const initialPreferences: Preferences = {
   show7tvBadges: true,
   showFFzBadges: true,
   showBttvBadges: true,
+  blockedTerms: [],
 };
 
 ensureObservablePersistenceConfig();

--- a/src/store/preferences/__tests__/preferenceStore.test.tsx
+++ b/src/store/preferences/__tests__/preferenceStore.test.tsx
@@ -29,6 +29,7 @@ const basePreferences = {
   show7tvBadges: true,
   showFFzBadges: true,
   showBttvBadges: true,
+  blockedTerms: [] as string[],
 } as const;
 
 describe('usePreferences', () => {


### PR DESCRIPTION
Resolves #326

Adds a persistent blocked terms list that hides chat messages containing those words or phrases.

### Changes
- blockedTerms: string[] added to Preferences (MMKV-persisted)
- useChat merges blockedTerms with transient hiddenPhrases so they apply across every channel
- BlockedTermsScreen: input to add terms, list with remove buttons, empty state
- Route /tabs/settings/blocked-terms registered
- Nav entry added under Stream Experience