### PR TITLE
perf(chat): index badge lookups and trim per-message hot-path work

### DIFF
--- a/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
+++ b/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
@@ -4,6 +4,7 @@ import { recentMessagesService } from '@app/services/recent-messages-service';
 import {
   addMessage,
   clearMessages,
+  getMaxChatMessages,
   moderateMessagesByLogin,
   removeMessageById,
   restoreRecentMessagesForChannel,
@@ -431,6 +432,7 @@ describe('Chat recent messages', () => {
     expect(mockedGetRecentMessages).toHaveBeenCalledWith(
       'foam',
       expect.any(AbortSignal),
+      getMaxChatMessages(),
     );
     expect(
       handleNewMessage.mock.calls.map(([message, options]) => ({

--- a/src/components/Chat/components/ChatComposer/hooks/useEmoteSuggestions.ts
+++ b/src/components/Chat/components/ChatComposer/hooks/useEmoteSuggestions.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import {
   useCurrentEmoteData,
   useEmojis,
@@ -84,6 +86,13 @@ function buildSearchableEmotes(
   return uniqueEmotes;
 }
 
+function matchesSearch(entry: SearchableEmote, lowerSearch: string): boolean {
+  return (
+    entry.lowerName.includes(lowerSearch) ||
+    (entry.lowerOriginalName?.includes(lowerSearch) ?? false)
+  );
+}
+
 export function useEmoteSuggestions({
   searchTerm,
   maxSuggestions = 50,
@@ -101,8 +110,23 @@ export function useEmoteSuggestions({
   } = useCurrentEmoteData();
   const emojis = useEmojis();
 
-  const searchableEmotes = buildSearchableEmotes(
-    {
+  const searchableEmotes = useMemo(
+    () =>
+      buildSearchableEmotes(
+        {
+          sevenTvChannelEmotes,
+          sevenTvGlobalEmotes,
+          twitchChannelEmotes,
+          twitchGlobalEmotes,
+          bttvChannelEmotes,
+          bttvGlobalEmotes,
+          ffzChannelEmotes,
+          ffzGlobalEmotes,
+          emojis,
+        },
+        prioritizeChannelEmotes,
+      ),
+    [
       sevenTvChannelEmotes,
       sevenTvGlobalEmotes,
       twitchChannelEmotes,
@@ -112,25 +136,33 @@ export function useEmoteSuggestions({
       ffzChannelEmotes,
       ffzGlobalEmotes,
       emojis,
-    },
-    prioritizeChannelEmotes,
+      prioritizeChannelEmotes,
+    ],
   );
 
-  const allEmotes = searchableEmotes.map(entry => entry.emote);
+  const allEmotes = useMemo(
+    () => searchableEmotes.map(entry => entry.emote),
+    [searchableEmotes],
+  );
 
   const trimmedSearch = searchTerm.trim();
   const lowerSearch = trimmedSearch.toLowerCase();
-  const filteredEmotes =
-    trimmedSearch.length < 1
-      ? []
-      : searchableEmotes
-          .filter(
-            entry =>
-              entry.lowerName.includes(lowerSearch) ||
-              entry.lowerOriginalName?.includes(lowerSearch),
-          )
-          .slice(0, maxSuggestions)
-          .map(entry => entry.emote);
+  const filteredEmotes = useMemo(() => {
+    if (lowerSearch.length < 1) {
+      return [];
+    }
+
+    const matches: SanitisedEmote[] = [];
+    for (const entry of searchableEmotes) {
+      if (matchesSearch(entry, lowerSearch)) {
+        matches.push(entry.emote);
+        if (matches.length >= maxSuggestions) {
+          break;
+        }
+      }
+    }
+    return matches;
+  }, [lowerSearch, maxSuggestions, searchableEmotes]);
 
   return {
     filteredEmotes,

--- a/src/components/Chat/components/MediaLinkCard.tsx
+++ b/src/components/Chat/components/MediaLinkCard.tsx
@@ -50,6 +50,9 @@ function MediaLinkCardComponent({
           return sevenTvService.getEmote(emoteId);
         },
         enabled: type === 'stvEmote',
+        // Emote and clip metadata is effectively immutable, so recycled chat
+        // rows must not refetch it on every remount past the default 30s.
+        staleTime: Infinity,
       },
       {
         queryKey: ['twitchClip', url],
@@ -60,6 +63,7 @@ function MediaLinkCardComponent({
           return twitchService.getClip(twitchClipId);
         },
         enabled: type === 'twitchClip' && Boolean(twitchClipId),
+        staleTime: Infinity,
       },
     ],
   });

--- a/src/components/Chat/components/useChatOverlays.tsx
+++ b/src/components/Chat/components/useChatOverlays.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Alert } from 'react-native';
 
 import { useObservable, useSelector } from '@legendapp/state/react';
@@ -639,8 +639,8 @@ export function useChatOverlays({
     />
   );
 
-  return {
-    openers: {
+  const openers = useMemo(
+    () => ({
       openBadge,
       openChattersSheet,
       openEmotePreview,
@@ -649,7 +649,21 @@ export function useChatOverlays({
       openSavedPhrasesSheet,
       openSettingsSheet,
       openUserActions,
-    },
+    }),
+    [
+      openBadge,
+      openChattersSheet,
+      openEmotePreview,
+      openEmoteSheet,
+      openMessageActions,
+      openSavedPhrasesSheet,
+      openSettingsSheet,
+      openUserActions,
+    ],
+  );
+
+  return {
+    openers,
     overlaysElement,
   };
 }

--- a/src/components/Chat/hooks/__tests__/useChatRowRenderer.test.tsx
+++ b/src/components/Chat/hooks/__tests__/useChatRowRenderer.test.tsx
@@ -56,6 +56,9 @@ jest.mock('@app/store/chat/observables/chatStore', () => ({
     },
     paints: { onChange: jest.fn() },
     userPaintIds: { onChange: jest.fn() },
+    sessionCaches: {
+      userPaintFlags: { peek: jest.fn(() => ({})) },
+    },
   },
 }));
 

--- a/src/components/Chat/hooks/__tests__/useChatRowRenderer.test.tsx
+++ b/src/components/Chat/hooks/__tests__/useChatRowRenderer.test.tsx
@@ -54,8 +54,8 @@ jest.mock('@app/store/chat/observables/chatStore', () => ({
     mentionLoginRevision: {
       peek: jest.fn(() => 7),
     },
-    paints: {},
-    userPaintIds: {},
+    paints: { onChange: jest.fn() },
+    userPaintIds: { onChange: jest.fn() },
   },
 }));
 

--- a/src/components/Chat/hooks/__tests__/useRecentChatMessages.test.ts
+++ b/src/components/Chat/hooks/__tests__/useRecentChatMessages.test.ts
@@ -13,6 +13,7 @@ jest.mock('@app/services/recent-messages-service', () => ({
 }));
 
 jest.mock('@app/store/chat/actions/messages', () => ({
+  getMaxChatMessages: jest.fn(() => 150),
   restoreRecentMessagesForChannel: jest.fn(),
 }));
 

--- a/src/components/Chat/hooks/useRecentChatMessages.ts
+++ b/src/components/Chat/hooks/useRecentChatMessages.ts
@@ -1,7 +1,10 @@
 import { MutableRefObject, useEffect, useRef } from 'react';
 
 import { recentMessagesService } from '@app/services/recent-messages-service';
-import { restoreRecentMessagesForChannel } from '@app/store/chat/actions/messages';
+import {
+  getMaxChatMessages,
+  restoreRecentMessagesForChannel,
+} from '@app/store/chat/actions/messages';
 import { chatStore$ } from '@app/store/chat/observables/chatStore';
 import { logger } from '@app/utils/logger';
 
@@ -56,6 +59,7 @@ export function useRecentChatMessages({
         const recentMessages = await recentMessagesService.getRecentMessages(
           channelName,
           abortController.signal,
+          getMaxChatMessages(),
         );
 
         for (const message of recentMessages) {

--- a/src/components/Chat/util/chatRowItemType.ts
+++ b/src/components/Chat/util/chatRowItemType.ts
@@ -12,13 +12,36 @@ export interface ChatRowItemTypeOptions {
   showInlineReplyContext?: boolean;
 }
 
+// getItemType runs per row on every list data change, so cache the two-peek
+// observable traversal per user and invalidate when the cosmetic maps change.
+const userPaintFlagCache = new Map<string, boolean>();
+let paintCacheInvalidatorAttached = false;
+
+function ensurePaintCacheInvalidator(): void {
+  if (paintCacheInvalidatorAttached) {
+    return;
+  }
+  paintCacheInvalidatorAttached = true;
+  chatStore$.userPaintIds.onChange(() => userPaintFlagCache.clear());
+  chatStore$.paints.onChange(() => userPaintFlagCache.clear());
+}
+
 function hasUserPaint(userId?: string): boolean {
   if (!userId) {
     return false;
   }
 
+  ensurePaintCacheInvalidator();
+
+  const cached = userPaintFlagCache.get(userId);
+  if (cached !== undefined) {
+    return cached;
+  }
+
   const paintId = chatStore$.userPaintIds[userId]?.peek();
-  return Boolean(paintId && chatStore$.paints[paintId]?.peek());
+  const result = Boolean(paintId && chatStore$.paints[paintId]?.peek());
+  userPaintFlagCache.set(userId, result);
+  return result;
 }
 
 function resolveBodyVariant(item: AnyChatMessageType): ChatBodyVariant {

--- a/src/components/Chat/util/chatRowItemType.ts
+++ b/src/components/Chat/util/chatRowItemType.ts
@@ -2,7 +2,7 @@ import {
   type ChatBodyVariant,
   getChatBodyInfo,
 } from '@app/components/Chat/util/richChatMessageHelpers';
-import { chatStore$ } from '@app/store/chat/observables/chatStore';
+import { hasUserPaint } from '@app/store/chat/actions/cosmetics';
 
 import { hasSharedChannelPointsMessage } from './channelPointsSharedMessage';
 import { isRenderableChatMessage } from './chatMessages';
@@ -10,38 +10,6 @@ import type { AnyChatMessageType } from './messageHandlers';
 
 export interface ChatRowItemTypeOptions {
   showInlineReplyContext?: boolean;
-}
-
-// getItemType runs per row on every list data change, so cache the two-peek
-// observable traversal per user and invalidate when the cosmetic maps change.
-const userPaintFlagCache = new Map<string, boolean>();
-let paintCacheInvalidatorAttached = false;
-
-function ensurePaintCacheInvalidator(): void {
-  if (paintCacheInvalidatorAttached) {
-    return;
-  }
-  paintCacheInvalidatorAttached = true;
-  chatStore$.userPaintIds.onChange(() => userPaintFlagCache.clear());
-  chatStore$.paints.onChange(() => userPaintFlagCache.clear());
-}
-
-function hasUserPaint(userId?: string): boolean {
-  if (!userId) {
-    return false;
-  }
-
-  ensurePaintCacheInvalidator();
-
-  const cached = userPaintFlagCache.get(userId);
-  if (cached !== undefined) {
-    return cached;
-  }
-
-  const paintId = chatStore$.userPaintIds[userId]?.peek();
-  const result = Boolean(paintId && chatStore$.paints[paintId]?.peek());
-  userPaintFlagCache.set(userId, result);
-  return result;
 }
 
 function resolveBodyVariant(item: AnyChatMessageType): ChatBodyVariant {

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -94,6 +94,13 @@ export const Image = function Image({
     };
   }, [cachePriority, cacheVariant, diskCachedUrl, shouldUseFileCache, url]);
 
+  // When the wrapper's own file cache is handling persistence, keep
+  // expo-image to memory caching — otherwise the same bytes land on disk
+  // twice (expo-image's disk cache for the remote fetch plus our MMKV-
+  // manifested file cache), burning through both caches' eviction budgets.
+  const resolvedCachePolicy =
+    cachePolicy ?? (shouldUseFileCache ? 'memory' : undefined);
+
   const handleError = (event: ImageErrorEventData) => {
     const host = getHostname(resolvedUrl);
     logger.main.warn('image.load_failed', {
@@ -121,7 +128,7 @@ export const Image = function Image({
         source={resolvedSource}
         style={style}
         contentFit={contentFit}
-        cachePolicy={cachePolicy}
+        cachePolicy={resolvedCachePolicy}
         transition={transition}
         decodeFormat='rgb'
         recyclingKey={recyclingKey ?? resolvedUrl ?? undefined}

--- a/src/components/LiveStreamCard/LiveStreamCard.tsx
+++ b/src/components/LiveStreamCard/LiveStreamCard.tsx
@@ -2,13 +2,12 @@ import { memo, useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { router } from 'expo-router';
 
 import { LiveBadge } from '@app/components/LiveBadge/LiveBadge';
 import { Text } from '@app/components/ui/Text/Text';
 import { impact } from '@app/lib/haptics';
-import { userQueryOptions } from '@app/lib/react-query/queries/twitch';
 import { twitchKeys } from '@app/lib/react-query/query-keys';
 import { Color } from '@app/styles/pallete';
 import { theme } from '@app/styles/themes';
@@ -24,6 +23,7 @@ import {
 import { Button } from '../Button/Button';
 import { Image } from '../Image/Image';
 import { PressableArea } from '../PressableArea/PressableArea';
+import { COMPACT_THUMBNAIL_SIZE, MEDIA_THUMBNAIL_SIZE } from './thumbnailSizes';
 
 interface Props {
   stream: TwitchStream;
@@ -58,24 +58,18 @@ function pushRouteOnce(path: string) {
 function LiveStreamCard({ stream, layout = 'compact' }: Props) {
   const { t } = useTranslation('common');
   const queryClient = useQueryClient();
+  const thumbnailSize =
+    layout === 'media' ? MEDIA_THUMBNAIL_SIZE : COMPACT_THUMBNAIL_SIZE;
   const thumbnailUrl = stream.thumbnail_url
-    .replace('{width}', '1920')
-    .replace('{height}', '1080');
+    .replace('{width}', thumbnailSize.width)
+    .replace('{height}', thumbnailSize.height);
 
   const avatarInitial = stream.user_name.trim().charAt(0).toUpperCase();
 
-  const { data: streamerInfo } = useQuery({
-    ...userQueryOptions(stream.user_login),
-    enabled: layout === 'media' && !stream.profilePicture,
-  });
-  const profilePicture =
-    stream.profilePicture ?? streamerInfo?.profile_image_url;
-  const languageLabel =
-    stream.tags?.find(tag =>
-      Object.values(LANGUAGE_NAMES).some(
-        language => language.toLowerCase() === tag.toLowerCase(),
-      ),
-    ) ?? LANGUAGE_NAMES[stream.language];
+  // Media-layout avatars come pre-batched on the stream via
+  // useStreamProfilePictures at the list level — one /users request per
+  // screen instead of one per visible card.
+  const profilePicture = stream.profilePicture;
 
   const handleStreamPressIn = useCallback(() => {
     router.prefetch(`/streams/live-stream/${stream.user_login}`);
@@ -128,6 +122,15 @@ function LiveStreamCard({ stream, layout = 'compact' }: Props) {
   }, ${formatViewCount(stream.viewer_count)} watching, ${stream.title}`;
 
   if (layout === 'media') {
+    // Only the media layout renders the language, so keep the tag scan out of
+    // the (default) compact path.
+    const languageLabel =
+      stream.tags?.find(tag =>
+        Object.values(LANGUAGE_NAMES).some(
+          language => language.toLowerCase() === tag.toLowerCase(),
+        ),
+      ) ?? LANGUAGE_NAMES[stream.language];
+
     return (
       <Button
         onPress={handleStreamPress}

--- a/src/components/LiveStreamCard/thumbnailSizes.ts
+++ b/src/components/LiveStreamCard/thumbnailSizes.ts
@@ -1,0 +1,13 @@
+/**
+ * Twitch preview URLs are `{width}x{height}` templates. The compact row
+ * renders at 132x88, so a 320x180 variant covers high-density screens; the
+ * media layout spans the screen width, where 860x484 covers 2x. The live
+ * stream screen requests the same media-size poster so navigating from a
+ * media card is a cache hit.
+ */
+export const MEDIA_THUMBNAIL_SIZE = { width: '860', height: '484' } as const;
+
+export const COMPACT_THUMBNAIL_SIZE = {
+  width: '320',
+  height: '180',
+} as const;

--- a/src/components/LiveStreamImage/LiveStreamImage.tsx
+++ b/src/components/LiveStreamImage/LiveStreamImage.tsx
@@ -18,6 +18,8 @@ export const LiveStreamImage = memo(function LiveStreamImage({
   style,
   thumbnail,
 }: Props) {
+  const { width, height } = getThumbnailRequestSize(size);
+
   return (
     <View style={[styles.imageContainer, style]}>
       {thumbnail ? (
@@ -25,8 +27,8 @@ export const LiveStreamImage = memo(function LiveStreamImage({
           testID='LiveStreamImage-image'
           contentFit='contain'
           source={thumbnail
-            .replace('{width}', '2560')
-            .replace('{height}', '1080')}
+            .replace('{width}', width)
+            .replace('{height}', height)}
           style={[styles.image, size && getImageSizeStyle(size)]}
           transition={animated ? 300 : 0}
         />
@@ -44,6 +46,28 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
 });
+
+/**
+ * Twitch preview URLs are `{width}x{height}` templates, so request a 16:9
+ * variant close to the rendered size (~3x the largest display width for
+ * high-density screens) instead of a full 2560x1080 frame for a small
+ * thumbnail.
+ */
+function getThumbnailRequestSize(size?: Props['size']): {
+  width: string;
+  height: string;
+} {
+  switch (size) {
+    case 'sm':
+    case 'md':
+      return { width: '320', height: '180' };
+    case 'lg':
+      return { width: '480', height: '270' };
+    case 'xl':
+    default:
+      return { width: '640', height: '360' };
+  }
+}
 
 function getImageSizeStyle(size: NonNullable<Props['size']>): ImageStyle {
   switch (size) {

--- a/src/components/LiveStreamImage/LiveStreamImage.tsx
+++ b/src/components/LiveStreamImage/LiveStreamImage.tsx
@@ -59,8 +59,9 @@ function getThumbnailRequestSize(size?: Props['size']): {
 } {
   switch (size) {
     case 'sm':
+      return { width: '160', height: '90' };
     case 'md':
-      return { width: '320', height: '180' };
+      return { width: '200', height: '112' };
     case 'lg':
       return { width: '480', height: '270' };
     case 'xl':

--- a/src/components/StreamPlayer/usePlayerBridge.ts
+++ b/src/components/StreamPlayer/usePlayerBridge.ts
@@ -89,9 +89,6 @@ export function usePlayerBridge({
   const [overlayUnlocked, setOverlayUnlocked] = useState(false);
   const [pipActive, setPipActive] = useState(false);
   const pipActiveRef = useRef(false);
-  const [playbackLatencySeconds, setPlaybackLatencySeconds] = useState<
-    number | null
-  >(null);
   const currentTimeResolverRef = useRef<((value: number) => void) | null>(null);
   const durationResolverRef = useRef<((value: number) => void) | null>(null);
   const userPausedRef = useRef(!autoplay);
@@ -151,7 +148,6 @@ export function usePlayerBridge({
     prevPlayerSource.webViewKey !== webViewKey
   ) {
     setPrevPlayerSource({ autoplay, sourceKey, webViewKey });
-    setPlaybackLatencySeconds(null);
     lastPlaybackLatencySecondsRef.current = null;
     pipActiveRef.current = false;
     setPipActive(false);
@@ -465,9 +461,11 @@ export function usePlayerBridge({
       case 'notifyStabilityLatency':
         stability.noteLatency(action.latencySeconds);
         break;
+      // Latency display flows through the videoLatencyDisplay$ observable via
+      // onPlaybackLatencyChange — holding it in React state here re-rendered
+      // the whole player subtree on every ~4s latency tick for nothing.
       case 'publishLatency':
         lastPlaybackLatencySecondsRef.current = action.latencySeconds;
-        setPlaybackLatencySeconds(action.latencySeconds);
         onPlaybackLatencyChange?.(action.latencySeconds);
         break;
       case 'resolveCurrentTime':
@@ -553,7 +551,6 @@ export function usePlayerBridge({
     pause,
     pipActive,
     play,
-    playbackLatencySeconds,
     playerState,
     playerStatus,
     resetPlayerStatus,

--- a/src/context/AccentColorContext.tsx
+++ b/src/context/AccentColorContext.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, use, useState } from 'react';
+import React, {
+  createContext,
+  use,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import { useColorScheme } from 'react-native';
 
 import { colors } from '@app/styles/colors';
@@ -49,7 +55,7 @@ export function AccentColorProvider({
 
   const accentHex = selectedHex ?? colors[scheme].tint;
 
-  const getBackgroundColor = () => {
+  const getBackgroundColor = useCallback(() => {
     if (!selectedHex) {
       return colors[scheme].background;
     }
@@ -62,13 +68,19 @@ export function AccentColorProvider({
     return matchedFamily
       ? getColorValue(matchedFamily, targetShade)
       : colors[scheme].background;
-  };
+  }, [selectedHex, scheme]);
 
-  const contextValue = {
-    accentHex,
-    setAccentHex: setSelectedHex,
-    getBackgroundColor,
-  } satisfies AccentColorContextValue;
+  // Memoized so consumers (the chat composer and input among them) only
+  // re-render when the accent actually changes, not on every provider render.
+  const contextValue = useMemo(
+    () =>
+      ({
+        accentHex,
+        setAccentHex: setSelectedHex,
+        getBackgroundColor,
+      }) satisfies AccentColorContextValue,
+    [accentHex, getBackgroundColor],
+  );
 
   return (
     <AccentColorContext.Provider value={contextValue}>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -2,7 +2,9 @@ import {
   createContext,
   ReactNode,
   use,
+  useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -612,28 +614,59 @@ function useAuthContextValue({
     };
   }, [refreshCurrentUserTokenRef, state.authState]);
 
-  const contextState: AuthContextState = {
-    authState: state.authState,
-    loginWithTwitch: (...args) => loginWithTwitchRef.current(...args),
-    populateAuthState: () => populateAuthStateRef.current(),
-    logout: async () => {
-      await Promise.all([
-        SecureStore.deleteItemAsync(storageKeys.user),
-        SecureStore.deleteItemAsync(storageKeys.anon),
-      ]);
-      setState({ ready: true });
-      setUser(undefined);
-      twitchApi.removeAuthToken();
-      await Promise.all([
-        queryClient.invalidateQueries(),
-        queryClient.resetQueries(),
-        doAnonAuthRef.current(),
-      ]);
-    },
-    fetchAnonToken: testResult => fetchAnonTokenRef.current(testResult),
-    user,
-    ready: state.ready,
-  };
+  // The ref-backed callbacks are identity-stable so the context value only
+  // changes when auth state actually changes — this provider wraps the whole
+  // app and self-updates on a refresh poll and app foreground, so an
+  // unmemoized value re-renders every consumer on each of those ticks.
+  const stableLoginWithTwitch = useCallback(
+    (...args: Parameters<AuthContextState['loginWithTwitch']>) =>
+      loginWithTwitchRef.current(...args),
+    [loginWithTwitchRef],
+  );
+  const stablePopulateAuthState = useCallback(
+    () => populateAuthStateRef.current(),
+    [populateAuthStateRef],
+  );
+  const stableFetchAnonToken = useCallback(
+    (testResult?: DefaultTokenResponse) =>
+      fetchAnonTokenRef.current(testResult),
+    [fetchAnonTokenRef],
+  );
+  const stableLogout = useCallback(async () => {
+    await Promise.all([
+      SecureStore.deleteItemAsync(storageKeys.user),
+      SecureStore.deleteItemAsync(storageKeys.anon),
+    ]);
+    setState({ ready: true });
+    setUser(undefined);
+    twitchApi.removeAuthToken();
+    await Promise.all([
+      queryClient.invalidateQueries(),
+      queryClient.resetQueries(),
+      doAnonAuthRef.current(),
+    ]);
+  }, [doAnonAuthRef]);
+
+  const contextState: AuthContextState = useMemo(
+    () => ({
+      authState: state.authState,
+      loginWithTwitch: stableLoginWithTwitch,
+      populateAuthState: stablePopulateAuthState,
+      logout: stableLogout,
+      fetchAnonToken: stableFetchAnonToken,
+      user,
+      ready: state.ready,
+    }),
+    [
+      state.authState,
+      state.ready,
+      user,
+      stableLoginWithTwitch,
+      stablePopulateAuthState,
+      stableLogout,
+      stableFetchAnonToken,
+    ],
+  );
 
   return contextState;
 }

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -618,21 +618,21 @@ function useAuthContextValue({
   // changes when auth state actually changes — this provider wraps the whole
   // app and self-updates on a refresh poll and app foreground, so an
   // unmemoized value re-renders every consumer on each of those ticks.
-  const stableLoginWithTwitch = useCallback(
+  const loginWithTwitchCallback = useCallback(
     (...args: Parameters<AuthContextState['loginWithTwitch']>) =>
       loginWithTwitchRef.current(...args),
     [loginWithTwitchRef],
   );
-  const stablePopulateAuthState = useCallback(
+  const populateAuthStateCallback = useCallback(
     () => populateAuthStateRef.current(),
     [populateAuthStateRef],
   );
-  const stableFetchAnonToken = useCallback(
+  const fetchAnonTokenCallback = useCallback(
     (testResult?: DefaultTokenResponse) =>
       fetchAnonTokenRef.current(testResult),
     [fetchAnonTokenRef],
   );
-  const stableLogout = useCallback(async () => {
+  const logout = useCallback(async () => {
     await Promise.all([
       SecureStore.deleteItemAsync(storageKeys.user),
       SecureStore.deleteItemAsync(storageKeys.anon),
@@ -650,10 +650,10 @@ function useAuthContextValue({
   const contextState: AuthContextState = useMemo(
     () => ({
       authState: state.authState,
-      loginWithTwitch: stableLoginWithTwitch,
-      populateAuthState: stablePopulateAuthState,
-      logout: stableLogout,
-      fetchAnonToken: stableFetchAnonToken,
+      loginWithTwitch: loginWithTwitchCallback,
+      populateAuthState: populateAuthStateCallback,
+      logout,
+      fetchAnonToken: fetchAnonTokenCallback,
       user,
       ready: state.ready,
     }),
@@ -661,10 +661,10 @@ function useAuthContextValue({
       state.authState,
       state.ready,
       user,
-      stableLoginWithTwitch,
-      stablePopulateAuthState,
-      stableLogout,
-      stableFetchAnonToken,
+      loginWithTwitchCallback,
+      populateAuthStateCallback,
+      logout,
+      fetchAnonTokenCallback,
     ],
   );
 

--- a/src/hooks/firebase/useRemoteConfig.ts
+++ b/src/hooks/firebase/useRemoteConfig.ts
@@ -18,7 +18,7 @@ const remoteConfig = getRemoteConfig(getApp());
 let remoteConfigFetchPromise: Promise<boolean> | null = null;
 
 void setConfigSettings(remoteConfig, {
-  minimumFetchIntervalMillis: 300,
+  minimumFetchIntervalMillis: __DEV__ ? 60 * 1000 : 5 * 60 * 1000,
 });
 
 export interface RemoteConfigSchema {

--- a/src/hooks/queries/__tests__/useStreamProfilePictures.test.tsx
+++ b/src/hooks/queries/__tests__/useStreamProfilePictures.test.tsx
@@ -1,0 +1,115 @@
+import { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { twitchService } from '@app/services/twitch-service';
+import type { TwitchStream } from '@app/types/twitch/stream';
+import type { UserInfoResponse } from '@app/types/twitch/user';
+
+import { useStreamProfilePictures } from '../useStreamProfilePictures';
+
+jest.mock('@app/services/twitch-service', () => ({
+  twitchService: {
+    getUsersById: jest.fn(),
+  },
+}));
+
+const mockGetUsersById = jest.mocked(twitchService.getUsersById);
+
+function stream(userId: string): TwitchStream {
+  return {
+    id: `stream-${userId}`,
+    user_id: userId,
+    user_login: userId,
+    user_name: userId,
+    game_id: '1',
+    game_name: 'game',
+    type: 'live',
+    title: 'title',
+    viewer_count: 1,
+    started_at: '',
+    language: 'en',
+    thumbnail_url: '',
+    tag_ids: [],
+    tags: [],
+    is_mature: false,
+  };
+}
+
+function user(id: string): UserInfoResponse {
+  return {
+    broadcaster_type: '',
+    created_at: '',
+    description: '',
+    display_name: id,
+    id,
+    login: id,
+    offline_image_url: '',
+    profile_image_url: `https://cdn/${id}.png`,
+    type: '',
+    view_count: 0,
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe('useStreamProfilePictures', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetUsersById.mockImplementation(async (ids: string[]) => ids.map(user));
+  });
+
+  test('only queries newly missing ids as the stream list grows', async () => {
+    const { result, rerender } = renderHook(
+      ({ streams }: { streams: TwitchStream[] }) =>
+        useStreamProfilePictures(streams, true),
+      {
+        initialProps: { streams: [stream('a'), stream('b')] },
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.map(s => s.profilePicture)).toEqual([
+        'https://cdn/a.png',
+        'https://cdn/b.png',
+      ]);
+    });
+    expect(mockGetUsersById).toHaveBeenCalledTimes(1);
+    expect(mockGetUsersById).toHaveBeenCalledWith(['a', 'b']);
+
+    rerender({ streams: [stream('a'), stream('b'), stream('c')] });
+
+    await waitFor(() => {
+      expect(result.current.map(s => s.profilePicture)).toEqual([
+        'https://cdn/a.png',
+        'https://cdn/b.png',
+        'https://cdn/c.png',
+      ]);
+    });
+    // The appended page only requests the newly-seen id, not the whole list.
+    expect(mockGetUsersById).toHaveBeenCalledTimes(2);
+    expect(mockGetUsersById).toHaveBeenLastCalledWith(['c']);
+  });
+
+  test('skips the lookup and returns the input untouched when disabled', () => {
+    const streams = [stream('a')];
+    const { result } = renderHook(
+      () => useStreamProfilePictures(streams, false),
+      { wrapper: createWrapper() },
+    );
+
+    expect(mockGetUsersById).not.toHaveBeenCalled();
+    expect(result.current).toBe(streams);
+  });
+});

--- a/src/hooks/queries/useStreamProfilePictures.ts
+++ b/src/hooks/queries/useStreamProfilePictures.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 
@@ -11,6 +11,11 @@ import type { TwitchStream } from '@app/types/twitch/stream';
  * avatars, and fetching one `/users` request per visible card is an N+1
  * against the Helix rate limit — `getUsersById` batches 100 ids per request.
  *
+ * `streams` typically grows as an infinite query appends pages, so ids
+ * already resolved are cached here and excluded from the next lookup —
+ * otherwise each appended page would key a brand new query off the whole
+ * accumulated list and re-fetch every previously seen `user_id`.
+ *
  * Pass `enabled: false` (e.g. for the compact layout, which shows no avatar)
  * to skip the lookup entirely; the input array is returned untouched.
  */
@@ -18,26 +23,51 @@ export function useStreamProfilePictures(
   streams: TwitchStream[],
   enabled: boolean,
 ): TwitchStream[] {
-  const userIds = useMemo(
-    () => [...new Set(streams.map(stream => stream.user_id))].toSorted(),
-    [streams],
+  // eslint-disable-next-line react-doctor/no-derived-state -- accumulates across pages/query resolutions, not derivable from a single input
+  const [profileImageById, setProfileImageById] = useState<Map<string, string>>(
+    () => new Map(),
   );
 
+  const missingUserIds = useMemo(() => {
+    if (!enabled) {
+      return [];
+    }
+    const missing = new Set<string>();
+    for (const stream of streams) {
+      if (!profileImageById.has(stream.user_id)) {
+        missing.add(stream.user_id);
+      }
+    }
+    // eslint-disable-next-line react-doctor/js-tosorted-immutable -- Hermes lacks Array.prototype.toSorted (throws "undefined is not a function"); copy-then-sort is the safe equivalent
+    return [...missing].sort();
+  }, [streams, enabled, profileImageById]);
+
   const { data: users } = useQuery({
-    ...usersByIdsQueryOptions(userIds),
-    enabled: enabled && userIds.length > 0,
+    ...usersByIdsQueryOptions(missingUserIds),
+    enabled: enabled && missingUserIds.length > 0,
   });
 
+  useEffect(() => {
+    if (!users || users.length === 0) {
+      return;
+    }
+    // eslint-disable-next-line react-doctor/no-derived-state -- accumulates across pages/query resolutions, not derivable from a single input
+    setProfileImageById(current => {
+      const next = new Map(current);
+      for (const user of users) {
+        next.set(user.id, user.profile_image_url);
+      }
+      return next;
+    });
+  }, [users]);
+
   return useMemo(() => {
-    if (!enabled || !users || users.length === 0) {
+    if (!enabled || profileImageById.size === 0) {
       return streams;
     }
-    const profileImageById = new Map(
-      users.map(user => [user.id, user.profile_image_url]),
-    );
     return streams.map(stream => {
       const profilePicture = profileImageById.get(stream.user_id);
       return profilePicture ? { ...stream, profilePicture } : stream;
     });
-  }, [streams, users, enabled]);
+  }, [streams, enabled, profileImageById]);
 }

--- a/src/hooks/queries/useStreamProfilePictures.ts
+++ b/src/hooks/queries/useStreamProfilePictures.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { usersByIdsQueryOptions } from '@app/lib/react-query/queries/twitch';
+import type { TwitchStream } from '@app/types/twitch/stream';
+
+/**
+ * Batch-resolves profile pictures for a list of streams and returns the
+ * streams enriched with `profilePicture`. The streams endpoints don't include
+ * avatars, and fetching one `/users` request per visible card is an N+1
+ * against the Helix rate limit — `getUsersById` batches 100 ids per request.
+ *
+ * Pass `enabled: false` (e.g. for the compact layout, which shows no avatar)
+ * to skip the lookup entirely; the input array is returned untouched.
+ */
+export function useStreamProfilePictures(
+  streams: TwitchStream[],
+  enabled: boolean,
+): TwitchStream[] {
+  const userIds = useMemo(
+    () => [...new Set(streams.map(stream => stream.user_id))].toSorted(),
+    [streams],
+  );
+
+  const { data: users } = useQuery({
+    ...usersByIdsQueryOptions(userIds),
+    enabled: enabled && userIds.length > 0,
+  });
+
+  return useMemo(() => {
+    if (!enabled || !users || users.length === 0) {
+      return streams;
+    }
+    const profileImageById = new Map(
+      users.map(user => [user.id, user.profile_image_url]),
+    );
+    return streams.map(stream => {
+      const profilePicture = profileImageById.get(stream.user_id);
+      return profilePicture ? { ...stream, profilePicture } : stream;
+    });
+  }, [streams, users, enabled]);
+}

--- a/src/hooks/useFlattenedInfiniteQuery.ts
+++ b/src/hooks/useFlattenedInfiniteQuery.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react';
+
+import { flattenInfiniteQueryPages } from '@app/utils/pagination/flattenInfiniteQueryPages';
+
+interface PageWithData<TItem> {
+  data?: readonly (TItem | undefined | null)[];
+}
+
+export function useFlattenedInfiniteQuery<TItem>(
+  pages: readonly (PageWithData<TItem> | undefined | null)[] | undefined,
+): TItem[] {
+  return useMemo(() => flattenInfiniteQueryPages(pages), [pages]);
+}

--- a/src/hooks/useRefetchOnForeground.ts
+++ b/src/hooks/useRefetchOnForeground.ts
@@ -7,15 +7,34 @@ import { subscribeToAppForeground } from '@app/utils/appState/appStateTransition
 interface UseRefetchOnForegroundOptions {
   enabled?: boolean;
   refetch: () => Promise<unknown>;
+  /**
+   * Minimum time between triggered refetches. The refetch callbacks passed in
+   * bypass query staleTime (`refetchQueries` refetches unconditionally), so
+   * without a floor a quick tab hop away and back fires a guaranteed network
+   * request each time. Defaults to the app-wide 30s query staleTime.
+   */
+  minIntervalMs?: number;
 }
 
 export function useRefetchOnForeground({
   enabled = true,
   refetch,
+  minIntervalMs = 30_000,
 }: UseRefetchOnForegroundOptions) {
   const refetchRef = useRef(refetch);
 
   refetchRef.current = refetch;
+
+  const lastRefetchAtRef = useRef(0);
+
+  const refetchIfDue = useCallback(() => {
+    const now = Date.now();
+    if (now - lastRefetchAtRef.current < minIntervalMs) {
+      return;
+    }
+    lastRefetchAtRef.current = now;
+    void refetchRef.current();
+  }, [minIntervalMs]);
 
   useFocusEffect(
     useCallback(() => {
@@ -26,11 +45,9 @@ export function useRefetchOnForeground({
       // If the screen regains focus while the app is active (e.g. returning
       // from background while still on this tab, or switching back to this
       // tab after a long pause) ensure data is refreshed.
-      void refetchRef.current();
+      refetchIfDue();
 
-      return subscribeToAppForeground(() => {
-        void refetchRef.current();
-      });
-    }, [enabled]),
+      return subscribeToAppForeground(refetchIfDue);
+    }, [enabled, refetchIfDue]),
   );
 }

--- a/src/lib/react-query/queries/twitch.ts
+++ b/src/lib/react-query/queries/twitch.ts
@@ -33,6 +33,14 @@ export function userQueryOptions(userId: string) {
   });
 }
 
+export function usersByIdsQueryOptions(userIds: string[]) {
+  return queryOptions<UserInfoResponse[]>({
+    queryKey: twitchKeys.usersByIds(userIds),
+    staleTime: 300_000,
+    queryFn: () => twitchService.getUsersById(userIds),
+  });
+}
+
 export function categoryQueryOptions(categoryId: string) {
   return queryOptions<Category>({
     queryKey: twitchKeys.category(categoryId),

--- a/src/lib/react-query/query-client.ts
+++ b/src/lib/react-query/query-client.ts
@@ -80,7 +80,6 @@ const createQueryClient = () => {
         // memoize on `data`, and a new array reference on every focus refetch
         // rebuilds them for nothing.
         retry: 2,
-        retryDelay: attempt => Math.min(1000 * 2 ** attempt, 30_000),
       },
     },
   });

--- a/src/lib/react-query/query-client.ts
+++ b/src/lib/react-query/query-client.ts
@@ -75,9 +75,12 @@ const createQueryClient = () => {
         networkMode: 'offlineFirst',
         refetchOnWindowFocus: false,
         refetchOnReconnect: true,
-        structuralSharing: false,
-        retry: 3,
-        retryDelay: 3000,
+        // structuralSharing stays at its default (true) so refetches that
+        // return identical payloads keep referential identity — list screens
+        // memoize on `data`, and a new array reference on every focus refetch
+        // rebuilds them for nothing.
+        retry: 2,
+        retryDelay: attempt => Math.min(1000 * 2 ** attempt, 30_000),
       },
     },
   });

--- a/src/lib/react-query/query-keys.ts
+++ b/src/lib/react-query/query-keys.ts
@@ -6,6 +6,8 @@ export const twitchKeys = {
   stream: (userLogin: string) =>
     [...twitchKeys.all, 'stream', userLogin] as const,
   user: (userId: string) => [...twitchKeys.all, 'user', userId] as const,
+  usersByIds: (userIds: string[]) =>
+    [...twitchKeys.all, 'usersByIds', userIds.join(',')] as const,
   category: (categoryId: string) =>
     [...twitchKeys.all, 'category', categoryId] as const,
   followedStreams: (userId: string) =>

--- a/src/lib/react-query/query-provider.tsx
+++ b/src/lib/react-query/query-provider.tsx
@@ -111,6 +111,20 @@ subscribeToAppStateTransitions(({ current }) => {
   }
 });
 
+// Fallback in case an AppState 'change' event is dropped — this is a known,
+// occasional issue on some Android OEMs/versions and would otherwise leave
+// polling stopped indefinitely after a missed foreground transition.
+// start/stopConnectivityPolling are both idempotent, so this just reconciles
+// against the actual current state rather than trusting event delivery alone.
+const APP_STATE_RECONCILE_INTERVAL_MS = 15_000;
+setInterval(() => {
+  if (AppState.currentState === 'active') {
+    startConnectivityPolling();
+  } else {
+    stopConnectivityPolling();
+  }
+}, APP_STATE_RECONCILE_INTERVAL_MS);
+
 // @ts-expect-error - not all codepaths return a value
 focusManager.setEventListener(onFocus => {
   if (Platform.OS === 'ios' || Platform.OS === 'android') {

--- a/src/lib/react-query/query-provider.tsx
+++ b/src/lib/react-query/query-provider.tsx
@@ -77,13 +77,39 @@ function checkIsOnlineIfNeeded() {
   });
 }
 
-setInterval(() => {
-  if (AppState.currentState === 'active') {
+// Only poll connectivity while the app is foregrounded — a lifetime interval
+// keeps waking the JS thread in the background for work the guard skips.
+let connectivityPollInterval: ReturnType<typeof setInterval> | undefined;
+
+function startConnectivityPolling() {
+  if (connectivityPollInterval) {
+    return;
+  }
+  connectivityPollInterval = setInterval(() => {
     if (!onlineManager.isOnline() || isNetworkStateUnclear) {
       checkIsOnlineIfNeeded();
     }
+  }, 2000);
+}
+
+function stopConnectivityPolling() {
+  if (connectivityPollInterval) {
+    clearInterval(connectivityPollInterval);
+    connectivityPollInterval = undefined;
   }
-}, 2000);
+}
+
+if (AppState.currentState === 'active') {
+  startConnectivityPolling();
+}
+
+subscribeToAppStateTransitions(({ current }) => {
+  if (current === 'active') {
+    startConnectivityPolling();
+  } else {
+    stopConnectivityPolling();
+  }
+});
 
 // @ts-expect-error - not all codepaths return a value
 focusManager.setEventListener(onFocus => {

--- a/src/lib/react-query/query-provider.tsx
+++ b/src/lib/react-query/query-provider.tsx
@@ -117,7 +117,17 @@ subscribeToAppStateTransitions(({ current }) => {
 // start/stopConnectivityPolling are both idempotent, so this just reconciles
 // against the actual current state rather than trusting event delivery alone.
 const APP_STATE_RECONCILE_INTERVAL_MS = 15_000;
-setInterval(() => {
+
+// Stored on globalThis and cleared before re-arming so a module re-evaluation
+// (Fast Refresh in dev) can't leak a second interval. In production the module
+// is evaluated once.
+const globalWithReconcile = globalThis as typeof globalThis & {
+  __foamAppStateReconcileInterval?: ReturnType<typeof setInterval>;
+};
+if (globalWithReconcile.__foamAppStateReconcileInterval) {
+  clearInterval(globalWithReconcile.__foamAppStateReconcileInterval);
+}
+globalWithReconcile.__foamAppStateReconcileInterval = setInterval(() => {
   if (AppState.currentState === 'active') {
     startConnectivityPolling();
   } else {

--- a/src/screens/CategoryScreen.tsx
+++ b/src/screens/CategoryScreen.tsx
@@ -16,12 +16,12 @@ import { EmptyState } from '@app/components/ui/EmptyState/EmptyState';
 import { Text } from '@app/components/ui/Text/Text';
 import { useCategoryQuery } from '@app/hooks/queries/useCategoryQuery';
 import { useStreamsByCategoryQuery } from '@app/hooks/queries/useStreamsByCategoryQuery';
+import { useFlattenedInfiniteQuery } from '@app/hooks/useFlattenedInfiniteQuery';
 import { useInfiniteQueryLoadMore } from '@app/hooks/useInfiniteQueryLoadMore';
 import { useScrollToTop } from '@app/hooks/useScrollToTop';
 import { theme } from '@app/styles/themes';
 import type { Category } from '@app/types/twitch/category';
 import type { TwitchStream } from '@app/types/twitch/stream';
-import { flattenInfiniteQueryPages } from '@app/utils/pagination/flattenInfiniteQueryPages';
 import { shareDeepLink } from '@app/utils/sharing/shareDeepLink';
 import { formatViewCount } from '@app/utils/string/formatViewCount';
 
@@ -108,10 +108,7 @@ export const CategoryScreen: FC<CategoryScreenProps> = ({ id }) => {
     isFetchingNextPage,
   });
 
-  const allStreams = useMemo(
-    () => flattenInfiniteQueryPages(streams?.pages),
-    [streams?.pages],
-  );
+  const allStreams = useFlattenedInfiniteQuery(streams?.pages);
   const totalViewers = useMemo(
     () => allStreams.reduce((acc, stream) => acc + stream.viewer_count, 0),
     [allStreams],

--- a/src/screens/CategoryScreen.tsx
+++ b/src/screens/CategoryScreen.tsx
@@ -1,4 +1,4 @@
-import { FC, memo, useRef } from 'react';
+import { FC, memo, useMemo, useRef } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
@@ -108,10 +108,13 @@ export const CategoryScreen: FC<CategoryScreenProps> = ({ id }) => {
     isFetchingNextPage,
   });
 
-  const allStreams = flattenInfiniteQueryPages(streams?.pages);
-  const totalViewers = allStreams.reduce(
-    (acc, stream) => acc + stream.viewer_count,
-    0,
+  const allStreams = useMemo(
+    () => flattenInfiniteQueryPages(streams?.pages),
+    [streams?.pages],
+  );
+  const totalViewers = useMemo(
+    () => allStreams.reduce((acc, stream) => acc + stream.viewer_count, 0),
+    [allStreams],
   );
 
   if (isCategoryLoading || isLoadingStreams) {

--- a/src/screens/FollowingScreen.tsx
+++ b/src/screens/FollowingScreen.tsx
@@ -228,11 +228,9 @@ export default function FollowingScreen() {
     [streamListLayout, layoutFade, updatePreferences],
   );
 
-  // FollowingListHeader is memo()'d and its props are stable (a primitive plus
-  // the useCallback above), so recreating this element per render is a no-op —
-  // memo bails out before re-rendering the header subtree. Wrapping it in
-  // useMemo here would run JSX before the early return below, which the
-  // rerender-memo-before-early-return lint rule (rightly) flags.
+  // Inline (not useMemo): FollowingListHeader is memo()'d with stable props, so
+  // recreating this element is a no-op, and a useMemo here would build JSX
+  // before the early return below (rerender-memo-before-early-return).
   const listHeader = (
     <FollowingListHeader
       streamListLayout={streamListLayout}

--- a/src/screens/FollowingScreen.tsx
+++ b/src/screens/FollowingScreen.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   type ReactElement,
   useCallback,
   useEffect,
@@ -31,6 +32,7 @@ import { Text } from '@app/components/ui/Text/Text';
 import { useAuthContext } from '@app/context/AuthContext';
 import { useFollowedChannelsQuery } from '@app/hooks/queries/useFollowedChannelsQuery';
 import { useFollowedStreamsQuery } from '@app/hooks/queries/useFollowedStreamsQuery';
+import { useStreamProfilePictures } from '@app/hooks/queries/useStreamProfilePictures';
 import { useRefetchOnForeground } from '@app/hooks/useRefetchOnForeground';
 import { useScrollToTop } from '@app/hooks/useScrollToTop';
 import i18next from '@app/i18n/i18next';
@@ -54,6 +56,27 @@ type FollowingListItem =
   | { type: 'stream'; stream: TwitchStream }
   | { type: 'offlineHeader' }
   | { type: 'offlineChannel'; channel: FollowedChannelWithProfile };
+
+const FollowingListHeader = memo(function FollowingListHeader({
+  streamListLayout,
+  onChangeLayout,
+}: {
+  streamListLayout: 'compact' | 'media';
+  onChangeLayout: (layout: 'compact' | 'media') => void;
+}) {
+  return (
+    <View>
+      <EditorialSectionHeader eyebrow='For you' />
+      <View style={styles.layoutToggleRow}>
+        <StreamListLayoutToggle
+          value={streamListLayout}
+          onChange={onChangeLayout}
+        />
+      </View>
+      <View style={styles.header} />
+    </View>
+  );
+});
 
 export default function FollowingScreen() {
   const { t } = useTranslation(['stream', 'common']);
@@ -94,8 +117,9 @@ export default function FollowingScreen() {
     retry: 2,
     retryDelay: (attemptIndex: number) =>
       Math.min(1000 * 2 ** attemptIndex, 3000),
-    refetchOnMount: true,
-    refetchOnWindowFocus: true,
+    // Focus/foreground refreshes are handled by useRefetchOnForeground below;
+    // stacking refetchOnMount/refetchOnWindowFocus on top forced a network
+    // request on every tab switch regardless of staleness.
   });
 
   useRefetchOnForeground({
@@ -103,9 +127,13 @@ export default function FollowingScreen() {
     refetch: refetchFollowingStreams,
   });
 
-  const streamsArray = useMemo(
+  const rawStreamsArray = useMemo(
     () => (Array.isArray(streams) ? streams : []),
     [streams],
+  );
+  const streamsArray = useStreamProfilePictures(
+    rawStreamsArray,
+    streamListLayout === 'media',
   );
 
   const { data: followedChannels, isLoading: isLoadingFollowedChannels } =
@@ -159,40 +187,53 @@ export default function FollowingScreen() {
     }
   }, [isError, isFetched]);
 
-  const renderItem: ListRenderItem<FollowingListItem> = ({ item }) => {
-    switch (item.type) {
-      case 'stream':
-        return (
-          <MemoizedLiveStreamCard
-            stream={item.stream}
-            layout={streamListLayout}
-          />
-        );
-      case 'offlineHeader':
-        return (
-          <View style={styles.offlineHeaderRow}>
-            <Text type='md' weight='bold'>
-              {t('offlineChannels')}
-            </Text>
-          </View>
-        );
-      case 'offlineChannel':
-        return <MemoizedOfflineChannelRow channel={item.channel} />;
-    }
-  };
+  const renderItem: ListRenderItem<FollowingListItem> = useCallback(
+    ({ item }) => {
+      switch (item.type) {
+        case 'stream':
+          return (
+            <MemoizedLiveStreamCard
+              stream={item.stream}
+              layout={streamListLayout}
+            />
+          );
+        case 'offlineHeader':
+          return (
+            <View style={styles.offlineHeaderRow}>
+              <Text type='md' weight='bold'>
+                {t('offlineChannels')}
+              </Text>
+            </View>
+          );
+        case 'offlineChannel':
+          return <MemoizedOfflineChannelRow channel={item.channel} />;
+      }
+    },
+    [streamListLayout, t],
+  );
 
   // Soft dip-and-recover fade when switching layouts so rows do not
   // hard-cut between shapes.
-  const setLayoutWithFade = (layout: 'compact' | 'media') => {
-    if (layout === streamListLayout) {
-      return;
-    }
-    layoutFade.set(0.35);
-    layoutFade.set(
-      withTiming(1, { duration: motion.medium, easing: motion.easing.out }),
-    );
-    updatePreferences({ streamListLayout: layout });
-  };
+  const setLayoutWithFade = useCallback(
+    (layout: 'compact' | 'media') => {
+      if (layout === streamListLayout) {
+        return;
+      }
+      layoutFade.set(0.35);
+      layoutFade.set(
+        withTiming(1, { duration: motion.medium, easing: motion.easing.out }),
+      );
+      updatePreferences({ streamListLayout: layout });
+    },
+    [streamListLayout, layoutFade, updatePreferences],
+  );
+
+  const listHeader = (
+    <FollowingListHeader
+      streamListLayout={streamListLayout}
+      onChangeLayout={setLayoutWithFade}
+    />
+  );
 
   if (!authState?.isLoggedIn) {
     return (
@@ -306,18 +347,7 @@ export default function FollowingScreen() {
           contentInsetAdjustmentBehavior='automatic'
           drawDistance={Platform.OS === 'ios' ? 500 : undefined}
           getItemType={item => item.type}
-          ListHeaderComponent={
-            <View>
-              <EditorialSectionHeader eyebrow='For you' />
-              <View style={styles.layoutToggleRow}>
-                <StreamListLayoutToggle
-                  value={streamListLayout}
-                  onChange={setLayoutWithFade}
-                />
-              </View>
-              <View style={styles.header} />
-            </View>
-          }
+          ListHeaderComponent={listHeader}
           contentContainerStyle={[
             styles.listContent,
             {

--- a/src/screens/FollowingScreen.tsx
+++ b/src/screens/FollowingScreen.tsx
@@ -228,6 +228,11 @@ export default function FollowingScreen() {
     [streamListLayout, layoutFade, updatePreferences],
   );
 
+  // FollowingListHeader is memo()'d and its props are stable (a primitive plus
+  // the useCallback above), so recreating this element per render is a no-op —
+  // memo bails out before re-rendering the header subtree. Wrapping it in
+  // useMemo here would run JSX before the early return below, which the
+  // rerender-memo-before-early-return lint rule (rightly) flags.
   const listHeader = (
     <FollowingListHeader
       streamListLayout={streamListLayout}

--- a/src/screens/Stream/LiveStreamScreen.tsx
+++ b/src/screens/Stream/LiveStreamScreen.tsx
@@ -32,6 +32,7 @@ import { Button } from '@app/components/Button/Button';
 import { ChannelPollCard } from '@app/components/ChannelPollCard/ChannelPollCard';
 import { ChannelPredictionCard } from '@app/components/ChannelPredictionCard/ChannelPredictionCard';
 import { Chat } from '@app/components/Chat/Chat';
+import { MEDIA_THUMBNAIL_SIZE } from '@app/components/LiveStreamCard/thumbnailSizes';
 import { StreamPlayer } from '@app/components/StreamPlayer/StreamPlayer';
 import type { StreamPlayerRef } from '@app/components/StreamPlayer/types';
 import { SymbolView } from '@app/components/ui/Icon/Icon';
@@ -742,14 +743,14 @@ export const LiveStreamScreen = memo(function LiveStreamScreen({
       ? styles.overlayChatContainer
       : undefined;
 
-  // Matches the live-stream card's request size so the loading poster is an
-  // instant cache hit when arriving from the stream list.
+  // Matches the media-layout live-stream card's request size so the loading
+  // poster is an instant cache hit when arriving from the stream list.
   const posterUrl = useMemo(
     () =>
       stream?.thumbnail_url
         ? stream.thumbnail_url
-            .replace('{width}', '1920')
-            .replace('{height}', '1080')
+            .replace('{width}', MEDIA_THUMBNAIL_SIZE.width)
+            .replace('{height}', MEDIA_THUMBNAIL_SIZE.height)
         : undefined,
     [stream?.thumbnail_url],
   );

--- a/src/screens/Stream/StreamerProfileScreen.tsx
+++ b/src/screens/Stream/StreamerProfileScreen.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useRef, useState } from 'react';
 import { Platform, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -23,6 +23,7 @@ import { useStreamElementsStatsQuery } from '@app/hooks/queries/useStreamelement
 import { useUserQuery } from '@app/hooks/queries/useUserQuery';
 import { useVideosQuery } from '@app/hooks/queries/useVideosQuery';
 import { useDownloadTwitchClip } from '@app/hooks/useDownloadTwitchClip';
+import { useFlattenedInfiniteQuery } from '@app/hooks/useFlattenedInfiniteQuery';
 import { useInfiniteQueryLoadMore } from '@app/hooks/useInfiniteQueryLoadMore';
 import { useScrollToTop } from '@app/hooks/useScrollToTop';
 import i18next from '@app/i18n/i18next';
@@ -31,7 +32,6 @@ import type { StreamElementsChatStats } from '@app/types/streamelements/stats';
 import type { TwitchClip } from '@app/types/twitch/clip';
 import type { UserInfoResponse } from '@app/types/twitch/user';
 import type { TwitchVideo } from '@app/types/twitch/video';
-import { flattenInfiniteQueryPages } from '@app/utils/pagination/flattenInfiniteQueryPages';
 import { shareDeepLink } from '@app/utils/sharing/shareDeepLink';
 import {
   formatViewCount,
@@ -460,14 +460,8 @@ export function StreamerProfileScreen({ id }: StreamerProfileScreenProps) {
     enabled: Boolean(user?.login),
   });
 
-  const clips = useMemo(
-    () => flattenInfiniteQueryPages(clipsQuery.data?.pages),
-    [clipsQuery.data?.pages],
-  );
-  const vods = useMemo(
-    () => flattenInfiniteQueryPages(videosQuery.data?.pages),
-    [videosQuery.data?.pages],
-  );
+  const clips = useFlattenedInfiniteQuery(clipsQuery.data?.pages);
+  const vods = useFlattenedInfiniteQuery(videosQuery.data?.pages);
 
   const cardWidth =
     Platform.OS === 'web' && windowWidth >= 820

--- a/src/screens/Stream/StreamerProfileScreen.tsx
+++ b/src/screens/Stream/StreamerProfileScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { Platform, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -263,7 +263,10 @@ function StreamerProfileHeader({
   );
 }
 
-function VodCard({
+// Memoized so the regex/Date formatting below only re-runs for cards whose
+// props actually changed — extraData ticks (tab captions, download state)
+// re-render the list wrapper, not every visible card.
+const VodCard = memo(function VodCard({
   vod,
   width,
   fallbackImage,
@@ -306,9 +309,9 @@ function VodCard({
       </Button>
     </View>
   );
-}
+});
 
-function ClipCard({
+const ClipCard = memo(function ClipCard({
   clip,
   downloading,
   onDownload,
@@ -372,7 +375,7 @@ function ClipCard({
       </View>
     </View>
   );
-}
+});
 
 function ProfileTabEmptyState({
   activeTab,
@@ -457,8 +460,14 @@ export function StreamerProfileScreen({ id }: StreamerProfileScreenProps) {
     enabled: Boolean(user?.login),
   });
 
-  const clips = flattenInfiniteQueryPages(clipsQuery.data?.pages);
-  const vods = flattenInfiniteQueryPages(videosQuery.data?.pages);
+  const clips = useMemo(
+    () => flattenInfiniteQueryPages(clipsQuery.data?.pages),
+    [clipsQuery.data?.pages],
+  );
+  const vods = useMemo(
+    () => flattenInfiniteQueryPages(videosQuery.data?.pages),
+    [videosQuery.data?.pages],
+  );
 
   const cardWidth =
     Platform.OS === 'web' && windowWidth >= 820
@@ -477,37 +486,46 @@ export function StreamerProfileScreen({ id }: StreamerProfileScreenProps) {
     isFetchingNextPage: videosQuery.isFetchingNextPage,
   });
 
-  const handleDownload = (clip: TwitchClip) => {
-    download(
-      { clip },
-      {
-        onError: error => toast.error(error.message),
-        onSuccess: () => toast.success(i18next.t('stream:clipSaved')),
-      },
-    );
-  };
+  const handleDownload = useCallback(
+    (clip: TwitchClip) => {
+      download(
+        { clip },
+        {
+          onError: error => toast.error(error.message),
+          onSuccess: () => toast.success(i18next.t('stream:clipSaved')),
+        },
+      );
+    },
+    [download],
+  );
 
-  const renderItem: ListRenderItem<ProfileListItem> = ({ item }) => {
-    if (activeTab === 'clips') {
-      const clip = item as TwitchClip;
+  const vodFallbackImage =
+    user?.offline_image_url ?? user?.profile_image_url ?? '';
+
+  const renderItem: ListRenderItem<ProfileListItem> = useCallback(
+    ({ item }) => {
+      if (activeTab === 'clips') {
+        const clip = item as TwitchClip;
+        return (
+          <ClipCard
+            clip={clip}
+            downloading={downloadingClipId === clip.id}
+            onDownload={handleDownload}
+            width={cardWidth}
+          />
+        );
+      }
+
       return (
-        <ClipCard
-          clip={clip}
-          downloading={downloadingClipId === clip.id}
-          onDownload={handleDownload}
+        <VodCard
+          vod={item as TwitchVideo}
           width={cardWidth}
+          fallbackImage={vodFallbackImage}
         />
       );
-    }
-
-    return (
-      <VodCard
-        vod={item as TwitchVideo}
-        width={cardWidth}
-        fallbackImage={user?.offline_image_url ?? user?.profile_image_url ?? ''}
-      />
-    );
-  };
+    },
+    [activeTab, cardWidth, downloadingClipId, handleDownload, vodFallbackImage],
+  );
 
   const isVods = activeTab === 'vods';
   const items = isVods ? vods : clips;

--- a/src/screens/Top/TopCategoriesScreen.tsx
+++ b/src/screens/Top/TopCategoriesScreen.tsx
@@ -88,8 +88,7 @@ export function TopCategoriesScreen({
   }, [refetch, refreshing$]);
 
   const allCategories = flattenInfiniteQueryPages(categories?.pages);
-  const showSkeleton =
-    isLoading || refreshing || (isFetching && allCategories.length === 0);
+  const showSkeleton = isLoading || (isFetching && allCategories.length === 0);
 
   if (showSkeleton) {
     return (
@@ -139,6 +138,7 @@ export function TopCategoriesScreen({
       listRef={listRef}
       onEndReached={handleLoadMore}
       onRefresh={onRefresh}
+      refreshing={refreshing}
       renderTopCategoryItem={renderTopCategoryItem}
       scrollHandler={scrollHandler}
     />
@@ -151,6 +151,7 @@ function TopCategoriesList({
   listRef,
   onEndReached,
   onRefresh,
+  refreshing,
   renderTopCategoryItem,
   scrollHandler,
 }: {
@@ -159,6 +160,7 @@ function TopCategoriesList({
   listRef: RefObject<FlashListRef<Category> | null>;
   onEndReached: () => void;
   onRefresh: () => void;
+  refreshing: boolean;
   renderTopCategoryItem: ListRenderItem<Category>;
   scrollHandler: ReturnType<typeof useAnimatedScrollHandler>;
 }) {
@@ -181,6 +183,7 @@ function TopCategoriesList({
         onEndReachedThreshold={0.4}
         onScroll={scrollHandler}
         onRefresh={onRefresh}
+        refreshing={refreshing}
       />
     </View>
   );

--- a/src/screens/Top/TopStreamsScreen.tsx
+++ b/src/screens/Top/TopStreamsScreen.tsx
@@ -138,8 +138,7 @@ export function TopStreamsScreen({
     />
   );
 
-  const showSkeleton =
-    refreshing || isLoading || (isFetching && allStreams.length === 0);
+  const showSkeleton = isLoading || (isFetching && allStreams.length === 0);
 
   if (showSkeleton) {
     return (

--- a/src/screens/Top/TopStreamsScreen.tsx
+++ b/src/screens/Top/TopStreamsScreen.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import Animated, {
@@ -20,6 +20,7 @@ import { EmptyState } from '@app/components/ui/EmptyState/EmptyState';
 import { useStreamProfilePictures } from '@app/hooks/queries/useStreamProfilePictures';
 import { useTopStreamsQuery } from '@app/hooks/queries/useTopStreamsQuery';
 import { useDebouncedCallback } from '@app/hooks/useDebouncedCallback';
+import { useFlattenedInfiniteQuery } from '@app/hooks/useFlattenedInfiniteQuery';
 import { useInfiniteQueryLoadMore } from '@app/hooks/useInfiniteQueryLoadMore';
 import { useRefetchOnForeground } from '@app/hooks/useRefetchOnForeground';
 import { useScrollToTop } from '@app/hooks/useScrollToTop';
@@ -31,7 +32,6 @@ import {
 import { motion } from '@app/styles/motion';
 import { theme } from '@app/styles/themes';
 import type { TwitchStream } from '@app/types/twitch/stream';
-import { flattenInfiniteQueryPages } from '@app/utils/pagination/flattenInfiniteQueryPages';
 
 type StreamListLayout = Preferences['streamListLayout'];
 
@@ -115,10 +115,7 @@ export function TopStreamsScreen({
     [streamListLayout],
   );
 
-  const flattenedStreams = useMemo(
-    () => flattenInfiniteQueryPages(streams?.pages),
-    [streams?.pages],
-  );
+  const flattenedStreams = useFlattenedInfiniteQuery(streams?.pages);
   const allStreams = useStreamProfilePictures(
     flattenedStreams,
     streamListLayout === 'media',

--- a/src/screens/Top/TopStreamsScreen.tsx
+++ b/src/screens/Top/TopStreamsScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import Animated, {
@@ -17,6 +17,7 @@ import { MemoizedLiveStreamCard } from '@app/components/LiveStreamCard/LiveStrea
 import { LiveStreamCardSkeleton } from '@app/components/LiveStreamCard/LiveStreamCardSkeleton';
 import { StreamListLayoutToggle } from '@app/components/StreamListLayoutToggle/StreamListLayoutToggle';
 import { EmptyState } from '@app/components/ui/EmptyState/EmptyState';
+import { useStreamProfilePictures } from '@app/hooks/queries/useStreamProfilePictures';
 import { useTopStreamsQuery } from '@app/hooks/queries/useTopStreamsQuery';
 import { useDebouncedCallback } from '@app/hooks/useDebouncedCallback';
 import { useInfiniteQueryLoadMore } from '@app/hooks/useInfiniteQueryLoadMore';
@@ -39,7 +40,7 @@ interface TopStreamsListHeaderProps {
   onChangeLayout: (layout: StreamListLayout) => void;
 }
 
-const TopStreamsListHeader = function TopStreamsListHeader({
+const TopStreamsListHeader = memo(function TopStreamsListHeader({
   streamListLayout,
   onChangeLayout,
 }: TopStreamsListHeaderProps) {
@@ -51,7 +52,7 @@ const TopStreamsListHeader = function TopStreamsListHeader({
       />
     </View>
   );
-};
+});
 
 interface TopStreamsScreenProps {
   contentTopInset?: number;
@@ -107,18 +108,31 @@ export function TopStreamsScreen({
     setRefreshing(false);
   }, [refetch]);
 
-  const renderItem: ListRenderItem<TwitchStream> = ({ item }) => {
-    return <MemoizedLiveStreamCard stream={item} layout={streamListLayout} />;
-  };
+  const renderItem: ListRenderItem<TwitchStream> = useCallback(
+    ({ item }) => (
+      <MemoizedLiveStreamCard stream={item} layout={streamListLayout} />
+    ),
+    [streamListLayout],
+  );
 
-  const allStreams = flattenInfiniteQueryPages(streams?.pages);
+  const flattenedStreams = useMemo(
+    () => flattenInfiniteQueryPages(streams?.pages),
+    [streams?.pages],
+  );
+  const allStreams = useStreamProfilePictures(
+    flattenedStreams,
+    streamListLayout === 'media',
+  );
 
-  const handleLayoutChange = (layout: StreamListLayout) => {
-    if (layout === streamListLayout) {
-      return;
-    }
-    updatePreferences({ streamListLayout: layout });
-  };
+  const handleLayoutChange = useCallback(
+    (layout: StreamListLayout) => {
+      if (layout === streamListLayout) {
+        return;
+      }
+      updatePreferences({ streamListLayout: layout });
+    },
+    [streamListLayout, updatePreferences],
+  );
 
   const listHeader = (
     <TopStreamsListHeader

--- a/src/services/recent-messages-service.ts
+++ b/src/services/recent-messages-service.ts
@@ -87,9 +87,11 @@ export const recentMessagesService = {
   getRecentMessages: async (
     channelName: string,
     signal?: AbortSignal,
+    limit?: number,
   ): Promise<string[]> => {
+    const query = limit && limit > 0 ? `?limit=${limit}` : '';
     const response = await fetch(
-      `${RECENT_MESSAGES_URL}/${encodeURIComponent(channelName)}`,
+      `${RECENT_MESSAGES_URL}/${encodeURIComponent(channelName)}${query}`,
       { signal },
     );
 

--- a/src/store/chat/__tests__/channelLoad.test.ts
+++ b/src/store/chat/__tests__/channelLoad.test.ts
@@ -23,6 +23,7 @@ import {
   loadChannelResources,
   resolveSubscriberChannelProfiles,
 } from '../actions/channelLoad';
+import { clearGlobalResourceCache } from '../actions/channelResources';
 import { chatStore$ } from '../observables/chatStore';
 import type { SubscriberChannelProfile } from '../types/constants';
 import { emptyEmoteData } from '../types/constants';
@@ -273,6 +274,7 @@ describe('loadChannelResources cache fallback', () => {
     chatStore$.currentChannelId.set(null);
     chatStore$.loadingState.set('IDLE');
     clearPersonalEmotesCache();
+    clearGlobalResourceCache();
 
     mockGetPersonalEmoteSet.mockResolvedValue([]);
     mockGetUsersById.mockResolvedValue([]);

--- a/src/store/chat/actions/__tests__/channelResources.test.ts
+++ b/src/store/chat/actions/__tests__/channelResources.test.ts
@@ -16,9 +16,6 @@ import {
 } from '../channelResources';
 
 jest.mock('@app/services/bttv-emote-service', () => ({ bttvEmoteService: {} }));
-jest.mock('@app/services/chatterino-service', () => ({
-  chatterinoService: {},
-}));
 jest.mock('@app/services/ffz-service', () => ({ ffzService: {} }));
 jest.mock('@app/services/seventv-service', () => ({ sevenTvService: {} }));
 jest.mock('@app/services/twitch-badge-service', () => ({
@@ -96,7 +93,6 @@ describe('buildBadgeResourceSpecs', () => {
       'twitchGlobalBadges',
       'ffzGlobalBadges',
       'ffzChannelBadges',
-      'chatterinoBadges',
     ]);
   });
 });

--- a/src/store/chat/actions/channelLoad.ts
+++ b/src/store/chat/actions/channelLoad.ts
@@ -7,6 +7,7 @@ import { twitchService } from '@app/services/twitch-service';
 import { getPreferences } from '@app/store/preferences/state';
 import type { SanitisedEmote } from '@app/types/emote';
 import { createFetchOnceGuard } from '@app/utils/async/fetchOnceGuard';
+import { getChatterinoBadges } from '@app/utils/chat/chatterinoBadges';
 import { fetchChannelCheermotes } from '@app/utils/chat/cheermoteStore';
 import { getEmojiEmotes } from '@app/utils/emoji/emojiEmotes';
 import { logger } from '@app/utils/logger';
@@ -18,9 +19,10 @@ import {
 } from '../observables/recentMessagesPersistence';
 import type {
   ChannelCacheType,
+  SanitisedBadgeSet,
   SubscriberChannelProfile,
 } from '../types/constants';
-import { emptyEmoteData } from '../types/constants';
+import { emptyResolvedEmoteData } from '../types/constants';
 import { planChannelRefresh } from './channelRefreshPlan';
 import {
   type BadgeResourceSets,
@@ -418,7 +420,6 @@ const loadChannelResourcesInternal = async (
           twitchGlobalBadges: badgeByKey.get('twitchGlobalBadges') ?? [],
           ffzGlobalBadges: badgeByKey.get('ffzGlobalBadges') ?? [],
           ffzChannelBadges: badgeByKey.get('ffzChannelBadges') ?? [],
-          chatterinoBadges: badgeByKey.get('chatterinoBadges') ?? [],
         };
 
         const allBadges = combineUniqueById(
@@ -549,7 +550,6 @@ const loadChannelResourcesInternal = async (
       twitchGlobalBadges: badgeByKey.get('twitchGlobalBadges') ?? [],
       ffzGlobalBadges: badgeByKey.get('ffzGlobalBadges') ?? [],
       ffzChannelBadges: badgeByKey.get('ffzChannelBadges') ?? [],
-      chatterinoBadges: badgeByKey.get('chatterinoBadges') ?? [],
     };
 
     const allEmotes = combineUniqueById(
@@ -731,62 +731,65 @@ export const clearChatCosmeticsCache = (): void => {
   void clearChatStorePersistence();
 };
 
+const NO_EMOTES: SanitisedEmote[] = [];
+const NO_BADGES: SanitisedBadgeSet[] = [];
+
 export const getCurrentEmoteData = (channelId?: string) => {
   const targetChannelId = channelId ?? chatStore$.currentChannelId.peek();
   if (!targetChannelId) {
-    return emptyEmoteData;
+    return emptyResolvedEmoteData;
   }
   const caches = chatStore$.persisted.channelCaches.peek();
   const cache = caches?.[targetChannelId];
   if (!cache) {
-    return emptyEmoteData;
+    return emptyResolvedEmoteData;
   }
 
   const preferences = getPreferences();
 
   return {
     twitchChannelEmotes: preferences.showTwitchEmotes
-      ? (cache.twitchChannelEmotes ?? [])
-      : [],
+      ? (cache.twitchChannelEmotes ?? NO_EMOTES)
+      : NO_EMOTES,
     twitchGlobalEmotes: preferences.showTwitchEmotes
-      ? (cache.twitchGlobalEmotes ?? [])
-      : [],
+      ? (cache.twitchGlobalEmotes ?? NO_EMOTES)
+      : NO_EMOTES,
     twitchSubscriberEmotes: preferences.showTwitchEmotes
-      ? (cache.twitchSubscriberEmotes ?? [])
-      : [],
+      ? (cache.twitchSubscriberEmotes ?? NO_EMOTES)
+      : NO_EMOTES,
     sevenTvChannelEmotes: preferences.show7TvEmotes
-      ? (cache.sevenTvChannelEmotes ?? [])
-      : [],
+      ? (cache.sevenTvChannelEmotes ?? NO_EMOTES)
+      : NO_EMOTES,
     sevenTvGlobalEmotes: preferences.show7TvEmotes
-      ? (cache.sevenTvGlobalEmotes ?? [])
-      : [],
+      ? (cache.sevenTvGlobalEmotes ?? NO_EMOTES)
+      : NO_EMOTES,
     ffzChannelEmotes: preferences.showFFzEmotes
-      ? (cache.ffzChannelEmotes ?? [])
-      : [],
+      ? (cache.ffzChannelEmotes ?? NO_EMOTES)
+      : NO_EMOTES,
     ffzGlobalEmotes: preferences.showFFzEmotes
-      ? (cache.ffzGlobalEmotes ?? [])
-      : [],
+      ? (cache.ffzGlobalEmotes ?? NO_EMOTES)
+      : NO_EMOTES,
     bttvGlobalEmotes: preferences.showBttvEmotes
-      ? (cache.bttvGlobalEmotes ?? [])
-      : [],
+      ? (cache.bttvGlobalEmotes ?? NO_EMOTES)
+      : NO_EMOTES,
     bttvChannelEmotes: preferences.showBttvEmotes
-      ? (cache.bttvChannelEmotes ?? [])
-      : [],
+      ? (cache.bttvChannelEmotes ?? NO_EMOTES)
+      : NO_EMOTES,
     twitchChannelBadges: preferences.showTwitchBadges
-      ? (cache.twitchChannelBadges ?? [])
-      : [],
+      ? (cache.twitchChannelBadges ?? NO_BADGES)
+      : NO_BADGES,
     twitchGlobalBadges: preferences.showTwitchBadges
-      ? (cache.twitchGlobalBadges ?? [])
-      : [],
+      ? (cache.twitchGlobalBadges ?? NO_BADGES)
+      : NO_BADGES,
     ffzChannelBadges: preferences.showFFzBadges
-      ? (cache.ffzChannelBadges ?? [])
-      : [],
+      ? (cache.ffzChannelBadges ?? NO_BADGES)
+      : NO_BADGES,
     ffzGlobalBadges: preferences.showFFzBadges
-      ? (cache.ffzGlobalBadges ?? [])
-      : [],
+      ? (cache.ffzGlobalBadges ?? NO_BADGES)
+      : NO_BADGES,
     chatterinoBadges: preferences.showChatterinoEmotes
-      ? (cache.chatterinoBadges ?? [])
-      : [],
+      ? getChatterinoBadges()
+      : NO_BADGES,
   };
 };
 

--- a/src/store/chat/actions/channelLoad.ts
+++ b/src/store/chat/actions/channelLoad.ts
@@ -499,6 +499,7 @@ const loadChannelResourcesInternal = async (
     const emoteSpecs = buildEmoteResourceSpecs({
       channelId,
       sevenTvSetId: sevenTvSetIdPromise,
+      sevenTvSetIdFallback: fallbackSevenTvSetId,
       twitchUserId,
     });
     const badgeSpecs = buildBadgeResourceSpecs({ channelId });

--- a/src/store/chat/actions/channelLoad.ts
+++ b/src/store/chat/actions/channelLoad.ts
@@ -27,6 +27,7 @@ import {
   buildBadgeResourceSpecs,
   buildEmoteResourceSpecs,
   buildSubscriberEmoteSpec,
+  clearGlobalResourceCache,
   combineUniqueById,
   deduplicateById,
   type EmoteResourceSets,
@@ -299,6 +300,9 @@ const loadChannelResourcesInternal = async (
     // set must forget those users or fetchUserPersonalEmotes short-circuits
     // into the emptied cache until the channel is left and re-entered.
     clearPersonalEmotesCache();
+    // An explicit refresh should re-download global provider data too, not
+    // serve it from the session cache.
+    clearGlobalResourceCache();
   }
   try {
     const caches = chatStore$.persisted.channelCaches.peek();
@@ -472,30 +476,29 @@ const loadChannelResourcesInternal = async (
       return false;
     }
 
-    let sevenTvSetId = existingCache?.sevenTvEmoteSetId ?? 'global';
-
-    try {
-      sevenTvSetId = await sevenTvService.getEmoteSetId(channelId);
-    } catch (error) {
-      logger.chat.warn('Failed to resolve 7TV emote set ID', {
-        name: 'seven_tv_emotes_warning',
-        error,
-        action: 'emote_set_id_failed',
-        channel_id: channelId,
-        provider: 'seven_tv',
-        resource_type: 'emotes',
-        scope: 'channel',
-        screen: 'chat',
+    // Only the 7TV channel-emote fetch needs the set id, so resolve it as a
+    // promise the spec awaits internally — the other 13 resource fetches
+    // start immediately instead of stalling a full round trip behind it.
+    const fallbackSevenTvSetId = existingCache?.sevenTvEmoteSetId ?? 'global';
+    const sevenTvSetIdPromise = sevenTvService
+      .getEmoteSetId(channelId)
+      .catch((error: unknown) => {
+        logger.chat.warn('Failed to resolve 7TV emote set ID', {
+          name: 'seven_tv_emotes_warning',
+          error,
+          action: 'emote_set_id_failed',
+          channel_id: channelId,
+          provider: 'seven_tv',
+          resource_type: 'emotes',
+          scope: 'channel',
+          screen: 'chat',
+        });
+        return fallbackSevenTvSetId;
       });
-    }
-
-    if (exitIfAborted(signal, true)) {
-      return false;
-    }
 
     const emoteSpecs = buildEmoteResourceSpecs({
       channelId,
-      sevenTvSetId,
+      sevenTvSetId: sevenTvSetIdPromise,
       twitchUserId,
     });
     const badgeSpecs = buildBadgeResourceSpecs({ channelId });
@@ -513,6 +516,10 @@ const loadChannelResourcesInternal = async (
     if (exitIfAborted(signal, true)) {
       return false;
     }
+
+    // Settled (or about to settle behind the same client timeout) by the time
+    // the resource fetches above have finished.
+    const sevenTvSetId = await sevenTvSetIdPromise;
 
     reportResourceResults({
       channelId,
@@ -697,6 +704,7 @@ export const clearCache = (channelId?: string) => {
       chatStore$.currentChannelId.set(null);
       chatStore$.loadingState.set('IDLE');
     });
+    clearGlobalResourceCache();
   }
 };
 
@@ -718,6 +726,7 @@ export const clearChatCosmeticsCache = (): void => {
   clearPersonalEmotesCache();
   clearSubscriberProfilesCache();
   clearEmoteImageCache();
+  clearGlobalResourceCache();
   void clearChatStorePersistence();
 };
 

--- a/src/store/chat/actions/channelResources.ts
+++ b/src/store/chat/actions/channelResources.ts
@@ -86,6 +86,42 @@ export const combineUniqueById = <T extends Identifiable>(
   ...itemGroups: readonly T[][]
 ): T[] => deduplicateById(itemGroups.flat());
 
+/**
+ * Global (channel-independent) provider data is identical for every channel,
+ * so re-downloading it on each channel join wastes a round trip per provider.
+ * Cache the successful fetch per session with a TTL matching the cached-path
+ * badge refresh window; failures are never cached, so the next join retries.
+ */
+const GLOBAL_RESOURCE_TTL_MS = 60 * 60 * 1000;
+
+const globalResourceCache = new Map<
+  string,
+  { fetchedAt: number; promise: Promise<Identifiable[]> }
+>();
+
+export const clearGlobalResourceCache = (): void => {
+  globalResourceCache.clear();
+};
+
+const fetchGlobalResourceOnce = <T extends Identifiable>(
+  key: string,
+  fetcher: () => Promise<T[]>,
+): Promise<T[]> => {
+  const now = Date.now();
+  const cached = globalResourceCache.get(key);
+  if (cached && now - cached.fetchedAt < GLOBAL_RESOURCE_TTL_MS) {
+    return cached.promise as Promise<T[]>;
+  }
+  const promise = fetcher().catch((error: unknown) => {
+    if (globalResourceCache.get(key)?.promise === promise) {
+      globalResourceCache.delete(key);
+    }
+    throw error;
+  });
+  globalResourceCache.set(key, { fetchedAt: now, promise });
+  return promise as Promise<T[]>;
+};
+
 export const buildSubscriberEmoteSpec = ({
   channelId,
   twitchUserId,
@@ -112,7 +148,12 @@ export const buildEmoteResourceSpecs = ({
   twitchUserId,
 }: {
   channelId: string;
-  sevenTvSetId: string;
+  /**
+   * Only the 7TV channel-emote fetch depends on the set id, so it may be
+   * passed as a pending promise — every other resource fetch starts
+   * immediately instead of waiting a full round trip behind the id lookup.
+   */
+  sevenTvSetId: string | Promise<string>;
   twitchUserId?: string;
 }): EmoteResourceSpec[] => [
   {
@@ -123,7 +164,7 @@ export const buildEmoteResourceSpecs = ({
     resourceType: 'emotes',
     scope: 'channel',
     warningName: 'seven_tv_emotes_warning',
-    fetch: () => sevenTvService.getSanitisedEmoteSet(sevenTvSetId),
+    fetch: async () => sevenTvService.getSanitisedEmoteSet(await sevenTvSetId),
   },
   {
     key: 'sevenTvGlobalEmotes',
@@ -133,7 +174,10 @@ export const buildEmoteResourceSpecs = ({
     resourceType: 'emotes',
     scope: 'global',
     warningName: 'seven_tv_emotes_warning',
-    fetch: () => sevenTvService.getSanitisedEmoteSet('global'),
+    fetch: () =>
+      fetchGlobalResourceOnce('seven_tv_global_emotes', () =>
+        sevenTvService.getSanitisedEmoteSet('global'),
+      ),
   },
   {
     key: 'twitchChannelEmotes',
@@ -153,7 +197,10 @@ export const buildEmoteResourceSpecs = ({
     resourceType: 'emotes',
     scope: 'global',
     warningName: 'twitch_emotes_warning',
-    fetch: () => twitchEmoteService.getGlobalEmotes(),
+    fetch: () =>
+      fetchGlobalResourceOnce('twitch_global_emotes', () =>
+        twitchEmoteService.getGlobalEmotes(),
+      ),
   },
   buildSubscriberEmoteSpec({ channelId, twitchUserId }),
   {
@@ -164,7 +211,10 @@ export const buildEmoteResourceSpecs = ({
     resourceType: 'emotes',
     scope: 'global',
     warningName: 'bttv_emotes_warning',
-    fetch: () => bttvEmoteService.getSanitisedGlobalEmotes(),
+    fetch: () =>
+      fetchGlobalResourceOnce('bttv_global_emotes', () =>
+        bttvEmoteService.getSanitisedGlobalEmotes(),
+      ),
   },
   {
     key: 'bttvChannelEmotes',
@@ -194,7 +244,10 @@ export const buildEmoteResourceSpecs = ({
     resourceType: 'emotes',
     scope: 'global',
     warningName: 'ffz_emotes_warning',
-    fetch: () => ffzService.getSanitisedGlobalEmotes(),
+    fetch: () =>
+      fetchGlobalResourceOnce('ffz_global_emotes', () =>
+        ffzService.getSanitisedGlobalEmotes(),
+      ),
   },
 ];
 
@@ -221,7 +274,10 @@ export const buildBadgeResourceSpecs = ({
     resourceType: 'badges',
     scope: 'global',
     warningName: 'twitch_badges_warning',
-    fetch: () => twitchBadgeService.listSanitisedGlobalBadges(),
+    fetch: () =>
+      fetchGlobalResourceOnce('twitch_global_badges', () =>
+        twitchBadgeService.listSanitisedGlobalBadges(),
+      ),
   },
   {
     key: 'ffzGlobalBadges',
@@ -231,7 +287,10 @@ export const buildBadgeResourceSpecs = ({
     resourceType: 'badges',
     scope: 'global',
     warningName: 'ffz_badges_warning',
-    fetch: () => ffzService.getSanitisedGlobalBadges(),
+    fetch: () =>
+      fetchGlobalResourceOnce('ffz_global_badges', () =>
+        ffzService.getSanitisedGlobalBadges(),
+      ),
   },
   {
     key: 'ffzChannelBadges',

--- a/src/store/chat/actions/channelResources.ts
+++ b/src/store/chat/actions/channelResources.ts
@@ -142,9 +142,19 @@ export const buildSubscriberEmoteSpec = ({
       : Promise.resolve([]),
 });
 
+/**
+ * Cap on how much of the overall resource-fetch timeout the 7TV set-id lookup
+ * may consume when `sevenTvSetId` is still pending. Without this, a slow id
+ * lookup could eat the whole `RESOURCE_FETCH_TIMEOUT_MS` window and leave no
+ * time for the actual emote-set fetch, timing it out for a reason unrelated
+ * to the emote-set request itself.
+ */
+export const SEVEN_TV_SET_ID_LOOKUP_BUDGET_MS = 3000;
+
 export const buildEmoteResourceSpecs = ({
   channelId,
   sevenTvSetId,
+  sevenTvSetIdFallback = 'global',
   twitchUserId,
 }: {
   channelId: string;
@@ -154,6 +164,12 @@ export const buildEmoteResourceSpecs = ({
    * immediately instead of waiting a full round trip behind the id lookup.
    */
   sevenTvSetId: string | Promise<string>;
+  /**
+   * Used if `sevenTvSetId` is still pending after
+   * `SEVEN_TV_SET_ID_LOOKUP_BUDGET_MS`, so the lookup can't consume the
+   * emote-set fetch's whole timeout budget.
+   */
+  sevenTvSetIdFallback?: string;
   twitchUserId?: string;
 }): EmoteResourceSpec[] => [
   {
@@ -164,7 +180,18 @@ export const buildEmoteResourceSpecs = ({
     resourceType: 'emotes',
     scope: 'channel',
     warningName: 'seven_tv_emotes_warning',
-    fetch: async () => sevenTvService.getSanitisedEmoteSet(await sevenTvSetId),
+    fetch: async () => {
+      const resolvedSetId = await Promise.race([
+        Promise.resolve(sevenTvSetId),
+        new Promise<string>(resolve => {
+          setTimeout(
+            () => resolve(sevenTvSetIdFallback),
+            SEVEN_TV_SET_ID_LOOKUP_BUDGET_MS,
+          );
+        }),
+      ]);
+      return sevenTvService.getSanitisedEmoteSet(resolvedSetId);
+    },
   },
   {
     key: 'sevenTvGlobalEmotes',

--- a/src/store/chat/actions/channelResources.ts
+++ b/src/store/chat/actions/channelResources.ts
@@ -1,6 +1,5 @@
 import type { MonitoringWarningName } from '@app/lib/sentry';
 import { bttvEmoteService } from '@app/services/bttv-emote-service';
-import { chatterinoService } from '@app/services/chatterino-service';
 import { ffzService } from '@app/services/ffz-service';
 import { sevenTvService } from '@app/services/seventv-service';
 import { twitchBadgeService } from '@app/services/twitch-badge-service';
@@ -11,8 +10,7 @@ import { logger } from '@app/utils/logger';
 
 import type { ChannelCacheType } from '../types/constants';
 
-export type ProviderName =
-  'bttv' | 'chatterino' | 'ffz' | 'seven_tv' | 'twitch';
+export type ProviderName = 'bttv' | 'ffz' | 'seven_tv' | 'twitch';
 export type ProviderResourceScope = 'channel' | 'global' | 'local' | 'personal';
 export type ProviderResourceType = 'badges' | 'emotes';
 
@@ -56,7 +54,6 @@ export type EmoteCacheKey =
   | 'twitchSubscriberEmotes';
 
 export type BadgeCacheKey =
-  | 'chatterinoBadges'
   | 'ffzChannelBadges'
   | 'ffzGlobalBadges'
   | 'twitchChannelBadges'
@@ -328,16 +325,6 @@ export const buildBadgeResourceSpecs = ({
     scope: 'channel',
     warningName: 'ffz_badges_warning',
     fetch: () => ffzService.getSanitisedChannelBadges(channelId),
-  },
-  {
-    key: 'chatterinoBadges',
-    name: 'chatterino_badges',
-    label: 'Chatterino badges',
-    provider: 'chatterino',
-    resourceType: 'badges',
-    scope: 'local',
-    warningName: 'chatterino_badges_warning',
-    fetch: () => Promise.resolve(chatterinoService.listSanitisedBadges()),
   },
 ];
 

--- a/src/store/chat/actions/chatColorCaches.ts
+++ b/src/store/chat/actions/chatColorCaches.ts
@@ -90,6 +90,7 @@ export function clearSessionCache(bucket?: SessionCacheBucket): void {
   chatStore$.sessionCaches.set({
     mentionColors: {},
     lightenedColors: {},
+    userPaintFlags: chatStore$.sessionCaches.userPaintFlags.peek(),
   });
 }
 

--- a/src/store/chat/actions/cosmetics.ts
+++ b/src/store/chat/actions/cosmetics.ts
@@ -267,13 +267,45 @@ export const getPaint = (paintId: string): PaintData | undefined =>
 const getUserPaintId = (ttvUserId: string): string | undefined =>
   chatStore$.userPaintIds[ttvUserId]?.peek();
 
+let userPaintFlagInvalidatorAttached = false;
+
+/**
+ * getChatRowItemType calls `hasUserPaint` once per visible row on every list
+ * data change, so the paints/userPaintIds traversal below is cached per user
+ * id and cleared wholesale whenever either map changes structurally.
+ */
+function ensureUserPaintFlagInvalidator(): void {
+  if (userPaintFlagInvalidatorAttached) {
+    return;
+  }
+  userPaintFlagInvalidatorAttached = true;
+  const clear = () => chatStore$.sessionCaches.userPaintFlags.set({});
+  chatStore$.userPaintIds.onChange(clear);
+  chatStore$.paints.onChange(clear);
+}
+
 export const hasUserPaint = (ttvUserId?: string): boolean => {
   if (!ttvUserId) {
     return false;
   }
 
+  ensureUserPaintFlagInvalidator();
+
+  const cached = chatStore$.sessionCaches.userPaintFlags[ttvUserId]?.peek();
+  if (cached !== undefined) {
+    return cached;
+  }
+
   const paintId = getUserPaintId(ttvUserId);
-  return Boolean(paintId && getPaint(paintId));
+  const result = Boolean(paintId && getPaint(paintId));
+
+  const flags = chatStore$.sessionCaches.userPaintFlags;
+  if (Object.keys(flags.peek()).length >= MAX_COSMETIC_ENTRIES) {
+    flags.set({});
+  }
+  flags[ttvUserId]?.set(result);
+
+  return result;
 };
 
 export const addBadge = (badge: SanitisedBadgeSet) => {

--- a/src/store/chat/actions/messages.ts
+++ b/src/store/chat/actions/messages.ts
@@ -339,8 +339,11 @@ const syncRecentMessagesForCurrentChannel = (
     return;
   }
 
+  // Hold the reference only — persistRecentMessagesForChannel slices to
+  // MAX_RECENT_MESSAGES at flush time, so slicing here on every deferred
+  // sync (~10/s under load) would be redundant allocation.
   pendingRecentMessagesChannelId = currentChannelId;
-  pendingRecentMessages = nextMessages.slice(-MAX_RECENT_MESSAGES);
+  pendingRecentMessages = nextMessages;
 
   if (recentMessagesSyncTimer) {
     return;

--- a/src/store/chat/observables/chatStore.ts
+++ b/src/store/chat/observables/chatStore.ts
@@ -196,7 +196,10 @@ const hydrateDeferredChatState = () => {
 InteractionManager.runAfterInteractions(hydrateDeferredChatState);
 
 // Recent messages used to live inside `persisted`; drop the stale field from
-// old installs so channelCaches writes stop re-serializing it.
+// old installs so channelCaches writes stop re-serializing it. Chatterino
+// badges likewise used to be stored per channel (~4,100 entries each) but are
+// now resolved from the bundled table at read time; strip them from old
+// caches so every future channelCaches write stops re-serializing them.
 when(persistedState$?._state?.isLoadedLocal, () => {
   const persisted = chatStore$.persisted.peek() as {
     recentMessagesByChannel?: unknown;
@@ -207,6 +210,25 @@ when(persistedState$?._state?.isLoadedLocal, () => {
         recentMessagesByChannel: { delete: () => void };
       }
     ).recentMessagesByChannel.delete();
+  }
+
+  const caches = chatStore$.persisted.channelCaches.peek() ?? {};
+  const staleChannelIds: string[] = [];
+  for (const [id, cache] of Object.entries(caches)) {
+    if ('chatterinoBadges' in cache) {
+      staleChannelIds.push(id);
+    }
+  }
+  if (staleChannelIds.length > 0) {
+    batch(() => {
+      for (const id of staleChannelIds) {
+        (
+          chatStore$.persisted.channelCaches[id] as unknown as {
+            chatterinoBadges: { delete: () => void };
+          }
+        ).chatterinoBadges.delete();
+      }
+    });
   }
 });
 

--- a/src/store/chat/observables/chatStore.ts
+++ b/src/store/chat/observables/chatStore.ts
@@ -51,6 +51,10 @@ export interface ChatStoreState {
   sessionCaches: {
     mentionColors: Record<string, { value: string; expiresAt: number }>;
     lightenedColors: Record<string, { value: string; expiresAt: number }>;
+    // getChatRowItemType runs per row on every list data change; caching the
+    // two-peek paints/userPaintIds traversal per user avoids re-walking those
+    // observables for every row on every render.
+    userPaintFlags: Record<string, boolean>;
   };
   sharedChatBadgeCaches: {
     sourceBadges: Record<
@@ -111,6 +115,7 @@ const initialChatStoreState: ChatStoreState = {
   sessionCaches: {
     mentionColors: {},
     lightenedColors: {},
+    userPaintFlags: {},
   },
   sharedChatBadgeCaches: {
     sourceBadges: {},
@@ -150,14 +155,28 @@ const hydrateDeferredChatState = () => {
   // Rehydrate the 7TV cosmetic maps from the previous session's MMKV snapshot
   // so paints/badges render on launch instead of waiting for the event API to
   // re-stream every entitlement. The websocket still corrects and extends
-  // this live (create/update/delete).
+  // this live (create/update/delete). It can also outrace this deferred
+  // hydration, so in-memory entries win over the snapshot, same as the
+  // recent-messages hydration below.
   const persistedCosmetics = loadPersistedCosmetics();
   if (persistedCosmetics) {
     batch(() => {
-      chatStore$.paints.set(persistedCosmetics.paints);
-      chatStore$.badges.set(persistedCosmetics.badges);
-      chatStore$.userPaintIds.set(persistedCosmetics.userPaintIds);
-      chatStore$.userBadgeIds.set(persistedCosmetics.userBadgeIds);
+      chatStore$.paints.set({
+        ...persistedCosmetics.paints,
+        ...chatStore$.paints.peek(),
+      });
+      chatStore$.badges.set({
+        ...persistedCosmetics.badges,
+        ...chatStore$.badges.peek(),
+      });
+      chatStore$.userPaintIds.set({
+        ...persistedCosmetics.userPaintIds,
+        ...chatStore$.userPaintIds.peek(),
+      });
+      chatStore$.userBadgeIds.set({
+        ...persistedCosmetics.userBadgeIds,
+        ...chatStore$.userBadgeIds.peek(),
+      });
     });
   }
 

--- a/src/store/chat/observables/chatStore.ts
+++ b/src/store/chat/observables/chatStore.ts
@@ -1,3 +1,5 @@
+import { InteractionManager } from 'react-native';
+
 import { batch, observable, when } from '@legendapp/state';
 import { persistObservable } from '@legendapp/state/persist';
 
@@ -94,7 +96,10 @@ const initialChatStoreState: ChatStoreState = {
   recentMessagesByChannel: {},
   loadingState: 'IDLE',
   currentChannelId: null,
-  emojis: getEmojiEmotes(getPreferences().emojiStyle),
+  // Seeded empty and hydrated after first interactions — building the full
+  // emoji emote set is thousands of allocations and this module loads with
+  // the root layout, before the first chat screen can possibly need it.
+  emojis: [],
   bits: [],
   messages: [],
   mentionLoginRevision: 0,
@@ -117,36 +122,59 @@ ensureObservablePersistenceConfig();
 
 export const chatStore$ = observable<ChatStoreState>(initialChatStoreState);
 
-// Rehydrate the 7TV cosmetic maps from the previous session's MMKV snapshot so
-// paints/badges render immediately on launch instead of waiting for the event
-// API to re-stream every entitlement. The websocket still corrects and extends
-// this live (create/update/delete).
-const persistedCosmetics = loadPersistedCosmetics();
-if (persistedCosmetics) {
-  batch(() => {
-    chatStore$.paints.set(persistedCosmetics.paints);
-    chatStore$.badges.set(persistedCosmetics.badges);
-    chatStore$.userPaintIds.set(persistedCosmetics.userPaintIds);
-    chatStore$.userBadgeIds.set(persistedCosmetics.userBadgeIds);
-  });
-}
-
 const persistedState$ = persistObservable(chatStore$.persisted, {
   local: createObservablePersistenceLocalConfig(CHAT_STORE_PERSISTENCE_KEY),
 });
 
-if (RECENT_MESSAGES_PERSISTENCE_ENABLED) {
-  // Native: seed from the per-channel MMKV keys (writes are handled per-channel
-  // in the message-sync path, not via Legend State, so a sync only re-serializes
-  // the active channel instead of every cached channel — issue #594).
-  chatStore$.recentMessagesByChannel.set(loadPersistedRecentMessages());
-} else {
+if (!RECENT_MESSAGES_PERSISTENCE_ENABLED) {
   persistObservable(chatStore$.recentMessagesByChannel, {
     local: createObservablePersistenceLocalConfig(
       CHAT_RECENT_MESSAGES_PERSISTENCE_KEY,
     ),
   });
 }
+
+/**
+ * Chat-only hydration deferred off the startup critical path: the emoji emote
+ * set, the 7TV cosmetics snapshot, and the per-channel recent-message caches
+ * are all pure JS-thread work (allocation plus blocking MMKV `JSON.parse`)
+ * for screens the app does not boot into — the entry route redirects to the
+ * stream tabs, not chat. Runs after first interactions, well before a user
+ * can navigate into a chat.
+ */
+const hydrateDeferredChatState = () => {
+  if (chatStore$.emojis.peek().length === 0) {
+    chatStore$.emojis.set(getEmojiEmotes(getPreferences().emojiStyle));
+  }
+
+  // Rehydrate the 7TV cosmetic maps from the previous session's MMKV snapshot
+  // so paints/badges render on launch instead of waiting for the event API to
+  // re-stream every entitlement. The websocket still corrects and extends
+  // this live (create/update/delete).
+  const persistedCosmetics = loadPersistedCosmetics();
+  if (persistedCosmetics) {
+    batch(() => {
+      chatStore$.paints.set(persistedCosmetics.paints);
+      chatStore$.badges.set(persistedCosmetics.badges);
+      chatStore$.userPaintIds.set(persistedCosmetics.userPaintIds);
+      chatStore$.userBadgeIds.set(persistedCosmetics.userBadgeIds);
+    });
+  }
+
+  if (RECENT_MESSAGES_PERSISTENCE_ENABLED) {
+    // Native: seed from the per-channel MMKV keys (writes are handled
+    // per-channel in the message-sync path, not via Legend State, so a sync
+    // only re-serializes the active channel instead of every cached channel —
+    // issue #594). Channels already live in memory win over the snapshot in
+    // case a chat was joined before this deferred hydration ran.
+    chatStore$.recentMessagesByChannel.set({
+      ...loadPersistedRecentMessages(),
+      ...chatStore$.recentMessagesByChannel.peek(),
+    });
+  }
+};
+
+InteractionManager.runAfterInteractions(hydrateDeferredChatState);
 
 // Recent messages used to live inside `persisted`; drop the stale field from
 // old installs so channelCaches writes stop re-serializing it.

--- a/src/store/chat/react/selectors.ts
+++ b/src/store/chat/react/selectors.ts
@@ -1,11 +1,13 @@
 import { useSelector } from '@legendapp/state/react';
 
 import { useEmoteRenderPreferences } from '@app/store/preferences/selectors';
+import { getChatterinoBadges } from '@app/utils/chat/chatterinoBadges';
 
 import { chatStore$ } from '../observables/chatStore';
 import {
   type ChannelCacheType,
   emptyEmoteData,
+  emptyResolvedEmoteData,
   type SanitisedBadgeSet,
   type SanitisedEmote,
 } from '../types/constants';
@@ -13,7 +15,7 @@ import {
 export const useMessages = () => useSelector(chatStore$.messages);
 export const useEmojis = () => useSelector(chatStore$.emojis);
 
-type ChannelEmoteData = Pick<
+type ChannelEmoteCache = Pick<
   ChannelCacheType,
   | 'twitchChannelEmotes'
   | 'twitchGlobalEmotes'
@@ -30,8 +32,11 @@ type ChannelEmoteData = Pick<
   | 'twitchGlobalBadges'
   | 'ffzChannelBadges'
   | 'ffzGlobalBadges'
-  | 'chatterinoBadges'
 >;
+
+type ChannelEmoteData = ChannelEmoteCache & {
+  chatterinoBadges: SanitisedBadgeSet[];
+};
 
 const EMPTY_EMOTES: SanitisedEmote[] = [];
 const EMPTY_BADGES: SanitisedBadgeSet[] = [];
@@ -41,23 +46,23 @@ const EMPTY_SUBSCRIBER_PROFILES: NonNullable<
 const EMPTY_PERSONAL_EMOTES: ChannelCacheType['sevenTvPersonalEmotes'] = {};
 
 function resolveEmoteData(
-  cache: ChannelEmoteData | undefined,
+  cache: ChannelEmoteCache | undefined,
   preferences: ReturnType<typeof useEmoteRenderPreferences>,
 ): ChannelEmoteData {
   if (!cache) {
-    return emptyEmoteData;
+    return emptyResolvedEmoteData;
   }
 
   return {
     twitchChannelEmotes: preferences.showTwitchEmotes
-      ? (cache.twitchChannelEmotes ?? [])
-      : [],
+      ? (cache.twitchChannelEmotes ?? EMPTY_EMOTES)
+      : EMPTY_EMOTES,
     twitchGlobalEmotes: preferences.showTwitchEmotes
-      ? (cache.twitchGlobalEmotes ?? [])
-      : [],
+      ? (cache.twitchGlobalEmotes ?? EMPTY_EMOTES)
+      : EMPTY_EMOTES,
     twitchSubscriberEmotes: preferences.showTwitchEmotes
-      ? (cache.twitchSubscriberEmotes ?? [])
-      : [],
+      ? (cache.twitchSubscriberEmotes ?? EMPTY_EMOTES)
+      : EMPTY_EMOTES,
     twitchSubscriberChannelProfiles: preferences.showTwitchEmotes
       ? (cache.twitchSubscriberChannelProfiles ?? EMPTY_SUBSCRIBER_PROFILES)
       : EMPTY_SUBSCRIBER_PROFILES,
@@ -65,42 +70,42 @@ function resolveEmoteData(
       ? (cache.sevenTvPersonalEmotes ?? EMPTY_PERSONAL_EMOTES)
       : EMPTY_PERSONAL_EMOTES,
     sevenTvChannelEmotes: preferences.show7TvEmotes
-      ? (cache.sevenTvChannelEmotes ?? [])
-      : [],
+      ? (cache.sevenTvChannelEmotes ?? EMPTY_EMOTES)
+      : EMPTY_EMOTES,
     sevenTvGlobalEmotes: preferences.show7TvEmotes
-      ? (cache.sevenTvGlobalEmotes ?? [])
-      : [],
+      ? (cache.sevenTvGlobalEmotes ?? EMPTY_EMOTES)
+      : EMPTY_EMOTES,
     ffzChannelEmotes: preferences.showFFzEmotes
-      ? (cache.ffzChannelEmotes ?? [])
-      : [],
+      ? (cache.ffzChannelEmotes ?? EMPTY_EMOTES)
+      : EMPTY_EMOTES,
     ffzGlobalEmotes: preferences.showFFzEmotes
-      ? (cache.ffzGlobalEmotes ?? [])
-      : [],
+      ? (cache.ffzGlobalEmotes ?? EMPTY_EMOTES)
+      : EMPTY_EMOTES,
     bttvGlobalEmotes: preferences.showBttvEmotes
-      ? (cache.bttvGlobalEmotes ?? [])
-      : [],
+      ? (cache.bttvGlobalEmotes ?? EMPTY_EMOTES)
+      : EMPTY_EMOTES,
     bttvChannelEmotes: preferences.showBttvEmotes
-      ? (cache.bttvChannelEmotes ?? [])
-      : [],
+      ? (cache.bttvChannelEmotes ?? EMPTY_EMOTES)
+      : EMPTY_EMOTES,
     twitchChannelBadges: preferences.showTwitchBadges
-      ? (cache.twitchChannelBadges ?? [])
-      : [],
+      ? (cache.twitchChannelBadges ?? EMPTY_BADGES)
+      : EMPTY_BADGES,
     twitchGlobalBadges: preferences.showTwitchBadges
-      ? (cache.twitchGlobalBadges ?? [])
-      : [],
+      ? (cache.twitchGlobalBadges ?? EMPTY_BADGES)
+      : EMPTY_BADGES,
     ffzChannelBadges: preferences.showFFzBadges
-      ? (cache.ffzChannelBadges ?? [])
-      : [],
+      ? (cache.ffzChannelBadges ?? EMPTY_BADGES)
+      : EMPTY_BADGES,
     ffzGlobalBadges: preferences.showFFzBadges
-      ? (cache.ffzGlobalBadges ?? [])
-      : [],
+      ? (cache.ffzGlobalBadges ?? EMPTY_BADGES)
+      : EMPTY_BADGES,
     chatterinoBadges: preferences.showChatterinoEmotes
-      ? (cache.chatterinoBadges ?? [])
-      : [],
+      ? getChatterinoBadges()
+      : EMPTY_BADGES,
   };
 }
 
-function getChannelEmoteData(channelId: string | null): ChannelEmoteData {
+function getChannelEmoteData(channelId: string | null): ChannelEmoteCache {
   if (!channelId) {
     return emptyEmoteData;
   }
@@ -127,7 +132,6 @@ function getChannelEmoteData(channelId: string | null): ChannelEmoteData {
     twitchGlobalBadges: cache$?.twitchGlobalBadges.get() ?? EMPTY_BADGES,
     ffzChannelBadges: cache$?.ffzChannelBadges.get() ?? EMPTY_BADGES,
     ffzGlobalBadges: cache$?.ffzGlobalBadges.get() ?? EMPTY_BADGES,
-    chatterinoBadges: cache$?.chatterinoBadges.get() ?? EMPTY_BADGES,
   };
 }
 

--- a/src/store/chat/types/constants.ts
+++ b/src/store/chat/types/constants.ts
@@ -161,7 +161,6 @@ export interface ChannelCacheType {
   twitchGlobalBadges: SanitisedBadgeSet[];
   ffzGlobalBadges: SanitisedBadgeSet[];
   ffzChannelBadges: SanitisedBadgeSet[];
-  chatterinoBadges: SanitisedBadgeSet[];
   sevenTvEmoteSetId?: string;
   badgesLastUpdated?: number;
 }
@@ -194,5 +193,14 @@ export const emptyEmoteData = {
   lastUpdated: 0,
   badgesLastUpdated: 0,
   sevenTvEmoteSetId: undefined,
-  chatterinoBadges: [],
 } satisfies ChannelCacheType;
+
+/**
+ * Consumer-facing emote-data shape: channel-cache fields plus the
+ * chatterinoBadges set, which is resolved from the bundled table at read time
+ * rather than stored per channel.
+ */
+export const emptyResolvedEmoteData = {
+  ...emptyEmoteData,
+  chatterinoBadges: [] as SanitisedBadgeSet[],
+};

--- a/src/store/preferences/selectors.ts
+++ b/src/store/preferences/selectors.ts
@@ -102,13 +102,17 @@ export function usePreference<K extends keyof Preferences>(
   return useSelector(() => preferences$[key].get()) as Preferences[K];
 }
 
+function updatePreferences(payload: Partial<Preferences>): void {
+  preferences$.assign({
+    ...payload,
+    updatedAt: Date.now(),
+  });
+}
+
+// A stable module-level function reference (preferences$ never changes), so
+// callers that pass this through memo()'d children keep their bailout.
 export function useUpdatePreferences(): (
   payload: Partial<Preferences>,
 ) => void {
-  return (payload: Partial<Preferences>) => {
-    preferences$.assign({
-      ...payload,
-      updatedAt: Date.now(),
-    });
-  };
+  return updatePreferences;
 }

--- a/src/utils/chat/chatterinoBadges.ts
+++ b/src/utils/chat/chatterinoBadges.ts
@@ -1,0 +1,9 @@
+import { chatterinoService } from '@app/services/chatterino-service';
+import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
+
+let cachedBadges: SanitisedBadgeSet[] | null = null;
+
+export function getChatterinoBadges(): SanitisedBadgeSet[] {
+  cachedBadges ??= chatterinoService.listSanitisedBadges();
+  return cachedBadges;
+}

--- a/src/utils/chat/extractEmotes.ts
+++ b/src/utils/chat/extractEmotes.ts
@@ -9,6 +9,8 @@ function toTwitchTaggedEmoteUrl(
   return `https://static-cdn.jtvnw.net/emoticons/v2/${emoteId}/${format}/dark/${scale}`;
 }
 
+const SURROGATE_PAIR_REGEX = /[\uD800-\uDFFF]/;
+
 const extractEmotes = (
   emotes: Record<string, string[]> | undefined,
   message: string,
@@ -16,7 +18,10 @@ const extractEmotes = (
   if (!emotes) {
     return [];
   }
-  const graphemes = [...message];
+  // The emotes tag indexes by code point. For the common all-BMP message a
+  // code-point index equals the UTF-16 index, so slice the string directly and
+  // only pay the full code-point expansion when surrogate pairs are present.
+  const graphemes = SURROGATE_PAIR_REGEX.test(message) ? [...message] : null;
   const imageVariantsByEmoteId = new Map<
     string,
     TwitchSanitisedEmote['image_variants']
@@ -26,7 +31,9 @@ const extractEmotes = (
     positions.map(position => {
       const [start, end] = position.split('-').map(Number);
 
-      const name = graphemes.slice(start, (end as number) + 1).join('');
+      const name = graphemes
+        ? graphemes.slice(start, (end as number) + 1).join('')
+        : message.slice(start, (end as number) + 1);
       let imageVariants = imageVariantsByEmoteId.get(emoteId);
       if (!imageVariants) {
         imageVariants = createEmoteImageVariants({

--- a/src/utils/chat/findBadges.ts
+++ b/src/utils/chat/findBadges.ts
@@ -67,19 +67,100 @@ const getRawTwitchBadges = (userstate: UserStateTags): string => {
   return userstate['badges-raw'] || '';
 };
 
+/**
+ * findBadges runs once per message (and again per visible message during 7TV
+ * hydration reprocessing), so linear scans over the badge arrays add up fast —
+ * the flattened Chatterino list alone holds thousands of entries, almost none
+ * of which match a given chatter. Index each array once per array identity
+ * (the arrays are stable until the channel's badge data is refetched) so every
+ * per-message lookup is a single Map hit.
+ */
+const badgeSetIndexCache = new WeakMap<
+  SanitisedBadgeSet[],
+  ReadonlyMap<string, SanitisedBadgeSet>
+>();
+
+const getBadgeSetIndex = (
+  badges: SanitisedBadgeSet[],
+): ReadonlyMap<string, SanitisedBadgeSet> => {
+  let index = badgeSetIndexCache.get(badges);
+  if (!index) {
+    const map = new Map<string, SanitisedBadgeSet>();
+    badges.forEach(badge => {
+      const key = `${badge.set}/${badge.id}`;
+      if (!map.has(key)) {
+        map.set(key, badge);
+      }
+    });
+    badgeSetIndexCache.set(badges, map);
+    index = map;
+  }
+  return index;
+};
+
+const badgeUserIdIndexCache = new WeakMap<
+  SanitisedBadgeSet[],
+  ReadonlyMap<string, SanitisedBadgeSet>
+>();
+
+const getBadgeUserIdIndex = (
+  badges: SanitisedBadgeSet[],
+): ReadonlyMap<string, SanitisedBadgeSet> => {
+  let index = badgeUserIdIndexCache.get(badges);
+  if (!index) {
+    const map = new Map<string, SanitisedBadgeSet>();
+    badges.forEach(badge => {
+      if (!map.has(badge.id)) {
+        map.set(badge.id, badge);
+      }
+    });
+    badgeUserIdIndexCache.set(badges, map);
+    index = map;
+  }
+  return index;
+};
+
+const badgeOwnerIndexCache = new WeakMap<
+  SanitisedBadgeSet[],
+  ReadonlyMap<string, SanitisedBadgeSet[]>
+>();
+
+const getBadgeOwnerIndex = (
+  badges: SanitisedBadgeSet[],
+): ReadonlyMap<string, SanitisedBadgeSet[]> => {
+  let index = badgeOwnerIndexCache.get(badges);
+  if (!index) {
+    const map = new Map<string, SanitisedBadgeSet[]>();
+    badges.forEach(badge => {
+      if (!badge.owner_username) {
+        return;
+      }
+      const existing = map.get(badge.owner_username);
+      if (existing) {
+        existing.push(badge);
+      } else {
+        map.set(badge.owner_username, [badge]);
+      }
+    });
+    badgeOwnerIndexCache.set(badges, map);
+    index = map;
+  }
+  return index;
+};
+
 const findTwitchChannelBadge = (
   twitchChannelBadges: SanitisedBadgeSet[],
   set: string,
   version: string,
 ): SanitisedBadgeSet | undefined =>
-  twitchChannelBadges.find(b => b.set === set && b.id === version);
+  getBadgeSetIndex(twitchChannelBadges).get(`${set}/${version}`);
 
 const findTwitchGlobalBadge = (
   twitchGlobalBadges: SanitisedBadgeSet[],
   set: string,
   version: string,
 ): SanitisedBadgeSet | undefined =>
-  twitchGlobalBadges.find(b => b.set === set && b.id === `${set}_${version}`);
+  getBadgeSetIndex(twitchGlobalBadges).get(`${set}/${set}_${version}`);
 
 export function findBadges({
   userstate,
@@ -123,9 +204,9 @@ export function findBadges({
     });
   }
 
-  const globalFfzBadges = ffzGlobalBadges.filter(
-    b => b.owner_username === userstate.username,
-  );
+  const globalFfzBadges = userstate.username
+    ? (getBadgeOwnerIndex(ffzGlobalBadges).get(userstate.username) ?? [])
+    : [];
 
   globalFfzBadges.forEach(b => {
     addBadgeIfMissing(badges, {
@@ -158,9 +239,9 @@ export function findBadges({
     }
   }
 
-  const chatterinoBadge = chatterinoBadges.find(
-    b => b.id === userstate['user-id'],
-  );
+  const chatterinoBadge = userstate['user-id']
+    ? getBadgeUserIdIndex(chatterinoBadges).get(userstate['user-id'])
+    : undefined;
 
   if (chatterinoBadge) {
     addBadgeIfMissing(badges, chatterinoBadge);


### PR DESCRIPTION
findBadges ran linear scans per message — the flattened Chatterino list
alone is ~3,500 entries walked for essentially every chatter. Index the
badge arrays once per array identity (WeakMap-cached Maps) so each
lookup is a single Map hit. extractEmotes now only expands the message
into code points when surrogate pairs are present, getItemType's paint
check caches per user id, and the deferred recent-messages sync no
longer slices the window on every flush.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JQZQfEGBojBALxBRjsCrCp