### PR TITLE
feat(app): improve chat settings ui

### DIFF
--- a/src/screens/Preferences/ChatPreferenceNativeForm.tsx
+++ b/src/screens/Preferences/ChatPreferenceNativeForm.tsx
@@ -1,0 +1,346 @@
+import { usePreferences } from '@app/store/preferenceStore';
+import { theme } from '@app/styles/themes';
+import {
+  EMOJI_STYLE_OPTIONS,
+  getEmojiEmotes,
+} from '@app/utils/emoji/emojiEmotes';
+import {
+  Button,
+  Form,
+  Host,
+  Picker,
+  RNHostView,
+  Section,
+  Text as NativeText,
+  Toggle,
+} from '@expo/ui/swift-ui';
+import { tag } from '@expo/ui/swift-ui/modifiers';
+import { router } from 'expo-router';
+import { useMemo, type ReactElement } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { ChatPreferencePreview } from './ChatPreferencesPreview';
+import {
+  DensityPreview,
+  EmojiStylePreview,
+  PreviewLabel,
+  ProviderPreviewItem,
+} from './ChatPreferencePreviewWidgets';
+import {
+  DELETED_STYLE_OPTIONS,
+  DENSITY_OPTIONS,
+  EMOJI_PREVIEW_SHORTCODES,
+  FONT_SCALE_OPTIONS,
+  SCROLLBACK_OPTIONS,
+  TIMESTAMP_FORMAT_OPTIONS,
+  type PreviewProvider,
+} from './chatPreferenceTypes';
+
+function hostPreview(node: ReactElement, padded = true) {
+  return (
+    <RNHostView matchContents>
+      {padded ? <View style={styles.previewRow}>{node}</View> : node}
+    </RNHostView>
+  );
+}
+
+export function ChatPreferenceNativeForm() {
+  const { t } = useTranslation('preferences');
+  const preferences = usePreferences();
+  const { update } = preferences;
+
+  const emojiPreviewEmotes = useMemo(() => {
+    const emotes = getEmojiEmotes(preferences.emojiStyle);
+    const preview = EMOJI_PREVIEW_SHORTCODES.flatMap(shortcode => {
+      const emote = emotes.find(item => item.name === shortcode);
+      return emote ? [emote] : [];
+    });
+    return preview.length > 0 ? preview : emotes.slice(0, 3);
+  }, [preferences.emojiStyle]);
+
+  const contextPreview = {
+    chatTimestamps: preferences.chatTimestamps,
+    highlightOwnMentions: preferences.highlightOwnMentions,
+    showInlineReplyContext: preferences.showInlineReplyContext,
+    showUnreadJumpPill: preferences.showUnreadJumpPill,
+  };
+
+  const providerSections = [
+    {
+      title: '7TV',
+      provider: '7tv' as PreviewProvider,
+      emotes: preferences.show7TvEmotes,
+      badges: preferences.show7tvBadges,
+      onEmotes: (value: boolean) => update({ show7TvEmotes: value }),
+      onBadges: (value: boolean) => update({ show7tvBadges: value }),
+    },
+    {
+      title: 'BTTV',
+      provider: 'bttv' as PreviewProvider,
+      emotes: preferences.showBttvEmotes,
+      badges: preferences.showBttvBadges,
+      onEmotes: (value: boolean) => update({ showBttvEmotes: value }),
+      onBadges: (value: boolean) => update({ showBttvBadges: value }),
+    },
+    {
+      title: 'FFZ',
+      provider: 'ffz' as PreviewProvider,
+      emotes: preferences.showFFzEmotes,
+      badges: preferences.showFFzBadges,
+      onEmotes: (value: boolean) => update({ showFFzEmotes: value }),
+      onBadges: (value: boolean) => update({ showFFzBadges: value }),
+    },
+    {
+      title: 'Twitch',
+      provider: 'twitch' as PreviewProvider,
+      emotes: preferences.showTwitchEmotes,
+      badges: preferences.showTwitchBadges,
+      onEmotes: (value: boolean) => update({ showTwitchEmotes: value }),
+      onBadges: (value: boolean) => update({ showTwitchBadges: value }),
+    },
+  ];
+
+  return (
+    <Host style={styles.host}>
+      <Form>
+        <Section title={t('layout')}>
+          <Picker
+            label={t('messageDensity')}
+            systemImage='list.bullet'
+            selection={preferences.chatDensity}
+            onSelectionChange={value => update({ chatDensity: value })}
+          >
+            {DENSITY_OPTIONS.map(option => (
+              <NativeText key={option.value} modifiers={[tag(option.value)]}>
+                {t(option.labelKey)}
+              </NativeText>
+            ))}
+          </Picker>
+          {hostPreview(<DensityPreview density={preferences.chatDensity} />)}
+          <Picker
+            label={t('fontSize')}
+            systemImage='textformat.size'
+            selection={preferences.chatFontScale}
+            onSelectionChange={value => update({ chatFontScale: value })}
+          >
+            {FONT_SCALE_OPTIONS.map(option => (
+              <NativeText key={option.value} modifiers={[tag(option.value)]}>
+                {t(option.labelKey)}
+              </NativeText>
+            ))}
+          </Picker>
+          {hostPreview(
+            <ChatPreferencePreview
+              variant='fontScale'
+              value={preferences.chatFontScale}
+            />,
+          )}
+          <Toggle
+            label={t('alternatingRows')}
+            systemImage='line.3.horizontal'
+            isOn={preferences.showAlternatingChatRows}
+            onIsOnChange={value => update({ showAlternatingChatRows: value })}
+          />
+          {hostPreview(
+            <ChatPreferencePreview
+              variant='alternatingRows'
+              value={preferences.showAlternatingChatRows}
+            />,
+          )}
+        </Section>
+
+        <Section title={t('emojiStyle')}>
+          <Picker
+            label={t('emojiSet')}
+            systemImage='face.smiling'
+            selection={preferences.emojiStyle}
+            onSelectionChange={value => update({ emojiStyle: value })}
+          >
+            {EMOJI_STYLE_OPTIONS.map(option => (
+              <NativeText key={option.value} modifiers={[tag(option.value)]}>
+                {option.label}
+              </NativeText>
+            ))}
+          </Picker>
+          {hostPreview(<EmojiStylePreview emotes={emojiPreviewEmotes} />)}
+        </Section>
+
+        <Section title={t('context')}>
+          <Toggle
+            label={t('historicalRecentMessages')}
+            systemImage='clock.arrow.circlepath'
+            isOn={preferences.showRecentMessages !== false}
+            onIsOnChange={value => update({ showRecentMessages: value })}
+          />
+          <Toggle
+            label={t('showTimestamps')}
+            systemImage='clock'
+            isOn={preferences.chatTimestamps}
+            onIsOnChange={value => update({ chatTimestamps: value })}
+          />
+          <Toggle
+            label={t('highlightOwnMentions')}
+            systemImage='at'
+            isOn={preferences.highlightOwnMentions}
+            onIsOnChange={value => update({ highlightOwnMentions: value })}
+          />
+          <Toggle
+            label={t('inlineReplyContext')}
+            systemImage='arrowshape.turn.up.left'
+            isOn={preferences.showInlineReplyContext}
+            onIsOnChange={value => update({ showInlineReplyContext: value })}
+          />
+          <Toggle
+            label={t('showJumpPill')}
+            systemImage='arrow.down.circle'
+            isOn={preferences.showUnreadJumpPill}
+            onIsOnChange={value => update({ showUnreadJumpPill: value })}
+          />
+          <Picker
+            label={t('timestampFormat')}
+            systemImage='clock.badge'
+            selection={preferences.chatTimestampFormat}
+            onSelectionChange={value => update({ chatTimestampFormat: value })}
+          >
+            {TIMESTAMP_FORMAT_OPTIONS.map(option => (
+              <NativeText key={option.value} modifiers={[tag(option.value)]}>
+                {t(option.labelKey)}
+              </NativeText>
+            ))}
+          </Picker>
+          {hostPreview(
+            <View>
+              <PreviewLabel />
+              <View style={styles.previewSpacer}>
+                <ChatPreferencePreview
+                  variant='context'
+                  value={contextPreview}
+                />
+              </View>
+            </View>,
+          )}
+        </Section>
+
+        <Section
+          title={t('highlights')}
+          footer={<NativeText>{t('highlightsFooter')}</NativeText>}
+        >
+          <Button
+            label={t('highlightedPhrases')}
+            systemImage='highlighter'
+            onPress={() => router.push('/tabs/settings/chat-highlights')}
+          />
+          <Toggle
+            label={t('mentionFeedback')}
+            systemImage='hand.tap'
+            isOn={preferences.chatMentionHaptics !== false}
+            onIsOnChange={value => update({ chatMentionHaptics: value })}
+          />
+        </Section>
+
+        <Section title={t('moderation')}>
+          <Picker
+            label={t('deletedMessages')}
+            systemImage='trash.slash'
+            selection={preferences.deletedMessageStyle}
+            onSelectionChange={value => update({ deletedMessageStyle: value })}
+          >
+            {DELETED_STYLE_OPTIONS.map(option => (
+              <NativeText key={option.value} modifiers={[tag(option.value)]}>
+                {t(option.labelKey)}
+              </NativeText>
+            ))}
+          </Picker>
+          <Toggle
+            label={t('keepHistoryOnClear')}
+            systemImage='clock.arrow.circlepath'
+            isOn={preferences.ignoreClearChat === true}
+            onIsOnChange={value => update({ ignoreClearChat: value })}
+          />
+        </Section>
+
+        <Section
+          title={t('performance')}
+          footer={<NativeText>{t('performanceFooter')}</NativeText>}
+        >
+          <Picker
+            label={t('scrollback')}
+            systemImage='text.line.last.and.arrowtriangle.forward'
+            selection={preferences.chatScrollback}
+            onSelectionChange={value => update({ chatScrollback: value })}
+          >
+            {SCROLLBACK_OPTIONS.map(option => (
+              <NativeText key={option.value} modifiers={[tag(option.value)]}>
+                {option.label}
+              </NativeText>
+            ))}
+          </Picker>
+        </Section>
+
+        {providerSections.map(section => (
+          <Section key={section.title} title={section.title}>
+            <Toggle
+              label={t('emotes')}
+              systemImage='face.smiling'
+              isOn={section.emotes}
+              onIsOnChange={section.onEmotes}
+            />
+            {hostPreview(
+              <ProviderPreviewItem
+                enabled={section.emotes}
+                provider={section.provider}
+                variant='emotes'
+              />,
+              false,
+            )}
+            <Toggle
+              label={t('badges')}
+              systemImage='rosette'
+              isOn={section.badges}
+              onIsOnChange={section.onBadges}
+            />
+            {hostPreview(
+              <ProviderPreviewItem
+                enabled={section.badges}
+                provider={section.provider}
+                variant='badges'
+              />,
+              false,
+            )}
+          </Section>
+        ))}
+
+        <Section
+          title={t('media')}
+          footer={<NativeText>{t('mediaFooter')}</NativeText>}
+        >
+          <Toggle
+            label={t('disableEmoteAnimations')}
+            systemImage='slash.circle'
+            isOn={preferences.disableEmoteAnimations}
+            onIsOnChange={value => update({ disableEmoteAnimations: value })}
+          />
+          {hostPreview(
+            <ChatPreferencePreview
+              variant='emoteAnimations'
+              value={preferences.disableEmoteAnimations}
+            />,
+          )}
+        </Section>
+      </Form>
+    </Host>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+  },
+  previewRow: {
+    paddingHorizontal: theme.space16,
+    paddingVertical: theme.space8,
+  },
+  previewSpacer: {
+    marginTop: theme.space8,
+  },
+});

--- a/src/screens/Preferences/ChatPreferenceScreen.tsx
+++ b/src/screens/Preferences/ChatPreferenceScreen.tsx
@@ -1,11 +1,20 @@
 import { useScrollToTop } from '@app/hooks/useScrollToTop';
 import { theme } from '@app/styles/themes';
-import { ScrollView, StyleSheet } from 'react-native';
+import { Platform, ScrollView, StyleSheet } from 'react-native';
 import { useRef } from 'react';
 import { ChatPreferenceDefaultContent } from './ChatPreferenceDefaultContent';
+import { ChatPreferenceNativeForm } from './ChatPreferenceNativeForm';
 import { useChatPreferenceScreenState } from './useChatPreferenceScreenState';
 
 export function ChatPreferenceScreen() {
+  if (Platform.OS === 'ios') {
+    return <ChatPreferenceNativeForm />;
+  }
+
+  return <ChatPreferenceScrollContent />;
+}
+
+export function ChatPreferenceScrollContent() {
   const state = useChatPreferenceScreenState();
   const scrollRef = useRef<ScrollView>(null);
 

--- a/src/screens/Preferences/__tests__/ChatPreferenceScreen.test.tsx
+++ b/src/screens/Preferences/__tests__/ChatPreferenceScreen.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/react-native';
 
 import type { Preferences } from '@app/store/preferenceStore';
-import { ChatPreferenceScreen } from '../ChatPreferenceScreen';
+import { ChatPreferenceScrollContent } from '../ChatPreferenceScreen';
 
 const mockUpdate = jest.fn();
 const mockPreferences: Preferences = {
@@ -118,7 +118,9 @@ describe('ChatPreferenceScreen', () => {
   });
 
   test('updates the context preview immediately when toggling a setting', () => {
-    const { getByLabelText, getByTestId } = render(<ChatPreferenceScreen />);
+    const { getByLabelText, getByTestId } = render(
+      <ChatPreferenceScrollContent />,
+    );
 
     expect(
       getByTestId('chat-preference-preview-context').props.children,
@@ -133,7 +135,9 @@ describe('ChatPreferenceScreen', () => {
   });
 
   test('updates alternating rows immediately when toggled', () => {
-    const { getByLabelText, getByTestId } = render(<ChatPreferenceScreen />);
+    const { getByLabelText, getByTestId } = render(
+      <ChatPreferenceScrollContent />,
+    );
 
     expect(
       getByTestId('chat-preference-preview-alternatingRows').props.children,
@@ -148,7 +152,9 @@ describe('ChatPreferenceScreen', () => {
   });
 
   test('updates provider previews immediately when toggling provider media', () => {
-    const { getAllByLabelText, getByTestId } = render(<ChatPreferenceScreen />);
+    const { getAllByLabelText, getByTestId } = render(
+      <ChatPreferenceScrollContent />,
+    );
 
     expect(
       getByTestId('chat-preference-preview-7tv-providerEmotes').props.children,
@@ -163,7 +169,9 @@ describe('ChatPreferenceScreen', () => {
   });
 
   test('updates the emote animation preview immediately when toggling media', () => {
-    const { getByLabelText, getByTestId } = render(<ChatPreferenceScreen />);
+    const { getByLabelText, getByTestId } = render(
+      <ChatPreferenceScrollContent />,
+    );
 
     expect(
       getByTestId('chat-preference-preview-emoteAnimations').props.children,


### PR DESCRIPTION
This PR:
* revamps the chat settings screen by replacing JS components with @expo/ui. Where necessary we use `RNHostView` to render JS ui within the swift components (for setting previews) 