### PR TITLE
ci(infrastructure): run ota compat check on main push + add local ota:check script

### DIFF
--- a/.github/workflows/ota-compatible.yml
+++ b/.github/workflows/ota-compatible.yml
@@ -45,7 +45,7 @@ jobs:
           if [ -n "${PR_BASE_SHA}" ]; then
             BASE_SHA="${PR_BASE_SHA}"
           else
-            git fetch --no-tags --depth=0 origin main
+            git fetch --no-tags origin main
             BASE_SHA="$(git merge-base HEAD origin/main)"
           fi
           echo "Base commit: ${BASE_SHA}"

--- a/.github/workflows/ota-compatible.yml
+++ b/.github/workflows/ota-compatible.yml
@@ -1,25 +1,24 @@
 name: OTA compatibility check
 
-# Answers a single question for the current changes: can they ship as an OTA
-# update, or do they change the native fingerprint and therefore require a new
-# native build? Compares HEAD against main (the PR base on pull_request, the
-# merge-base with origin/main otherwise) using the same
-# `expo-updates fingerprint:generate` the deploy pipeline relies on. If the
-# fingerprint is identical for every variant/platform the changes are OTA
-# compatible; any difference means a native release is required.
+# Answers a single question for the changes just pushed to main: can they ship
+# as an OTA update, or do they change the native fingerprint and therefore
+# require a new native build? Compares the new main tip against the commit it
+# replaced using the same `expo-updates fingerprint:generate` the deploy
+# pipeline relies on. If the fingerprint is identical for every variant/platform
+# the changes are OTA compatible; any difference means a native release is
+# required.
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   ota-compatible:
@@ -42,11 +41,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -n "${PR_BASE_SHA}" ]; then
-            BASE_SHA="${PR_BASE_SHA}"
+          # On a push, github.event.before is the commit main pointed at before
+          # this push. It is all-zeroes for the very first push to a branch, so
+          # fall back to the previous commit in that case (and on
+          # workflow_dispatch, where the event carries no before SHA).
+          if [ -n "${PUSH_BEFORE_SHA}" ] && [ "${PUSH_BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then
+            BASE_SHA="${PUSH_BEFORE_SHA}"
           else
-            git fetch --no-tags origin main
-            BASE_SHA="$(git merge-base HEAD origin/main)"
+            BASE_SHA="$(git rev-parse HEAD^)"
           fi
           echo "Base commit: ${BASE_SHA}"
           echo "BASE_SHA=${BASE_SHA}" >> "$GITHUB_ENV"
@@ -54,7 +56,7 @@ jobs:
           git worktree remove --force .__ota_base__ 2>/dev/null || true
           git worktree add --detach .__ota_base__ "${BASE_SHA}"
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
 
       - name: ⚙️ Install dependencies for base commit
         run: |
@@ -104,43 +106,6 @@ jobs:
           echo "ota_compatible=${STEPS_FP_OUTPUTS_OTA_COMPATIBLE}" >> "$GITHUB_OUTPUT"
         env:
           STEPS_FP_OUTPUTS_OTA_COMPATIBLE: ${{ steps.fp.outputs.ota_compatible }}
-
-      - name: 💬 Comment verdict on PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405
-        with:
-          header: ota-compatible
-          GITHUB_TOKEN: ${{ secrets.PR_COMMENT_GITHUB_TOKEN || github.token }}
-          message: |
-            ## ${{ steps.fp.outputs.ota_compatible == 'true' && '✅ OTA compatible' || '🔨 Native build required' }}
-
-            ${{ steps.fp.outputs.ota_compatible == 'true' && 'These changes do not alter the native fingerprint, so they can ship as an OTA update.' || 'These changes alter the native fingerprint. Bump the app version and cut a native release; an OTA update alone will not reach users.' }}
-
-            <details>
-            <summary>Fingerprint comparison (base → head)</summary>
-
-            **production**
-
-            | Platform | Base | Head |
-            |---|---|---|
-            | iOS | `${{ steps.fp.outputs.base_ios_production }}` | `${{ steps.fp.outputs.head_ios_production }}` |
-            | Android | `${{ steps.fp.outputs.base_android_production }}` | `${{ steps.fp.outputs.head_android_production }}` |
-
-            **testflight**
-
-            | Platform | Base | Head |
-            |---|---|---|
-            | iOS | `${{ steps.fp.outputs.base_ios_testflight }}` | `${{ steps.fp.outputs.head_ios_testflight }}` |
-            | Android | `${{ steps.fp.outputs.base_android_testflight }}` | `${{ steps.fp.outputs.head_android_testflight }}` |
-
-            **internal**
-
-            | Platform | Base | Head |
-            |---|---|---|
-            | iOS | `${{ steps.fp.outputs.base_ios_internal }}` | `${{ steps.fp.outputs.head_ios_internal }}` |
-            | Android | `${{ steps.fp.outputs.base_android_internal }}` | `${{ steps.fp.outputs.head_android_internal }}` |
-
-            </details>
 
       - name: 📊 Summary
         run: |

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "lint:fix": "eslint . --fix",
     "metadata:push": "EXPO_PUBLIC_APP_VARIANT=production eas metadata:push --profile production",
     "ota": "./scripts/release-ota.sh",
+    "ota:check": "./scripts/ota-compat-check.sh",
     "perf:chat:ios": "bash scripts/perf/capture-chat-instruments.sh",
     "perf:chat:ios:export": "bash scripts/perf/export-instruments-trace.sh",
     "perf:chat:rn": "bash scripts/perf/capture-chat-react-devtools.sh",

--- a/scripts/ota-compat-check.sh
+++ b/scripts/ota-compat-check.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local mirror of the "OTA compatibility check" GitHub workflow. Answers a
+# single question for the current code: can it ship as an OTA update, or does it
+# change the native fingerprint and therefore require a new native build?
+#
+# Compares the current working tree against a base commit (origin/main by
+# default) using the same `expo-updates fingerprint:generate` the deploy
+# pipeline relies on, across every variant/platform. Exits 0 when OTA
+# compatible, 1 when a native release is required.
+#
+#   ./scripts/ota-compat-check.sh [base-ref]
+#
+# base-ref defaults to the merge-base with origin/main.
+
+base_ref="${1:-}"
+worktree_dir=".__ota_base__"
+
+cleanup() {
+  git worktree remove --force "$worktree_dir" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+if [ -z "$base_ref" ]; then
+  echo "Fetching origin/main..."
+  git fetch --no-tags origin main
+  base_sha="$(git merge-base HEAD origin/main)"
+else
+  base_sha="$(git rev-parse "$base_ref")"
+fi
+
+echo "Base commit: $base_sha"
+
+git worktree remove --force "$worktree_dir" 2>/dev/null || true
+git worktree add --detach "$worktree_dir" "$base_sha"
+
+echo "Installing dependencies for base commit..."
+(cd "$worktree_dir" && bun install --frozen-lockfile)
+
+ota_compatible="true"
+
+for variant in production testflight internal; do
+  echo "=== Variant: $variant ==="
+
+  echo "Computing current fingerprints..."
+  head_ios="$(EXPO_PUBLIC_APP_VARIANT="$variant" bunx expo-updates fingerprint:generate --platform ios | jq -r '.hash')"
+  head_android="$(EXPO_PUBLIC_APP_VARIANT="$variant" bunx expo-updates fingerprint:generate --platform android | jq -r '.hash')"
+
+  echo "Computing base fingerprints..."
+  base_ios="$(cd "$worktree_dir" && EXPO_PUBLIC_APP_VARIANT="$variant" bunx expo-updates fingerprint:generate --platform ios | jq -r '.hash')"
+  base_android="$(cd "$worktree_dir" && EXPO_PUBLIC_APP_VARIANT="$variant" bunx expo-updates fingerprint:generate --platform android | jq -r '.hash')"
+
+  if [ "$head_ios" != "$base_ios" ]; then
+    echo "  iOS fingerprint changed: $base_ios -> $head_ios"
+    ota_compatible="false"
+  else
+    echo "  iOS fingerprint unchanged: $head_ios"
+  fi
+
+  if [ "$head_android" != "$base_android" ]; then
+    echo "  Android fingerprint changed: $base_android -> $head_android"
+    ota_compatible="false"
+  else
+    echo "  Android fingerprint unchanged: $head_android"
+  fi
+done
+
+echo
+if [ "$ota_compatible" = "true" ]; then
+  echo "✅ OTA compatible: the current code does not alter the native fingerprint and can ship as an OTA update."
+  exit 0
+fi
+
+echo "🔨 Native build required: the current code alters the native fingerprint. Bump the app version and cut a native release."
+exit 1


### PR DESCRIPTION
Follow-up to #691.

## Changes

1. **Run on main push only** - the OTA compatibility check now triggers on `push` to `main` (plus manual dispatch) instead of on PRs. On a push it compares the new tip against `github.event.before`. Dropped the PR sticky-comment step and the now-unneeded `pull-requests: write` permission.

2. **`bun run ota:check`** - a local mirror of the workflow (`scripts/ota-compat-check.sh`). Compares the current working tree against `origin/main` (or a given base ref) across every variant/platform using `expo-updates fingerprint:generate`, exiting non-zero when a native release is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)