### PR TITLE
fix(infrastructure): per env changelogs

### DIFF
--- a/.github/actions/update-changelog/action.yml
+++ b/.github/actions/update-changelog/action.yml
@@ -25,23 +25,13 @@ runs:
         INPUTS_GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         git pull --rebase
-        # Variant tags for the same version often point at the same commits as
-        # this release. Ignore them so git-cliff applies --tag instead of
-        # reusing the existing tag's name (WARN: There is already a tag ...).
-        VERSION="${INPUTS_TAG%-internal}"
-        VERSION="${VERSION%-testflight}"
-        VERSION="${VERSION%-preview}"
-        ESCAPED_VERSION="$(printf '%s' "$VERSION" | sed 's/[.]/\\./g')"
-        case "$INPUTS_TAG" in
-          "$VERSION") IGNORE_TAGS="^${ESCAPED_VERSION}-(internal|testflight|preview)$" ;;
-          "${VERSION}-internal") IGNORE_TAGS="^${ESCAPED_VERSION}-(testflight|preview)$" ;;
-          "${VERSION}-testflight") IGNORE_TAGS="^${ESCAPED_VERSION}-(internal|preview)$" ;;
-          *) IGNORE_TAGS="^${ESCAPED_VERSION}-(internal|testflight)$" ;;
-        esac
+        # Keep all variant tags so the changelog retains per-environment sections.
+        IGNORE_TAGS=""
 
         ~/.cargo/bin/git-cliff --config cliff.toml --tag "$INPUTS_TAG" --ignore-tags "$IGNORE_TAGS" -o CHANGELOG.md
 
         bunx prettier --write CHANGELOG.md
+        bunx tsx scripts/workflows/changelog-headings-cli.ts CHANGELOG.md
 
         if git diff --quiet CHANGELOG.md 2>/dev/null; then
           echo "CHANGELOG.md has not changed"

--- a/scripts/release-github.sh
+++ b/scripts/release-github.sh
@@ -163,7 +163,8 @@ if [ "$no_push" = "false" ]; then
   }
 fi
 
-"$git_cliff_bin" --config cliff.toml --tag "$tag" --ignore-tags "$ignore_tags" -o CHANGELOG.md
+"$git_cliff_bin" --config cliff.toml --tag "$tag" --ignore-tags "" -o CHANGELOG.md
+bunx tsx scripts/workflows/changelog-headings-cli.ts CHANGELOG.md
 
 bunx prettier --write CHANGELOG.md
 

--- a/scripts/workflows/changelog-headings-cli.ts
+++ b/scripts/workflows/changelog-headings-cli.ts
@@ -1,0 +1,26 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+import { applyEnvironmentLabelsToChangelogHeadings } from './changelog-headings';
+
+export function normalizeChangelogFile(changelogPath: string): string {
+  const source = readFileSync(changelogPath, 'utf8');
+  const normalized = applyEnvironmentLabelsToChangelogHeadings(source);
+
+  writeFileSync(changelogPath, normalized, 'utf8');
+
+  return normalized;
+}
+
+function main(): void {
+  const changelogPath = process.argv[2];
+  if (changelogPath == null || changelogPath === '') {
+    console.error('Expected a path to CHANGELOG.md');
+    process.exit(1);
+  }
+
+  normalizeChangelogFile(changelogPath);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/workflows/changelog-headings.ts
+++ b/scripts/workflows/changelog-headings.ts
@@ -1,0 +1,25 @@
+const HEADING_REGEXP =
+  /^##\s+v?(\d+\.\d+\.\d+)(?:-(internal|testflight|preview))?\s*$/gm;
+
+function changelogVariantLabel(suffix: string | undefined): string {
+  switch (suffix) {
+    case 'internal':
+      return 'Internal';
+    case 'testflight':
+      return 'TestFlight';
+    case 'preview':
+      return 'Preview';
+    default:
+      return 'Production';
+  }
+}
+
+export function applyEnvironmentLabelsToChangelogHeadings(
+  content: string,
+): string {
+  return content.replace(
+    HEADING_REGEXP,
+    (_match, version: string, suffix: string | undefined) =>
+      `## ${version} (${changelogVariantLabel(suffix)})`,
+  );
+}

--- a/test/workflows.test.ts
+++ b/test/workflows.test.ts
@@ -8,6 +8,8 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { applyEnvironmentLabelsToChangelogHeadings } from '../scripts/workflows/changelog-headings';
+import { normalizeChangelogFile } from '../scripts/workflows/changelog-headings-cli';
 import {
   buildChatPerformanceComment,
   buildCurrentTable,
@@ -277,6 +279,179 @@ Rollout Percentage  25%
         'target_percentage must be an integer between 1 and 100.',
       );
     });
+  });
+});
+
+describe('changelog headings', () => {
+  test('adds environment labels for generated release headings', () => {
+    const source = [
+      '# Changelog',
+      '',
+      '## 1.2.3',
+      '### Changes',
+      '- changelog item',
+      '## 1.2.3-internal',
+      '### Changes',
+      '- internal changelog item',
+      '## 1.2.3-testflight',
+      '### Changes',
+      '- testflight changelog item',
+      '## 1.2.3-preview',
+      '### Changes',
+      '- preview changelog item',
+      '',
+      '## 1.2.2',
+      '- old changelog item',
+    ].join('\n');
+
+    expect(applyEnvironmentLabelsToChangelogHeadings(source)).toEqual(
+      [
+        '# Changelog',
+        '',
+        '## 1.2.3 (Production)',
+        '### Changes',
+        '- changelog item',
+        '## 1.2.3 (Internal)',
+        '### Changes',
+        '- internal changelog item',
+        '## 1.2.3 (TestFlight)',
+        '### Changes',
+        '- testflight changelog item',
+        '## 1.2.3 (Preview)',
+        '### Changes',
+        '- preview changelog item',
+        '',
+        '## 1.2.2 (Production)',
+        '- old changelog item',
+      ].join('\n'),
+    );
+  });
+
+  test('leaves non-version headings untouched', () => {
+    const source = [
+      '# Changelog',
+      '',
+      '## [unreleased]',
+      '### Changes',
+      '- local item',
+      '### Notes',
+      '- details',
+    ].join('\n');
+
+    expect(applyEnvironmentLabelsToChangelogHeadings(source)).toEqual(source);
+  });
+
+  test('normalizes version headings that include a leading v', () => {
+    expect(applyEnvironmentLabelsToChangelogHeadings('## v1.2.3\n')).toEqual(
+      '## 1.2.3 (Production)',
+    );
+  });
+
+  test('preserves already labeled environment headings', () => {
+    expect(
+      applyEnvironmentLabelsToChangelogHeadings(
+        [
+          '# Changelog',
+          '## 1.2.3 (Internal)',
+          '## 1.2.3-testflight',
+          '## 1.2.2 (Production)',
+          '## 1.2.2',
+        ].join('\n'),
+      ),
+    ).toEqual(
+      [
+        '# Changelog',
+        '## 1.2.3 (Internal)',
+        '## 1.2.3 (TestFlight)',
+        '## 1.2.2 (Production)',
+        '## 1.2.2 (Production)',
+      ].join('\n'),
+    );
+  });
+
+  test('is idempotent on already normalized content', () => {
+    const source = ['## 1.2.3 (Internal)', '## 1.2.2-testflight'].join('\n');
+
+    const normalized = applyEnvironmentLabelsToChangelogHeadings(source);
+
+    expect(applyEnvironmentLabelsToChangelogHeadings(normalized)).toEqual(
+      normalized,
+    );
+  });
+});
+
+describe('changelog generation', () => {
+  test('normalizes generated changelog markdown written to a file', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'foam-changelog-generation-'));
+    const changelogPath = join(tempDir, 'CHANGELOG.md');
+    const generatedChangelog = [
+      '# Changelog',
+      '',
+      '## 1.0.0-internal',
+      '### Added',
+      '- internal-only item',
+      '## 1.0.0-testflight',
+      '### Fixed',
+      '- testflight item',
+      '## 1.0.0',
+      '### Changed',
+      '- production item',
+      '## 1.0.0-preview',
+      '### Fixed',
+      '- preview item',
+      '## [Unreleased]',
+      '- future change',
+    ].join('\n');
+    const expectedChangelog = [
+      '# Changelog',
+      '',
+      '## 1.0.0 (Internal)',
+      '### Added',
+      '- internal-only item',
+      '## 1.0.0 (TestFlight)',
+      '### Fixed',
+      '- testflight item',
+      '## 1.0.0 (Production)',
+      '### Changed',
+      '- production item',
+      '## 1.0.0 (Preview)',
+      '### Fixed',
+      '- preview item',
+      '## [Unreleased]',
+      '- future change',
+    ].join('\n');
+
+    try {
+      writeFileSync(changelogPath, generatedChangelog, 'utf8');
+      const normalized = normalizeChangelogFile(changelogPath);
+
+      expect(normalized).toEqual(expectedChangelog);
+      expect(readFileSync(changelogPath, 'utf8')).toEqual(expectedChangelog);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('is stable when run over an already generated changelog file', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'foam-changelog-generation-'));
+    const changelogPath = join(tempDir, 'CHANGELOG.md');
+    const generatedChangelog = [
+      '# Changelog',
+      '',
+      '## 1.0.0 (Internal)',
+      '### Added',
+      '- already normalized',
+    ].join('\n');
+
+    try {
+      writeFileSync(changelogPath, generatedChangelog, 'utf8');
+      const normalized = normalizeChangelogFile(changelogPath);
+
+      expect(normalized).toEqual(generatedChangelog);
+      expect(readFileSync(changelogPath, 'utf8')).toEqual(generatedChangelog);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
# Why

* Changelog generation for releases was intentionally ignoring variant tags, which removed visibility into per-environment sections (production/internal/testflight/preview) in generated changelog output.
* The release flow now needs explicit environment labels so reviewers can see exactly which notes belong to each variant without inferring from tag suffixes.
* This change updates release tooling so changelogs preserve all variant entries while keeping headings readable in a single, clearly labeled list.

# How

* Updated `.github/actions/update-changelog/action.yml` to stop filtering variant tags before running `git-cliff` (`IGNORE_TAGS` is now left empty).
* Updated `.github/actions/update-changelog/action.yml` and `scripts/release-github.sh` to post-process `CHANGELOG.md` through:

  * `scripts/workflows/changelog-headings.ts`: `applyEnvironmentLabelsToChangelogHeadings` normalizes headings to:

    * `## x.y.z (Production)`
    * `## x.y.z (Internal)`
    * `## x.y.z (TestFlight)`
    * `## x.y.z (Preview)`
  * `scripts/workflows/changelog-headings-cli.ts`: CLI wrapper used by scripts.
* Added and extended workflow coverage in `test/workflows.test.ts`:

  * Heading transforms for generated and pre-existing variants.
  * Handling of leading `v`.
  * Idempotency.
  * File-level normalization path using temporary changelog fixtures.

# Test Plan

1. Automated

* Repro command:

  * `bun run test test/workflows.test.ts --runInBand`
* Expected result:

  * Tests under "changelog headings" and "changelog generation" pass.

2. Manual reproduction (no full test run required)

* Create a sample changelog with:

  * `## 1.2.3-internal`
  * `## 1.2.3-testflight`
  * `## 1.2.3-preview`
* Run:

  * `bunx tsx scripts/workflows/changelog-headings-cli.ts CHANGELOG.md`
* Verify headings become:

  * `## 1.2.3 (Internal)`
  * `## 1.2.3 (TestFlight)`
  * `## 1.2.3 (Preview)`

3. Release-path verification (optional but useful for reviewer confidence)

* Execute a staging `release-github` flow and verify the generated `CHANGELOG.md` retains distinct per-environment headings.
