### PR TITLE
fix(infrastructure): drop invalid --depth=0 from ota base fetch

### DIFF
--- a/.github/workflows/ota-compatible.yml
+++ b/.github/workflows/ota-compatible.yml
@@ -45,7 +45,7 @@ jobs:
           if [ -n "${PR_BASE_SHA}" ]; then
             BASE_SHA="${PR_BASE_SHA}"
           else
-            git fetch --no-tags --depth=0 origin main
+            git fetch --no-tags origin main
             BASE_SHA="$(git merge-base HEAD origin/main)"
           fi
           echo "Base commit: ${BASE_SHA}"


### PR DESCRIPTION
## Problem

The `OTA compatibility check` job fails at **Create worktree for the base commit** with:

```
fatal: depth 0 is not a positive number
```

`git fetch --no-tags --depth=0 origin main` is invalid - git requires a shallow depth to be a positive integer. This path runs whenever `PR_BASE_SHA` is empty (e.g. `workflow_dispatch` runs).

## Fix

Drop `--depth=0`. The checkout step already uses `fetch-depth: 0` (a full, unshallow clone), so the base fetch never needed to be shallow. It's now a plain `git fetch --no-tags origin main`, which populates `origin/main` for the subsequent `git merge-base HEAD origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)