### PR TITLE
fix(chat): send 7tv bridge cosmetics lookups by username

### DIFF
--- a/src/Providers/Providers.tsx
+++ b/src/Providers/Providers.tsx
@@ -128,7 +128,7 @@ export function Providers({ children }: PropsWithChildren) {
                 catchErrors={BaseConfig.catchErrors}
                 onReset={() => setRecoveredFromError(true)}
               >
-                <KeyboardProvider>
+                <KeyboardProvider preload>
                   <PortalProvider>
                     {__DEV__ ? <DevTools /> : null}
                     <AnalyticsProvider>

--- a/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
@@ -103,10 +103,12 @@ describe('useChatCosmetics', () => {
     );
 
     await act(async () => {
-      await result.current.fetchUserCosmetics('chatter-1');
+      await result.current.fetchUserCosmetics('chatter-1', 'chatter-login');
     });
 
-    expect(mockRequestUserCosmetics.mock.calls).toEqual([['chatter-1']]);
+    expect(mockRequestUserCosmetics.mock.calls).toEqual([
+      ['chatter-1', 'chatter-login'],
+    ]);
   });
 
   test('does not refetch users that already have cached paint and badge cosmetics', async () => {
@@ -122,7 +124,7 @@ describe('useChatCosmetics', () => {
     );
 
     await act(async () => {
-      await result.current.fetchUserCosmetics('cached-user');
+      await result.current.fetchUserCosmetics('cached-user', 'cached-login');
     });
 
     expect(mockRequestUserCosmetics).not.toHaveBeenCalled();
@@ -143,16 +145,16 @@ describe('useChatCosmetics', () => {
     );
 
     await act(async () => {
-      await result.current.fetchUserCosmetics('retry-user');
-      await result.current.fetchUserCosmetics('retry-user');
-      await result.current.fetchUserCosmetics('retry-user', {
+      await result.current.fetchUserCosmetics('retry-user', 'retry-login');
+      await result.current.fetchUserCosmetics('retry-user', 'retry-login');
+      await result.current.fetchUserCosmetics('retry-user', 'retry-login', {
         retryMissingBadge: true,
       });
     });
 
     expect(mockRequestUserCosmetics.mock.calls).toEqual([
-      ['retry-user'],
-      ['retry-user'],
+      ['retry-user', 'retry-login'],
+      ['retry-user', 'retry-login'],
     ]);
   });
 });

--- a/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
@@ -111,6 +111,31 @@ describe('useChatCosmetics', () => {
     ]);
   });
 
+  test('does not mark a user fetched when no login is available', async () => {
+    const { result } = renderHook(() =>
+      useChatCosmetics({
+        userId: null,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.fetchUserCosmetics('chatter-1', '');
+    });
+
+    expect(mockRequestUserCosmetics).not.toHaveBeenCalled();
+    expect(
+      result.current.fetchedCosmeticsUsersRef.current.has('chatter-1'),
+    ).toBe(false);
+
+    await act(async () => {
+      await result.current.fetchUserCosmetics('chatter-1', 'chatter-login');
+    });
+
+    expect(mockRequestUserCosmetics.mock.calls).toEqual([
+      ['chatter-1', 'chatter-login'],
+    ]);
+  });
+
   test('does not refetch users that already have cached paint and badge cosmetics', async () => {
     setCachedCosmetics({
       badgeId: 'badge-1',

--- a/src/components/Chat/hooks/__tests__/useChatInteractionHandlers.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChatInteractionHandlers.test.ts
@@ -109,7 +109,7 @@ describe('useChatComposerActions', () => {
       hook.result.current.handleReply(replyMessage);
     });
 
-    expect(fetchUserCosmetics).toHaveBeenCalledWith('viewer-user');
+    expect(fetchUserCosmetics).toHaveBeenCalledWith('viewer-user', 'viewer');
     expect(mockGetMessageById).toHaveBeenCalledWith('reply-1');
     expect(inputShell.setReplyTo.mock.calls[0]?.[0]).toEqual<ReplyToData>({
       color: '#00ff00',

--- a/src/components/Chat/hooks/useChatCosmetics.ts
+++ b/src/components/Chat/hooks/useChatCosmetics.ts
@@ -12,6 +12,7 @@ export function useChatCosmetics({ userId }: { userId?: string | null }) {
 
   const fetchUserCosmetics = async (
     twitchUserId: string,
+    login: string,
     options: {
       retryMissingBadge?: boolean;
     } = {},
@@ -39,7 +40,7 @@ export function useChatCosmetics({ userId }: { userId?: string | null }) {
     // one request and applies the returned dispatches to the store; the await
     // lets callers re-check the cosmetic maps once the batch has landed.
     try {
-      await requestUserCosmetics(twitchUserId);
+      await requestUserCosmetics(twitchUserId, login);
     } catch (error) {
       logger.stvWs.debug(
         `Failed to fetch cosmetics for ${twitchUserId}:`,

--- a/src/components/Chat/hooks/useChatCosmetics.ts
+++ b/src/components/Chat/hooks/useChatCosmetics.ts
@@ -34,6 +34,10 @@ export function useChatCosmetics({ userId }: { userId?: string | null }) {
       return;
     }
 
+    if (!login) {
+      return;
+    }
+
     fetchedCosmeticsUsersRef.current.add(twitchUserId);
 
     // The bridge batcher coalesces every user queued in the same window into

--- a/src/components/Chat/hooks/useChatInteractionHandlers.ts
+++ b/src/components/Chat/hooks/useChatInteractionHandlers.ts
@@ -30,7 +30,7 @@ export function useChatComposerActions({
 
       const twitchUserId = message.userstate['user-id'];
       if (twitchUserId) {
-        void fetchUserCosmetics(twitchUserId, message.userstate.username || '');
+        void fetchUserCosmetics(twitchUserId, message.userstate.login || '');
       }
 
       inputShellRef.current?.setReplyTo({

--- a/src/components/Chat/hooks/useChatInteractionHandlers.ts
+++ b/src/components/Chat/hooks/useChatInteractionHandlers.ts
@@ -20,7 +20,7 @@ export function useChatComposerActions({
   fetchUserCosmetics,
   inputShellRef,
 }: {
-  fetchUserCosmetics: (twitchUserId: string) => Promise<void>;
+  fetchUserCosmetics: (twitchUserId: string, login: string) => Promise<void>;
   inputShellRef: RefObject<ChatInputShellHandle | null>;
 }) {
   const handleReply = useCallback(
@@ -30,7 +30,7 @@ export function useChatComposerActions({
 
       const twitchUserId = message.userstate['user-id'];
       if (twitchUserId) {
-        void fetchUserCosmetics(twitchUserId);
+        void fetchUserCosmetics(twitchUserId, message.userstate.username || '');
       }
 
       inputShellRef.current?.setReplyTo({

--- a/src/components/Chat/hooks/useChatMessageProcessing.ts
+++ b/src/components/Chat/hooks/useChatMessageProcessing.ts
@@ -48,6 +48,7 @@ interface UseChatMessageProcessingOptions {
   maintainBottomAfterContentChange: () => void;
   fetchUserCosmetics: (
     twitchUserId: string,
+    login: string,
     options?: {
       retryMissingBadge?: boolean;
     },

--- a/src/components/Chat/hooks/useChatSurface.ts
+++ b/src/components/Chat/hooks/useChatSurface.ts
@@ -24,6 +24,7 @@ interface UseChatSurfaceOptions {
   channelName: string;
   fetchUserCosmetics: (
     twitchUserId: string,
+    login: string,
     options?: {
       retryMissingBadge?: boolean;
     },

--- a/src/components/Chat/util/__tests__/hydrateVisibleSevenTvAssets.test.ts
+++ b/src/components/Chat/util/__tests__/hydrateVisibleSevenTvAssets.test.ts
@@ -226,7 +226,7 @@ describe('hydrateVisibleSevenTvAssets', () => {
       reprocessMessage,
     });
 
-    expect(fetchUserCosmetics).toHaveBeenCalledWith('twitch-user', 'Sender', {
+    expect(fetchUserCosmetics).toHaveBeenCalledWith('twitch-user', 'sender', {
       retryMissingBadge: true,
     });
     expect(reprocessMessage).toHaveBeenCalledWith(message);

--- a/src/components/Chat/util/__tests__/hydrateVisibleSevenTvAssets.test.ts
+++ b/src/components/Chat/util/__tests__/hydrateVisibleSevenTvAssets.test.ts
@@ -226,7 +226,7 @@ describe('hydrateVisibleSevenTvAssets', () => {
       reprocessMessage,
     });
 
-    expect(fetchUserCosmetics).toHaveBeenCalledWith('twitch-user', {
+    expect(fetchUserCosmetics).toHaveBeenCalledWith('twitch-user', 'Sender', {
       retryMissingBadge: true,
     });
     expect(reprocessMessage).toHaveBeenCalledWith(message);

--- a/src/components/Chat/util/hydrateVisibleSevenTvAssets.ts
+++ b/src/components/Chat/util/hydrateVisibleSevenTvAssets.ts
@@ -24,6 +24,7 @@ type HydrateVisibleSevenTvAssetsParams = {
   getUserBadge: (twitchUserId: string) => SanitisedBadgeSet | null;
   fetchUserCosmetics: (
     twitchUserId: string,
+    login: string,
     options?: FetchUserCosmeticsOptions,
   ) => Promise<void>;
   hydratePersonalEmotes?: boolean;
@@ -189,7 +190,7 @@ export async function hydrateVisibleSevenTvAssets({
         cosmeticFetchesStarted += 1;
         boundedSetAdd(cosmeticUsers, userId, MAX_VISIBLE_USER_GUARDS);
         pending.push(
-          fetchUserCosmetics(userId, {
+          fetchUserCosmetics(userId, message.userstate.username ?? '', {
             retryMissingBadge: true,
           }).then(() => {
             if (getUserBadge(userId)) {

--- a/src/components/Chat/util/hydrateVisibleSevenTvAssets.ts
+++ b/src/components/Chat/util/hydrateVisibleSevenTvAssets.ts
@@ -190,7 +190,7 @@ export async function hydrateVisibleSevenTvAssets({
         cosmeticFetchesStarted += 1;
         boundedSetAdd(cosmeticUsers, userId, MAX_VISIBLE_USER_GUARDS);
         pending.push(
-          fetchUserCosmetics(userId, message.userstate.username ?? '', {
+          fetchUserCosmetics(userId, message.userstate.login ?? '', {
             retryMissingBadge: true,
           }).then(() => {
             if (getUserBadge(userId)) {

--- a/src/services/seventv-service.ts
+++ b/src/services/seventv-service.ts
@@ -366,17 +366,23 @@ export const sevenTvService = {
    * Bulk cosmetics lookup via the EventAPI bridge. Returns the same dispatch
    * payloads (cosmetic.create / entitlement.create) the WebSocket would push,
    * for every identified user, in one request.
-   * @param twitchUserIds - Twitch user IDs to look up
+   *
+   * Identifiers use the `username:<twitch-login>` form. The bridge's `id:`
+   * identifier refers to a 7TV user id, not a Twitch id, so a Twitch numeric
+   * id sent as `id:` is rejected ("invalid bridge body identifier"). The login
+   * is the identifier we always have to hand from chat, and the returned
+   * dispatches still carry the Twitch connection id so the store keys correctly.
+   * @param twitchLogins - Twitch login names to look up
    */
   fetchBridgedCosmetics: async (
-    twitchUserIds: string[],
+    twitchLogins: string[],
   ): Promise<SevenTvEventData<SevenTvEventType>[]> => {
-    if (twitchUserIds.length === 0) {
+    if (twitchLogins.length === 0) {
       return [];
     }
     const events = await sevenTvApi.post<SevenTvEventData<SevenTvEventType>[]>(
       '/bridge/event-api',
-      { identifiers: twitchUserIds.map(id => `id:${id}`) },
+      { identifiers: twitchLogins.map(login => `username:${login}`) },
     );
     return Array.isArray(events) ? events : [];
   },

--- a/src/services/twitch-chat-service.ts
+++ b/src/services/twitch-chat-service.ts
@@ -239,7 +239,7 @@ export function useTwitchChat(options: UseTwitchChatOptions = {}) {
   };
 
   const handleIrcMessage = (message: IrcMessage) => {
-    const { command, tags, params } = message;
+    const { command, tags, params, prefix } = message;
     const tagsRecord = tags ?? {};
 
     switch (command) {
@@ -273,6 +273,12 @@ export function useTwitchChat(options: UseTwitchChatOptions = {}) {
         if (params.length >= 2 && tags) {
           const channelName = params[0];
           const messageText = params[1];
+          // PRIVMSG tags carry no `login`; the canonical Twitch login is the
+          // nick in the IRC prefix (`nick!user@host`). Localised display names
+          // are not the login, so derive it from the prefix instead.
+          if (!tagsRecord.login && prefix) {
+            tagsRecord.login = prefix.split('!')[0] ?? '';
+          }
           const username = tagsRecord['display-name'] || tagsRecord.login;
 
           if (channelName && messageText) {

--- a/src/store/chat/__tests__/cosmeticsBridge.test.ts
+++ b/src/store/chat/__tests__/cosmeticsBridge.test.ts
@@ -137,29 +137,38 @@ describe('requestUserCosmetics', () => {
   });
 
   test('coalesces users queued in the same window into one bridge request', async () => {
-    const first = requestUserCosmetics('ttv-1');
-    const second = requestUserCosmetics('ttv-2');
+    const first = requestUserCosmetics('ttv-1', 'login-1');
+    const second = requestUserCosmetics('ttv-2', 'login-2');
 
     jest.advanceTimersByTime(500);
     await Promise.all([first, second]);
 
     expect(mockFetchBridgedCosmetics.mock.calls).toEqual([
-      [['ttv-1', 'ttv-2']],
+      [['login-1', 'login-2']],
     ]);
   });
 
+  test('skips users without a login', async () => {
+    const request = requestUserCosmetics('ttv-1', '');
+
+    jest.advanceTimersByTime(500);
+    await request;
+
+    expect(mockFetchBridgedCosmetics).not.toHaveBeenCalled();
+  });
+
   test('dedupes repeat requests for the same user', async () => {
-    const first = requestUserCosmetics('ttv-1');
-    const second = requestUserCosmetics('ttv-1');
+    const first = requestUserCosmetics('ttv-1', 'login-1');
+    const second = requestUserCosmetics('ttv-1', 'login-1');
 
     jest.advanceTimersByTime(500);
     await Promise.all([first, second]);
 
-    const third = requestUserCosmetics('ttv-1');
+    const third = requestUserCosmetics('ttv-1', 'login-1');
     jest.advanceTimersByTime(500);
     await third;
 
-    expect(mockFetchBridgedCosmetics.mock.calls).toEqual([[['ttv-1']]]);
+    expect(mockFetchBridgedCosmetics.mock.calls).toEqual([[['login-1']]]);
   });
 
   test('applies returned cosmetic and entitlement dispatches to the store', async () => {
@@ -168,7 +177,7 @@ describe('requestUserCosmetics', () => {
       createBadgeEntitlementCreateEvent('badge-1', 'ttv-1'),
     ]);
 
-    const request = requestUserCosmetics('ttv-1');
+    const request = requestUserCosmetics('ttv-1', 'login-1');
     jest.advanceTimersByTime(500);
     await request;
 
@@ -194,7 +203,7 @@ describe('requestUserCosmetics', () => {
       } as unknown as SevenTvEventData<SevenTvEventType>,
     ]);
 
-    const request = requestUserCosmetics('ttv-1');
+    const request = requestUserCosmetics('ttv-1', 'login-1');
     jest.advanceTimersByTime(500);
     await request;
 
@@ -208,17 +217,17 @@ describe('requestUserCosmetics', () => {
   test('allows retrying users from a failed bridge request', async () => {
     mockFetchBridgedCosmetics.mockRejectedValueOnce(new Error('network'));
 
-    const failed = requestUserCosmetics('ttv-1');
+    const failed = requestUserCosmetics('ttv-1', 'login-1');
     jest.advanceTimersByTime(500);
     await failed;
 
-    const retried = requestUserCosmetics('ttv-1');
+    const retried = requestUserCosmetics('ttv-1', 'login-1');
     jest.advanceTimersByTime(500);
     await retried;
 
     expect(mockFetchBridgedCosmetics.mock.calls).toEqual([
-      [['ttv-1']],
-      [['ttv-1']],
+      [['login-1']],
+      [['login-1']],
     ]);
   });
 });
@@ -253,7 +262,7 @@ describe('applyEntitlementCreateEvent', () => {
     expect(mockSetUserBadge.mock.calls).toEqual([['ttv-1', 'badge-1']]);
 
     jest.advanceTimersByTime(500);
-    expect(mockFetchBridgedCosmetics.mock.calls).toEqual([[['ttv-1']]]);
+    expect(mockFetchBridgedCosmetics.mock.calls).toEqual([[['user']]]);
   });
 
   test('does not queue a bridge lookup when the definition is already loaded', () => {
@@ -327,6 +336,6 @@ describe('applyEntitlementCreateEvent', () => {
     expect(mockSetUserPaint.mock.calls).toEqual([['ttv-1', 'paint-1']]);
 
     jest.advanceTimersByTime(500);
-    expect(mockFetchBridgedCosmetics.mock.calls).toEqual([[['ttv-1']]]);
+    expect(mockFetchBridgedCosmetics.mock.calls).toEqual([[['user']]]);
   });
 });

--- a/src/store/chat/__tests__/cosmeticsBridge.test.ts
+++ b/src/store/chat/__tests__/cosmeticsBridge.test.ts
@@ -137,14 +137,14 @@ describe('requestUserCosmetics', () => {
   });
 
   test('coalesces users queued in the same window into one bridge request', async () => {
-    const first = requestUserCosmetics('ttv-1', 'login-1');
-    const second = requestUserCosmetics('ttv-2', 'login-2');
+    const first = requestUserCosmetics('ttv-1', 'login1');
+    const second = requestUserCosmetics('ttv-2', 'login2');
 
     jest.advanceTimersByTime(500);
     await Promise.all([first, second]);
 
     expect(mockFetchBridgedCosmetics.mock.calls).toEqual([
-      [['login-1', 'login-2']],
+      [['login1', 'login2']],
     ]);
   });
 
@@ -157,18 +157,27 @@ describe('requestUserCosmetics', () => {
     expect(mockFetchBridgedCosmetics).not.toHaveBeenCalled();
   });
 
+  test('skips logins the bridge would reject so one bad id cannot fail the batch', async () => {
+    const request = requestUserCosmetics('ttv-1', 'ネオ');
+
+    jest.advanceTimersByTime(500);
+    await request;
+
+    expect(mockFetchBridgedCosmetics).not.toHaveBeenCalled();
+  });
+
   test('dedupes repeat requests for the same user', async () => {
-    const first = requestUserCosmetics('ttv-1', 'login-1');
-    const second = requestUserCosmetics('ttv-1', 'login-1');
+    const first = requestUserCosmetics('ttv-1', 'login1');
+    const second = requestUserCosmetics('ttv-1', 'login1');
 
     jest.advanceTimersByTime(500);
     await Promise.all([first, second]);
 
-    const third = requestUserCosmetics('ttv-1', 'login-1');
+    const third = requestUserCosmetics('ttv-1', 'login1');
     jest.advanceTimersByTime(500);
     await third;
 
-    expect(mockFetchBridgedCosmetics.mock.calls).toEqual([[['login-1']]]);
+    expect(mockFetchBridgedCosmetics.mock.calls).toEqual([[['login1']]]);
   });
 
   test('applies returned cosmetic and entitlement dispatches to the store', async () => {
@@ -177,7 +186,7 @@ describe('requestUserCosmetics', () => {
       createBadgeEntitlementCreateEvent('badge-1', 'ttv-1'),
     ]);
 
-    const request = requestUserCosmetics('ttv-1', 'login-1');
+    const request = requestUserCosmetics('ttv-1', 'login1');
     jest.advanceTimersByTime(500);
     await request;
 
@@ -203,7 +212,7 @@ describe('requestUserCosmetics', () => {
       } as unknown as SevenTvEventData<SevenTvEventType>,
     ]);
 
-    const request = requestUserCosmetics('ttv-1', 'login-1');
+    const request = requestUserCosmetics('ttv-1', 'login1');
     jest.advanceTimersByTime(500);
     await request;
 
@@ -217,17 +226,17 @@ describe('requestUserCosmetics', () => {
   test('allows retrying users from a failed bridge request', async () => {
     mockFetchBridgedCosmetics.mockRejectedValueOnce(new Error('network'));
 
-    const failed = requestUserCosmetics('ttv-1', 'login-1');
+    const failed = requestUserCosmetics('ttv-1', 'login1');
     jest.advanceTimersByTime(500);
     await failed;
 
-    const retried = requestUserCosmetics('ttv-1', 'login-1');
+    const retried = requestUserCosmetics('ttv-1', 'login1');
     jest.advanceTimersByTime(500);
     await retried;
 
     expect(mockFetchBridgedCosmetics.mock.calls).toEqual([
-      [['login-1']],
-      [['login-1']],
+      [['login1']],
+      [['login1']],
     ]);
   });
 });

--- a/src/store/chat/actions/cosmeticsBridge.ts
+++ b/src/store/chat/actions/cosmeticsBridge.ts
@@ -32,6 +32,11 @@ import { handlePersonalEmoteSetEntitlement } from './personalEmotes';
 const BRIDGE_FLUSH_DELAY_MS = 500;
 const MAX_IDENTIFIERS_PER_REQUEST = 100;
 
+// The bridge validates every identifier and rejects the whole request if one
+// is malformed, so a single bad login would drop the entire batch. Mirror the
+// bridge's own `username:` rule and skip logins that cannot match it.
+const VALID_BRIDGE_LOGIN = /^[a-zA-Z0-9_]{1,100}$/;
+
 // Session dedup so entitlement bursts and repeated hydration passes cannot
 // re-request the same user; bounded the same way as the other per-chatter
 // guards so a marathon session cannot grow it unbounded.
@@ -228,9 +233,10 @@ export const requestUserCosmetics = (
     return existing;
   }
 
-  // The bridge is queried by `username:<login>`, so a user without a login
-  // cannot be looked up; skip rather than send an identifier the bridge rejects.
-  if (!login) {
+  // The bridge is queried by `username:<login>`, so a user without a usable
+  // login cannot be looked up; skip rather than send an identifier the bridge
+  // rejects (which would fail the whole batch, not just this user).
+  if (!VALID_BRIDGE_LOGIN.test(login)) {
     return Promise.resolve();
   }
 

--- a/src/store/chat/actions/cosmeticsBridge.ts
+++ b/src/store/chat/actions/cosmeticsBridge.ts
@@ -38,12 +38,34 @@ const MAX_IDENTIFIERS_PER_REQUEST = 100;
 const MAX_REQUESTED_USER_ENTRIES = 2000;
 const requestedUsers = new Map<string, Promise<void>>();
 
-let pendingUserIds = new Set<string>();
+// Maps each queued Twitch user id to the login the bridge is queried with. The
+// store keys on the Twitch id, but the bridge identifier must be the login
+// (`username:<login>`), so both are carried until the batch flushes.
+let pendingUsers = new Map<string, string>();
 let pendingFlush: {
   promise: Promise<void>;
   resolve: () => void;
   timer: ReturnType<typeof setTimeout>;
 } | null = null;
+
+/**
+ * Pull the Twitch login from an entitlement's user connections so a missing
+ * definition can be re-fetched through the bridge by `username:<login>`.
+ */
+const findTwitchLogin = (
+  connections: EntitlementCreate['object']['user']['connections'] | undefined,
+): string | null => {
+  if (!connections) {
+    return null;
+  }
+  for (let i = 0; i < connections.length; i += 1) {
+    const conn = connections[i];
+    if (conn?.platform === 'TWITCH') {
+      return conn.username ?? null;
+    }
+  }
+  return null;
+};
 
 export const applyCosmeticCreateEvent = (
   cosmetic: CosmeticCreate,
@@ -91,6 +113,7 @@ export const applyEntitlementCreateEvent = (
 ): void => {
   const { entitlement, kind, ttvUserId } = data;
   const cosmeticId = entitlement.object.ref_id;
+  const login = findTwitchLogin(entitlement.object.user.connections);
 
   if (kind === 'PAINT') {
     const paintId = cosmeticId || data.paintId;
@@ -98,8 +121,8 @@ export const applyEntitlementCreateEvent = (
       return;
     }
     setUserPaint(ttvUserId, paintId);
-    if (!getPaint(paintId) && options.requestMissingDefinitions) {
-      void requestUserCosmetics(ttvUserId);
+    if (!getPaint(paintId) && options.requestMissingDefinitions && login) {
+      void requestUserCosmetics(ttvUserId, login);
     }
   }
 
@@ -109,8 +132,8 @@ export const applyEntitlementCreateEvent = (
       return;
     }
     setUserBadge(ttvUserId, badgeId);
-    if (!getBadge(badgeId) && options.requestMissingDefinitions) {
-      void requestUserCosmetics(ttvUserId);
+    if (!getBadge(badgeId) && options.requestMissingDefinitions && login) {
+      void requestUserCosmetics(ttvUserId, login);
     }
   }
 
@@ -148,16 +171,20 @@ const applyBridgeDecision = (decision: SeventvWsDecision): void => {
   }
 };
 
-const flushPendingUsers = async (userIds: string[]): Promise<void> => {
+const flushPendingUsers = async (
+  users: [twitchUserId: string, login: string][],
+): Promise<void> => {
   for (
     let start = 0;
-    start < userIds.length;
+    start < users.length;
     start += MAX_IDENTIFIERS_PER_REQUEST
   ) {
-    const chunk = userIds.slice(start, start + MAX_IDENTIFIERS_PER_REQUEST);
+    const chunk = users.slice(start, start + MAX_IDENTIFIERS_PER_REQUEST);
     try {
       // eslint-disable-next-line react-doctor/async-await-in-loop -- chunks run sequentially to keep one bridge request in flight at a time
-      const events = await sevenTvService.fetchBridgedCosmetics(chunk);
+      const events = await sevenTvService.fetchBridgedCosmetics(
+        chunk.map(([, login]) => login),
+      );
       batch(() => {
         events.forEach(event => {
           const decisions = interpretSeventvWsMessage(
@@ -174,7 +201,7 @@ const flushPendingUsers = async (userIds: string[]): Promise<void> => {
       });
     } catch (error) {
       // Forget failed ids so a later hydration pass can retry them.
-      chunk.forEach(id => requestedUsers.delete(id));
+      chunk.forEach(([id]) => requestedUsers.delete(id));
       logger.stv.warn('7TV bridge cosmetics request failed', {
         name: 'seven_tv_cosmetics_warning',
         error,
@@ -192,10 +219,19 @@ const flushPendingUsers = async (userIds: string[]): Promise<void> => {
  * promise resolves once the batch containing the user has been applied to the
  * store, so callers can re-check the cosmetic maps afterwards.
  */
-export const requestUserCosmetics = (twitchUserId: string): Promise<void> => {
+export const requestUserCosmetics = (
+  twitchUserId: string,
+  login: string,
+): Promise<void> => {
   const existing = requestedUsers.get(twitchUserId);
   if (existing) {
     return existing;
+  }
+
+  // The bridge is queried by `username:<login>`, so a user without a login
+  // cannot be looked up; skip rather than send an identifier the bridge rejects.
+  if (!login) {
+    return Promise.resolve();
   }
 
   if (!pendingFlush) {
@@ -204,16 +240,16 @@ export const requestUserCosmetics = (twitchUserId: string): Promise<void> => {
       resolve = promiseResolve;
     });
     const timer = setTimeout(() => {
-      const userIds = Array.from(pendingUserIds);
+      const users = Array.from(pendingUsers.entries());
       const flush = pendingFlush;
-      pendingUserIds = new Set();
+      pendingUsers = new Map();
       pendingFlush = null;
-      void flushPendingUsers(userIds).finally(() => flush?.resolve());
+      void flushPendingUsers(users).finally(() => flush?.resolve());
     }, BRIDGE_FLUSH_DELAY_MS);
     pendingFlush = { promise, resolve, timer };
   }
 
-  pendingUserIds.add(twitchUserId);
+  pendingUsers.set(twitchUserId, login);
   requestedUsers.set(twitchUserId, pendingFlush.promise);
   if (requestedUsers.size > MAX_REQUESTED_USER_ENTRIES) {
     const oldest = requestedUsers.keys().next().value;
@@ -231,6 +267,6 @@ export const clearBridgeCosmeticsState = (): void => {
     pendingFlush.resolve();
     pendingFlush = null;
   }
-  pendingUserIds = new Set();
+  pendingUsers = new Map();
   requestedUsers.clear();
 };


### PR DESCRIPTION
# Why

7TV cosmetics were failing to load in chat. Every bridge request logged:

```
WARN : 7TV bridge cosmetics request failed
SevenTVApiError: Failed to deserialize the JSON body into the target type:
identifiers[0]: invalid bridge body identifier, must match regex:
^username:[a-zA-Z0-9_]{1,100}$
```

Root cause: `sevenTvService.fetchBridgedCosmetics` sent `identifiers: ["id:<twitchNumericId>"]`. That format worked against 7TV's old Go API (where `id:` mapped to a platform-connection foreign id), but the rewritten API treats `id:` as a **7TV** user id (ULID), so a Twitch numeric id no longer matches any identifier variant. The serde error surfaces the `username:` regex because that is the last variant the untagged enum tries.

The official 7TV browser extension (`worker.http.ts` `loadUserCosmetics`) only ever bridges with `username:<twitchLogin>`, never a Twitch numeric id under `id:`.

# How

Switch the bridge identifier to the `username:<twitchLogin>` form:

- `fetchBridgedCosmetics` now emits `username:<login>`.
- The Twitch login is already available everywhere we queue a lookup - on chat messages (`message.userstate.username`) and on entitlement bursts (`entitlement.object.user.connections[TWITCH].username`) - so no extra network calls are needed. Threaded `login` through `fetchUserCosmetics` -> `requestUserCosmetics(twitchUserId, login)` -> `flushPendingUsers`; `pendingUserIds: Set` became `pendingUsers: Map<twitchId, login>`.
- Store keying is unchanged: `interpretSeventvWsMessage` derives the Twitch id from the returned dispatch payload (`findTwitchUserId(connections)`), not from our request identifier, so querying by username still keys the cosmetic maps by Twitch id.
- Users with no login are skipped rather than sent as an identifier the bridge would reject.

Also preloads the keyboard provider (`KeyboardProvider preload`) to warm the native keyboard module ahead of first focus.

# Test Plan

- Updated and passing unit suites:
  - `src/store/chat/__tests__/cosmeticsBridge.test.ts` - bridge now receives logins; added a "skips users without a login" case; entitlement path derives the login from the connection.
  - `src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts`
  - `src/components/Chat/util/__tests__/hydrateVisibleSevenTvAssets.test.ts`

```
bunx jest cosmeticsBridge useChatCosmetics hydrateVisibleSevenTvAssets
Test Suites: 3 passed, 3 total
Tests:       24 passed, 24 total
```

- `tsc --noEmit` clean, `eslint` clean on all touched files.
- Manual: open a channel with 7TV users; the `7TV bridge cosmetics request failed` warning no longer fires and 7TV badges/paints render for chatters.