### PR TITLE
fix(player): make login-required content gate tappable on custom player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
 ## 1.0.1 (Internal)
+
 ### 🐛 Bug Fixes
 
 - **chat:** Send 7tv bridge cosmetics lookups by username ([#694](https://github.com/lhowsam/foam/issues/694))
 
 ## 1.0.1 (Production)
+
 ### ♻️ Refactor
 
 - **chat:** Improve bottom sheet
@@ -102,6 +104,7 @@
 - **infrastructure:** Add OTA compat check
 
 ## 1.0.0 (TestFlight)
+
 ### ⚡ Performance
 
 - **chat:** Cut emote + badge perf overhead ([#626](https://github.com/lhowsam/foam/issues/626))
@@ -127,12 +130,14 @@
 - **test:** Full e2e coverage
 
 ## 0.0.42 (Internal)
+
 ### 🐛 Bug Fixes
 
 - **app:** Sentry initialization
 - **app:** Sentry initialization
 
 ## 0.0.42 (TestFlight)
+
 ### ♻️ Refactor
 
 - **app:** Native feel + folder org ([#616](https://github.com/lhowsam/foam/issues/616))
@@ -166,6 +171,7 @@
 - **infrastructure:** Update action versions ([#618](https://github.com/lhowsam/foam/issues/618))
 
 ## 0.0.41 (Production)
+
 ### ♻️ Refactor
 
 - **app:** Perf improvements ([#602](https://github.com/lhowsam/foam/issues/602))
@@ -190,6 +196,7 @@
 - **tooling:** Update commitlint
 
 ## 0.0.40 (Production)
+
 ### ♻️ Refactor
 
 - **app:** Blank screen during splash
@@ -360,6 +367,7 @@
 - **infrastructure:** Fix deploy-ota-or-native
 
 ## 0.0.39 (Production)
+
 ### ♻️ Refactor
 
 - **chat:** Move to v4 stv ([#485](https://github.com/lhowsam/foam/issues/485))
@@ -430,6 +438,7 @@
 - **app:** Automate changelog ([#474](https://github.com/lhowsam/foam/issues/474))
 
 ## 0.0.38 (Production)
+
 ### ✨ Features
 
 - **app:** 7tv paints ([#460](https://github.com/lhowsam/foam/issues/460))
@@ -460,6 +469,7 @@
 - **app:** Testing OTA
 
 ## 0.0.36 (Production)
+
 ### ✨ Features
 
 - **infrastructure:** Tidy up release tag
@@ -471,6 +481,7 @@
 - **infrastructure:** OTA
 
 ## 0.0.37 (Production)
+
 ### ♻️ Refactor
 
 - **app:** Remove screen wrapper ([#437](https://github.com/lhowsam/foam/issues/437))
@@ -518,6 +529,7 @@
 - **infrastructure:** Test self hosted runner ([#454](https://github.com/lhowsam/foam/issues/454))
 
 ## 0.0.34 (Production)
+
 ### ♻️ Refactor
 
 - **app:** Rework error screen
@@ -541,6 +553,7 @@
 - **app:** Install expo-insights
 
 ## 0.0.33 (Production)
+
 ### ♻️ Refactor
 
 - **app:** Social-app style query provider ([#420](https://github.com/lhowsam/foam/issues/420))
@@ -576,6 +589,7 @@
 - **sentry:** Adjust sentry rates ([#419](https://github.com/lhowsam/foam/issues/419))
 
 ## 0.0.32 (Production)
+
 ### 🐛 Bug Fixes
 
 - **app:** Improve perf of profilePicture query
@@ -592,6 +606,7 @@
 - **infrastructure:** Tidy up ci/cd ([#385](https://github.com/lhowsam/foam/issues/385))
 
 ## 0.0.31 (Production)
+
 ### 🐛 Bug Fixes
 
 - **app:** Remove barrel imports for services ([#374](https://github.com/lhowsam/foam/issues/374))
@@ -604,6 +619,7 @@
 - Add refined plugin
 
 ## 0.0.30 (Production)
+
 ### ✨ Features
 
 - **app:** Listen for WS changes in chat ([#364](https://github.com/lhowsam/foam/issues/364))
@@ -620,6 +636,7 @@
 - **infrastructure:** Remove dead code
 
 ## 0.0.29 (Production)
+
 ### ✨ Features
 
 - **chat:** Improve image caching performance ([#354](https://github.com/lhowsam/foam/issues/354))
@@ -639,6 +656,7 @@
 - Revert deploy.sh
 
 ## 0.0.27 (Production)
+
 ### ♻️ Refactor
 
 - **app:** Kebab-case services ([#315](https://github.com/lhowsam/foam/issues/315))
@@ -658,6 +676,7 @@
 - **documentation:** Update setup docs ([#329](https://github.com/lhowsam/foam/issues/329))
 
 ## 0.0.26 (Production)
+
 ### ✨ Features
 
 - **app:** Custom switch component ([#313](https://github.com/lhowsam/foam/issues/313))
@@ -671,6 +690,7 @@
 - **app:** Remove auth loading screen ([#314](https://github.com/lhowsam/foam/issues/314))
 
 ## 0.0.25 (Production)
+
 ### ♻️ Refactor
 
 - **app:** Tidy up entrypoint ([#302](https://github.com/lhowsam/foam/issues/302))
@@ -700,6 +720,7 @@
 - **app:** Update core RN deps ([#311](https://github.com/lhowsam/foam/issues/311))
 
 ## 0.0.24 (Production)
+
 ### ✨ Features
 
 - **chat:** Chat wrap up tasks ([#288](https://github.com/lhowsam/foam/issues/288))
@@ -712,6 +733,7 @@
 - **chat:** Improve sheet typography
 
 ## 0.0.23 (Production)
+
 ### ✨ Features
 
 - **app:** Add start activity module ([#283](https://github.com/lhowsam/foam/issues/283))
@@ -721,6 +743,7 @@
 - Update .gitignore
 
 ## 0.0.22 (Production)
+
 ### ✨ Features
 
 - **chat:** Chat other tasks ([#257](https://github.com/lhowsam/foam/issues/257))
@@ -738,6 +761,7 @@
 - **docs:** Update .env.example
 
 ## 0.0.21 (Production)
+
 ### ✨ Features
 
 - **app:** Chat parsing
@@ -752,6 +776,7 @@
 - **infrastructure:** Add OTA ci/cd
 
 ## 0.0.20 (Production)
+
 ### ✨ Features
 
 - **ui:** Add style helpers
@@ -769,11 +794,13 @@
 - **app:** Compress Images
 
 ## 0.0.19 (Production)
+
 ### ✨ Features
 
 - **app:** Add react-query devtools
 
 ## 0.0.18 (Production)
+
 ### 🐛 Bug Fixes
 
 - **app:** Fix toasts + settings modal
@@ -783,11 +810,13 @@
 - **auth:** Improve auth tests
 
 ## 0.0.17 (Production)
+
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Refactor online manager
 
 ## 0.0.16 (Production)
+
 ### ✨ Features
 
 - **app:** Add cheaper deploy workflow
@@ -797,11 +826,13 @@
 - **app:** Fix auth ctx persistence issues
 
 ## 0.0.15 (Production)
+
 ### 🐛 Bug Fixes
 
 - **app:** Fix auth crashes
 
 ## 0.0.14 (Production)
+
 ### ✨ Features
 
 - **app:** Add diangostics table
@@ -820,6 +851,7 @@
 - **ci:** Test alternate ci/cd workflow
 
 ## 0.0.13 (Production)
+
 ### ♻️ Refactor
 
 - **app:** Settings screen
@@ -836,16 +868,19 @@
 - **app:** Debug auth issues
 
 ## 0.0.12 (Production)
+
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Debug auth
 
 ## 0.0.11 (Production)
+
 ### 🐛 Bug Fixes
 
 - **app:** Speculative crash fix around fonts
 
 ## 0.0.9 (Production)
+
 ### ✨ Features
 
 - **app:** Add nr logging
@@ -857,11 +892,13 @@
 - **app:** Comment out fb
 
 ## 0.0.8 (Production)
+
 ### 🐛 Bug Fixes
 
 - **app:** Fix crash on start
 
 ## 0.0.7 (Production)
+
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Debug release
@@ -869,31 +906,37 @@
 - **app:** Debug release
 
 ## 0.0.6 (Production)
+
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Debug release
 
 ## 0.0.5 (Production)
+
 ### 🐛 Bug Fixes
 
 - **app:** Navigation state in prod
 
 ## 0.0.4 (Production)
+
 ### ✨ Features
 
 - **app:** Debug screen
 
 ## 0.0.3 (Production)
+
 ### 🐛 Bug Fixes
 
 - **app:** Fix commmitlint
 
 ## 0.0.2 (Production)
+
 ### 🔧 Miscellaneous Tasks
 
 - **app:** Gs services file
 
 ## 0.0.1 (Production)
+
 ### ♻️ Refactor
 
 - **app:** Refactor landscape utils

--- a/src/components/StreamPlayer/StreamPlayer.tsx
+++ b/src/components/StreamPlayer/StreamPlayer.tsx
@@ -21,6 +21,7 @@ import {
   buildTwitchChromeHiderScript,
   buildTwitchClipPlayerUrl,
   buildTwitchContentGateAcceptScript,
+  buildTwitchContentGateWatcherScript,
   buildTwitchLatencyTrackerScript,
   buildTwitchLiveSyncScript,
   buildTwitchPipBridgeScript,
@@ -367,7 +368,12 @@ export const StreamPlayer = memo(function StreamPlayer({
       ? '\n' +
         buildTwitchChromeHiderScript() +
         '\n' +
-        buildTwitchPlayerStateScript()
+        buildTwitchPlayerStateScript() +
+        // Custom player only: the WebView is non-interactive while foam draws
+        // its own controls, so a login-required content gate can't be tapped.
+        // Watch for it and re-enable interaction when one appears.
+        '\n' +
+        buildTwitchContentGateWatcherScript()
       : '') +
     // Live + custom-player only: read broadcaster latency for the chat pill and seek to live at start.
     (showOverlayControls && !clip && !video

--- a/src/components/StreamPlayer/StreamPlayer.tsx
+++ b/src/components/StreamPlayer/StreamPlayer.tsx
@@ -74,9 +74,11 @@ const TWITCH_AUTH_HELPER_SCRIPT = `
 true;
 `;
 
-// Polls the VOD <video> element's position and reports it to native so the
-// last-known offset survives a WebView reload. The stock player owns the
-// scrubber; we only observe, so this never fights the user's own seeks.
+/**
+ * Polls the VOD <video> element's position and reports it to native so the
+ * last-known offset survives a WebView reload. The stock player owns the
+ * scrubber; we only observe, so this never fights the user's own seeks.
+ */
 const VOD_PROGRESS_TRACKER_SCRIPT = `
 (() => {
   if (window.__foamVodProgressInstalled) {
@@ -99,9 +101,11 @@ const VOD_PROGRESS_TRACKER_SCRIPT = `
 true;
 `;
 
-// The unscripted live player gives no 'playing' bridge event, so the poster is
-// dismissed off WebView load-end. Linger briefly past that so the first decoded
-// frame is already on screen before the loading frame fades away.
+/**
+ * The unscripted live player gives no 'playing' bridge event, so the poster is
+ * dismissed off WebView load-end. Linger briefly past that so the first decoded
+ * frame is already on screen before the loading frame fades away.
+ */
 const POSTER_HIDE_DELAY_MS = 450;
 // Never strand the poster over the player if the page errors before load-end.
 const POSTER_SAFETY_TIMEOUT_MS = 9000;
@@ -149,11 +153,13 @@ export const StreamPlayer = memo(function StreamPlayer({
     url: string;
     statusCode: number;
   } | null>(null);
-  // Mounting the WebView while the screen-push animation is still running
-  // makes WKWebView start the inline video mid-transition; its AVPlayer
-  // layer then intermittently never attaches to the compositor (audio and
-  // currentTime advance but the picture is black or frozen on one frame).
-  // Wait for interactions/transitions to settle before creating the WebView.
+  /**
+   * Mounting the WebView while the screen-push animation is still running
+   * makes WKWebView start the inline video mid-transition; its AVPlayer
+   * layer then intermittently never attaches to the compositor (audio and
+   * currentTime advance but the picture is black or frozen on one frame).
+   * Wait for interactions/transitions to settle before creating the WebView.
+   */
   const [canMountWebView, setCanMountWebView] = useState(false);
   useEffect(() => {
     const task = InteractionManager.runAfterInteractions(() => {
@@ -162,21 +168,26 @@ export const StreamPlayer = memo(function StreamPlayer({
     return () => task.cancel();
   }, []);
 
-  // Even when mounted post-transition, WKWebView sometimes fails to attach
-  // the inline video's AVPlayer layer to the compositor (picture stays black
-  // or frozen while playback advances). The page cannot observe this, so we
-  // unconditionally force a frame change shortly after playback starts —
-  // resizing the WKWebView makes it rebuild its layer tree and pick the
-  // video layer up.
-  // With the unscripted player there is no bridge 'playing' event, so the
-  // nudge fires off WebView load-end; autoplay starts shortly after, which
-  // the second pulse at +2.5s covers.
+  /**
+   * Even when mounted post-transition, WKWebView sometimes fails to attach
+   * the inline video's AVPlayer layer to the compositor (picture stays black
+   * or frozen while playback advances). The page cannot observe this, so we
+   * unconditionally force a frame change shortly after playback starts —
+   * resizing the WKWebView makes it rebuild its layer tree and pick the
+   * video layer up.
+   * With the unscripted player there is no bridge 'playing' event, so the
+   * nudge fires off WebView load-end; autoplay starts shortly after, which
+   * the second pulse at +2.5s covers.
+   */
   const [layoutNudge, setLayoutNudge] = useState(0);
   const nudgeTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const nudgePlayedRef = useRef(false);
-  // Loading frame shown over the WebView (stream thumbnail + spinner) until the
-  // player has actually started, replacing the black box during page load.
-  const [isPlayerLoading, setIsPlayerLoading] = useState(true);
+  /**
+   * Loading frame shown over the WebView (stream thumbnail + spinner) until the
+   * player has actually started, replacing the black box during page load.
+   */
+  const [loadedGeneration, setLoadedGeneration] = useState<string | null>(null);
+  const generationRef = useRef('');
   const posterHideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -188,7 +199,7 @@ export const StreamPlayer = memo(function StreamPlayer({
     if (!posterHideTimeoutRef.current) {
       posterHideTimeoutRef.current = setTimeout(() => {
         posterHideTimeoutRef.current = null;
-        setIsPlayerLoading(false);
+        setLoadedGeneration(generationRef.current);
       }, POSTER_HIDE_DELAY_MS);
     }
     const pulse = (delay: number) => {
@@ -213,8 +224,14 @@ export const StreamPlayer = memo(function StreamPlayer({
 
   const sourceKey = `${channel ?? ''}|${clip ?? ''}|${video ?? ''}|${parent}|${autoplay}|${initialMuted}|${deferOverlayUntilUserUnmute}`;
 
-  // Last reported VOD playback offset (seconds). Survives a WebView remount so
-  // the embed can resume instead of restarting at 0:00; reset per source.
+  const generation = `${sourceKey}|${webViewKey}`;
+  generationRef.current = generation;
+  const isPlayerLoading = loadedGeneration !== generation;
+
+  /**
+   * Last reported VOD playback offset (seconds). Survives a WebView remount so
+   * the embed can resume instead of restarting at 0:00; reset per source.
+   */
   const resumeTimeRef = useRef(0);
 
   useWatchTimeTracking();
@@ -223,14 +240,15 @@ export const StreamPlayer = memo(function StreamPlayer({
     needsInitRef.current = true;
     nudgePlayedRef.current = false;
     resumeTimeRef.current = 0;
-    setIsPlayerLoading(true);
   }, [sourceKey]);
 
-  // Re-show the loading frame for each WebView generation and arm a safety
-  // dismissal so a load that never finishes can't trap it over the player.
+  /**
+   * Arm a safety dismissal per generation so a load that never finishes can't
+   * trap the loading frame over the player.
+   */
   useEffect(() => {
     const timeout = setTimeout(
-      () => setIsPlayerLoading(false),
+      () => setLoadedGeneration(generationRef.current),
       POSTER_SAFETY_TIMEOUT_MS,
     );
     return () => clearTimeout(timeout);
@@ -247,7 +265,6 @@ export const StreamPlayer = memo(function StreamPlayer({
       clearTimeout(posterHideTimeoutRef.current);
       posterHideTimeoutRef.current = null;
     }
-    setIsPlayerLoading(true);
     setWebViewKey(key => key + 1);
   }, [channel]);
 
@@ -318,10 +335,12 @@ export const StreamPlayer = memo(function StreamPlayer({
   });
 
   const channelName = channel || 'twitch';
-  // Memoised so the URL only changes when the source or a remount (webViewKey)
-  // does — never on an incidental re-render (e.g. the layout nudge), which
-  // would otherwise reload the WebView. On remount it reads the latest
-  // resume offset so a VOD picks up where it left off.
+  /**
+   * Memoised so the URL only changes when the source or a remount (webViewKey)
+   * does — never on an incidental re-render (e.g. the layout nudge), which
+   * would otherwise reload the WebView. On remount it reads the latest
+   * resume offset so a VOD picks up where it left off.
+   */
   const webViewSource = useMemo(
     () =>
       clip
@@ -347,14 +366,16 @@ export const StreamPlayer = memo(function StreamPlayer({
     [clip, channelName, video, parent, autoplay, initialMuted, webViewKey],
   );
 
-  // The stock player.twitch.tv page runs unscripted: Twitch's own UI handles
-  // playback, so the playerControls bootstrap is not injected and the bridge
-  // (ready/playing/pause messages, native controls overlay) stays dormant.
-  // We auto-accept the mature-content gate, hide the text track ('hidden', not
-  // 'disabled', which would stall WKWebView's native HLS AVPlayer), and — when
-  // autoplaying — nudge the video into unmuted playback since Twitch's embed
-  // otherwise tends to land paused/muted. The player's own chrome is hidden
-  // only when foam is drawing its own overlay controls over the video.
+  /**
+   * The stock player.twitch.tv page runs unscripted: Twitch's own UI handles
+   * playback, so the playerControls bootstrap is not injected and the bridge
+   * (ready/playing/pause messages, native controls overlay) stays dormant.
+   * We auto-accept the mature-content gate, hide the text track ('hidden', not
+   * 'disabled', which would stall WKWebView's native HLS AVPlayer), and — when
+   * autoplaying — nudge the video into unmuted playback since Twitch's embed
+   * otherwise tends to land paused/muted. The player's own chrome is hidden
+   * only when foam is drawing its own overlay controls over the video.
+   */
   const injectedJavaScript =
     TWITCH_AUTH_HELPER_SCRIPT +
     '\n' +
@@ -369,9 +390,6 @@ export const StreamPlayer = memo(function StreamPlayer({
         buildTwitchChromeHiderScript() +
         '\n' +
         buildTwitchPlayerStateScript() +
-        // Custom player only: the WebView is non-interactive while foam draws
-        // its own controls, so a login-required content gate can't be tapped.
-        // Watch for it and re-enable interaction when one appears.
         '\n' +
         buildTwitchContentGateWatcherScript()
       : '') +
@@ -388,8 +406,10 @@ export const StreamPlayer = memo(function StreamPlayer({
       ? '\n' + buildTwitchPipBridgeScript()
       : '');
 
-  // The tracker posts unsolicited `vodProgress` messages; capture those for
-  // resume-on-reload and forward everything else to the player bridge.
+  /**
+   * The tracker posts unsolicited `vodProgress` messages; capture those for
+   * resume-on-reload and forward everything else to the player bridge.
+   */
   const handleWebViewMessage = useCallback(
     (event: WebViewMessageEvent) => {
       try {
@@ -450,8 +470,10 @@ export const StreamPlayer = memo(function StreamPlayer({
   const playerHeight = height ?? '100%';
   const allowsTwitchInteraction =
     Boolean(clip) || !showOverlayControls || hasContentGate;
-  // Thumbnail behind a transparent WebView so the iOS rotation snapshot shows the poster,
-  // not the WebView's black backing. Live only.
+  /**
+   * Thumbnail behind a transparent WebView so the iOS rotation snapshot shows the poster,
+   * not the WebView's black backing. Live only.
+   */
   const showBehindThumbnail = Boolean(posterUrl) && !clip && !video;
   const shouldShowNativeControls =
     showOverlayControls &&

--- a/src/components/StreamPlayer/StreamPlayerWebView.tsx
+++ b/src/components/StreamPlayer/StreamPlayerWebView.tsx
@@ -172,16 +172,23 @@ export const StreamPlayerWebView = memo(function StreamPlayerWebView({
       // don't delay the overlay's tap.
       pointerEvents={allowsTwitchInteraction ? 'auto' : 'none'}
       scrollEnabled={allowsTwitchInteraction}
-      keyboardDisplayRequiresUserAction={!allowsTwitchInteraction}
+      // Both of these are baked into the WKWebView at creation and never
+      // re-applied on prop updates, so they can't be gated on the live
+      // allowsTwitchInteraction. Keep them permissive: during playback
+      // pointerEvents='none' blocks touches from reaching the WebView anyway,
+      // and when a content gate hands control to Twitch's login the fields must
+      // be focusable and typeable (keyboard without a prior user gesture).
+      keyboardDisplayRequiresUserAction={false}
       setBuiltInZoomControls={false}
       setDisplayZoomControls={false}
       setSupportMultipleWindows={false}
       sharedCookiesEnabled
       thirdPartyCookiesEnabled
-      // Text interaction (selection + the paste callout) is off while foam owns
-      // the chrome, but must be on when a content gate hands control back to
-      // Twitch so the user can paste into the login form.
-      textInteractionEnabled={allowsTwitchInteraction}
+      // Applied to the WKWebView config at creation only (never on live
+      // updates), so it can't track allowsTwitchInteraction. Left on so the
+      // login form the content gate hands off to is selectable/pasteable;
+      // pointerEvents='none' keeps it inert during normal playback.
+      textInteractionEnabled
       originWhitelist={['*']}
       source={source}
       injectedJavaScript={injectedJavaScript}

--- a/src/components/StreamPlayer/StreamPlayerWebView.tsx
+++ b/src/components/StreamPlayer/StreamPlayerWebView.tsx
@@ -178,7 +178,10 @@ export const StreamPlayerWebView = memo(function StreamPlayerWebView({
       setSupportMultipleWindows={false}
       sharedCookiesEnabled
       thirdPartyCookiesEnabled
-      textInteractionEnabled={false}
+      // Text interaction (selection + the paste callout) is off while foam owns
+      // the chrome, but must be on when a content gate hands control back to
+      // Twitch so the user can paste into the login form.
+      textInteractionEnabled={allowsTwitchInteraction}
       originWhitelist={['*']}
       source={source}
       injectedJavaScript={injectedJavaScript}

--- a/src/components/StreamPlayer/StreamPlayerWebView.tsx
+++ b/src/components/StreamPlayer/StreamPlayerWebView.tsx
@@ -172,22 +172,16 @@ export const StreamPlayerWebView = memo(function StreamPlayerWebView({
       // don't delay the overlay's tap.
       pointerEvents={allowsTwitchInteraction ? 'auto' : 'none'}
       scrollEnabled={allowsTwitchInteraction}
-      // Both of these are baked into the WKWebView at creation and never
-      // re-applied on prop updates, so they can't be gated on the live
-      // allowsTwitchInteraction. Keep them permissive: during playback
-      // pointerEvents='none' blocks touches from reaching the WebView anyway,
-      // and when a content gate hands control to Twitch's login the fields must
-      // be focusable and typeable (keyboard without a prior user gesture).
+      // Baked into the WKWebView config at creation and never re-applied on
+      // prop updates, so these can't track the live allowsTwitchInteraction.
+      // Kept permissive so the content gate's login form is focusable/typeable;
+      // pointerEvents='none' keeps the WebView inert during normal playback.
       keyboardDisplayRequiresUserAction={false}
       setBuiltInZoomControls={false}
       setDisplayZoomControls={false}
       setSupportMultipleWindows={false}
       sharedCookiesEnabled
       thirdPartyCookiesEnabled
-      // Applied to the WKWebView config at creation only (never on live
-      // updates), so it can't track allowsTwitchInteraction. Left on so the
-      // login form the content gate hands off to is selectable/pasteable;
-      // pointerEvents='none' keeps it inert during normal playback.
       textInteractionEnabled
       originWhitelist={['*']}
       source={source}

--- a/src/components/StreamPlayer/__tests__/twitchPlayerSource.test.ts
+++ b/src/components/StreamPlayer/__tests__/twitchPlayerSource.test.ts
@@ -42,6 +42,17 @@ describe('twitchPlayerSource', () => {
     expect(script).toContain('hasContentGate: hasGate');
     // Only posts on a change, so the bridge isn't spammed every tick.
     expect(script).toContain('if (lastReported === hasGate) { return; }');
+    // Stays interactive across the whole login flow: tapping the gate's login
+    // link navigates off player.twitch.tv, and the WebView must stay tappable so
+    // the user can type/paste credentials.
+    expect(script).toContain(
+      "window.location.hostname.indexOf('player.twitch.tv') === -1",
+    );
+    expect(script).toContain('isInAuthFlow() || isBlockingGate()');
+    // Only the top frame reports, so a login subframe can't race it.
+    expect(script).toContain(
+      'if (window.top !== window.self) { return true; }',
+    );
   });
 
   test('latency tracker drives the video-stats menu and reads the latency node', () => {

--- a/src/components/StreamPlayer/__tests__/twitchPlayerSource.test.ts
+++ b/src/components/StreamPlayer/__tests__/twitchPlayerSource.test.ts
@@ -5,6 +5,7 @@ import {
   buildTwitchCaptionHiderScript,
   buildTwitchClipPlayerUrl,
   buildTwitchContentGateAcceptScript,
+  buildTwitchContentGateWatcherScript,
   buildTwitchLatencyTrackerScript,
   buildTwitchLiveSyncScript,
   buildTwitchOverlayHideScript,
@@ -21,6 +22,26 @@ describe('twitchPlayerSource', () => {
       'asyncQuerySelector(\'button[data-a-target*="content-classification-gate"]\', 10000)',
     );
     expect(script).toContain('button.click()');
+  });
+
+  test('content-gate watcher reports a login-required gate so the WebView becomes tappable', () => {
+    const script = buildTwitchContentGateWatcherScript();
+
+    // Finds the gate overlay by the same wildcard the accept script uses.
+    expect(script).toContain(
+      'var GATE_SELECTOR = \'[data-a-target*="content-classification-gate"]\'',
+    );
+    // A gate blocks only when it has no auto-clickable continue button - i.e. it
+    // requires login - so the anonymous mature gate (auto-accepted elsewhere) is
+    // never reported as blocking.
+    expect(script).toContain(
+      '!gate.querySelector(\'button[data-a-target*="content-classification-gate"]\')',
+    );
+    // Posts the bridge message the player uses to re-enable WebView interaction.
+    expect(script).toContain("type: 'contentGateDetected'");
+    expect(script).toContain('hasContentGate: hasGate');
+    // Only posts on a change, so the bridge isn't spammed every tick.
+    expect(script).toContain('if (lastReported === hasGate) { return; }');
   });
 
   test('latency tracker drives the video-stats menu and reads the latency node', () => {

--- a/src/components/StreamPlayer/__tests__/twitchPlayerSource.test.ts
+++ b/src/components/StreamPlayer/__tests__/twitchPlayerSource.test.ts
@@ -27,7 +27,6 @@ describe('twitchPlayerSource', () => {
   test('content-gate watcher reports a login-required gate so the WebView becomes tappable', () => {
     const script = buildTwitchContentGateWatcherScript();
 
-    // Finds the gate overlay by the same wildcard the accept script uses.
     expect(script).toContain(
       'var GATE_SELECTOR = \'[data-a-target*="content-classification-gate"]\'',
     );
@@ -40,11 +39,15 @@ describe('twitchPlayerSource', () => {
     // Posts the bridge message the player uses to re-enable WebView interaction.
     expect(script).toContain("type: 'contentGateDetected'");
     expect(script).toContain('hasContentGate: hasGate');
+
     // Only posts on a change, so the bridge isn't spammed every tick.
     expect(script).toContain('if (lastReported === hasGate) { return; }');
-    // Stays interactive across the whole login flow: tapping the gate's login
-    // link navigates off player.twitch.tv, and the WebView must stay tappable so
-    // the user can type/paste credentials.
+
+    /**
+     * Stays interactive across the whole login flow: tapping the gate's login
+     * link navigates off player.twitch.tv, and the WebView must stay tappable so
+     * the user can type/paste credentials.
+     */
     expect(script).toContain(
       "window.location.hostname.indexOf('player.twitch.tv') === -1",
     );

--- a/src/components/StreamPlayer/__tests__/twitchPlayerSource.test.ts
+++ b/src/components/StreamPlayer/__tests__/twitchPlayerSource.test.ts
@@ -51,7 +51,16 @@ describe('twitchPlayerSource', () => {
     expect(script).toContain(
       "window.location.hostname.indexOf('player.twitch.tv') === -1",
     );
-    expect(script).toContain('isInAuthFlow() || isBlockingGate()');
+    expect(script).toContain('return isInAuthFlow() || isBlockingGate();');
+    /**
+     * Tapping the login link removes the gate before window.location updates to
+     * the auth host, so a synchronous clear would disable the WebView just as the
+     * login form appears. Once interactive, the clear is deferred and re-checked
+     * so a pending navigation can settle before interaction is handed back.
+     */
+    expect(script).toContain('if (lastReported === true) {');
+    expect(script).toContain('clearTimer = setTimeout(function() {');
+    expect(script).toContain('if (!isActive()) { post(false); }');
     // Only the top frame reports, so a login subframe can't race it.
     expect(script).toContain(
       'if (window.top !== window.self) { return true; }',

--- a/src/components/StreamPlayer/twitchPlayerSource.ts
+++ b/src/components/StreamPlayer/twitchPlayerSource.ts
@@ -1140,6 +1140,73 @@ true;`;
 }
 
 /**
+ * Reports whether a login-required content-classification gate is blocking the
+ * player. The anonymous mature gate is auto-dismissed by
+ * `buildTwitchContentGateAcceptScript` (it clicks the continue button), but some
+ * restricted content forces a "you must log in or create an account to continue"
+ * gate that has no continue button - only login/create-account links. On the
+ * custom player the WebView is normally non-interactive (foam draws its own
+ * controls over it), so those links can't be tapped. Posting
+ * `contentGateDetected { hasContentGate: true }` flips the WebView back to
+ * interactive so the user can reach them, and `false` once the gate clears.
+ */
+export function buildTwitchContentGateWatcherScript(): string {
+  return `
+(function() {
+  if (window.__foamContentGateWatcherInstalled) { return true; }
+  window.__foamContentGateWatcherInstalled = true;
+
+  var GATE_SELECTOR = '[data-a-target*="content-classification-gate"]';
+  var lastReported = null;
+
+  function post(hasGate) {
+    if (lastReported === hasGate) { return; }
+    lastReported = hasGate;
+    try {
+      window.ReactNativeWebView.postMessage(JSON.stringify({
+        type: 'contentGateDetected',
+        payload: { hasContentGate: hasGate }
+      }));
+    } catch (e) {}
+  }
+
+  // The gate overlay container and its buttons both match GATE_SELECTOR; pick
+  // the container (the accept script targets the button, so the container comes
+  // first in document order and is never itself a <button>).
+  function findGate() {
+    var candidates = document.querySelectorAll(GATE_SELECTOR);
+    for (var i = 0; i < candidates.length; i++) {
+      if (candidates[i].tagName !== 'BUTTON') { return candidates[i]; }
+    }
+    return null;
+  }
+
+  // A gate blocks only when it can't be auto-accepted: the anonymous mature gate
+  // carries a continue button (which the accept script clicks), whereas the
+  // login-required gate has none, so it stays up until the user logs in.
+  function isBlockingGate() {
+    var gate = findGate();
+    if (!gate) { return false; }
+    return !gate.querySelector('button[data-a-target*="content-classification-gate"]');
+  }
+
+  function check() {
+    post(isBlockingGate());
+  }
+
+  check();
+  var observer = new MutationObserver(check);
+  observer.observe(document.body || document.documentElement, {
+    childList: true,
+    subtree: true
+  });
+  setInterval(check, 1000);
+  return true;
+})();
+true;`;
+}
+
+/**
  * Hides the stock player's chrome so only the video shows when foam draws its
  * own overlay controls: hides .top-bar, .player-controls and
  * #channel-player-disclosures, re-applying them as the .video-player__overlay

--- a/src/components/StreamPlayer/twitchPlayerSource.ts
+++ b/src/components/StreamPlayer/twitchPlayerSource.ts
@@ -1200,8 +1200,37 @@ export function buildTwitchContentGateWatcherScript(): string {
     }
   }
 
+  function isActive() {
+    return isInAuthFlow() || isBlockingGate();
+  }
+
+  // Tapping the gate's login link removes the gate from the DOM, which fires the
+  // observer's check() a beat before window.location updates to the auth host -
+  // so both predicates momentarily read false. Handing interaction straight back
+  // then would kill the WebView just as the login form appears. Once we've been
+  // interactive, defer any clear so a pending navigation can settle first; if the
+  // page is still on the embed with no gate after that, it was a genuine clear.
+  var clearTimer = null;
+
   function check() {
-    post(isInAuthFlow() || isBlockingGate());
+    if (isActive()) {
+      if (clearTimer !== null) {
+        clearTimeout(clearTimer);
+        clearTimer = null;
+      }
+      post(true);
+      return;
+    }
+    if (lastReported === true) {
+      if (clearTimer === null) {
+        clearTimer = setTimeout(function() {
+          clearTimer = null;
+          if (!isActive()) { post(false); }
+        }, 600);
+      }
+      return;
+    }
+    post(false);
   }
 
   check();

--- a/src/components/StreamPlayer/twitchPlayerSource.ts
+++ b/src/components/StreamPlayer/twitchPlayerSource.ts
@@ -1172,9 +1172,8 @@ export function buildTwitchContentGateWatcherScript(): string {
     } catch (e) {}
   }
 
-  // The gate overlay container and its buttons both match GATE_SELECTOR; pick
-  // the container (the accept script targets the button, so the container comes
-  // first in document order and is never itself a <button>).
+  // The overlay container and its buttons both match GATE_SELECTOR; return the
+  // container, which is never itself a <button>.
   function findGate() {
     var candidates = document.querySelectorAll(GATE_SELECTOR);
     for (var i = 0; i < candidates.length; i++) {
@@ -1183,20 +1182,16 @@ export function buildTwitchContentGateWatcherScript(): string {
     return null;
   }
 
-  // A gate blocks only when it can't be auto-accepted: the anonymous mature gate
-  // carries a continue button (which the accept script clicks), whereas the
-  // login-required gate has none, so it stays up until the user logs in.
+  // Blocks only when it has no continue button: the mature gate carries one
+  // (auto-clicked by the accept script), the login-required gate does not.
   function isBlockingGate() {
     var gate = findGate();
     if (!gate) { return false; }
     return !gate.querySelector('button[data-a-target*="content-classification-gate"]');
   }
 
-  // The player embed lives on player.twitch.tv; any other host means the gate's
-  // "log in"/"create an account" link has navigated the WebView into Twitch's
-  // auth flow. Keep interaction on for that whole interstitial so the user can
-  // type and paste credentials - it only clears once we're back on the embed
-  // and the gate is gone.
+  // Any host other than the player embed means the gate's login link navigated
+  // into Twitch's auth flow; keep interaction on until we're back on the embed.
   function isInAuthFlow() {
     try {
       return window.location.hostname.indexOf('player.twitch.tv') === -1;

--- a/src/components/StreamPlayer/twitchPlayerSource.ts
+++ b/src/components/StreamPlayer/twitchPlayerSource.ts
@@ -1153,6 +1153,8 @@ true;`;
 export function buildTwitchContentGateWatcherScript(): string {
   return `
 (function() {
+  // Only the top frame drives interaction; a subframe reporting would race it.
+  if (window.top !== window.self) { return true; }
   if (window.__foamContentGateWatcherInstalled) { return true; }
   window.__foamContentGateWatcherInstalled = true;
 
@@ -1190,8 +1192,21 @@ export function buildTwitchContentGateWatcherScript(): string {
     return !gate.querySelector('button[data-a-target*="content-classification-gate"]');
   }
 
+  // The player embed lives on player.twitch.tv; any other host means the gate's
+  // "log in"/"create an account" link has navigated the WebView into Twitch's
+  // auth flow. Keep interaction on for that whole interstitial so the user can
+  // type and paste credentials - it only clears once we're back on the embed
+  // and the gate is gone.
+  function isInAuthFlow() {
+    try {
+      return window.location.hostname.indexOf('player.twitch.tv') === -1;
+    } catch (e) {
+      return false;
+    }
+  }
+
   function check() {
-    post(isBlockingGate());
+    post(isInAuthFlow() || isBlockingGate());
   }
 
   check();

--- a/src/services/__tests__/ffz-service.test.ts
+++ b/src/services/__tests__/ffz-service.test.ts
@@ -5,6 +5,7 @@ import type {
   FfzGlobalEmotesResponse,
 } from '@app/types/ffz/emote';
 
+import { ApiError } from '../api/Client';
 import { ffzApi } from '../api/clients';
 import { ffzService } from '../ffz-service';
 
@@ -145,6 +146,22 @@ describe('ffzService', () => {
     });
 
     const result = await ffzService.getSanitisedChannelEmotes('999');
+
+    expect(result).toEqual([]);
+  });
+
+  test('getSanitisedChannelEmotes returns an empty list when the API throws a 404', async () => {
+    api.get.mockRejectedValue(new ApiError('No such room', 404, 'FFZApiError'));
+
+    const result = await ffzService.getSanitisedChannelEmotes('999');
+
+    expect(result).toEqual([]);
+  });
+
+  test('getSanitisedChannelBadges returns an empty list when the API throws a 404', async () => {
+    api.get.mockRejectedValue(new ApiError('No such room', 404, 'FFZApiError'));
+
+    const result = await ffzService.getSanitisedChannelBadges('999');
 
     expect(result).toEqual([]);
   });

--- a/src/services/__tests__/ffz-service.test.ts
+++ b/src/services/__tests__/ffz-service.test.ts
@@ -165,4 +165,20 @@ describe('ffzService', () => {
 
     expect(result).toEqual([]);
   });
+
+  test('getSanitisedChannelEmotes rethrows a 404 that is not a "No such room" error', async () => {
+    api.get.mockRejectedValue(new ApiError('Not Found', 404, 'FFZApiError'));
+
+    await expect(ffzService.getSanitisedChannelEmotes('999')).rejects.toThrow(
+      'Not Found',
+    );
+  });
+
+  test('getSanitisedChannelBadges rethrows a 404 that is not a "No such room" error', async () => {
+    api.get.mockRejectedValue(new ApiError('Not Found', 404, 'FFZApiError'));
+
+    await expect(ffzService.getSanitisedChannelBadges('999')).rejects.toThrow(
+      'Not Found',
+    );
+  });
 });

--- a/src/services/api/Client.ts
+++ b/src/services/api/Client.ts
@@ -255,22 +255,32 @@ export function createApiClient({
         }
       }
 
-      const logFailure = response.status >= 500 ? log.error : log.warn;
-      logFailure(`${method} ${path} ${response.status}`, {
-        name: errorName,
-        exceptionName,
-        tags: {
-          service,
-          method,
-          status: String(response.status),
-          endpoint: String(context.endpoint ?? path),
-        },
-        // Group by service + method + path + status so each broken endpoint
-        // creates exactly one Sentry issue regardless of query params.
-        fingerprint: [service, method, path, String(response.status)],
-        action: 'response_error_status',
-        ...context,
-      });
+      // FFZ returns 404 "No such room" for channels that have never configured
+      // FFZ; it's a benign empty result the caller handles, so don't log it (and
+      // don't forward it to Sentry).
+      const isExpectedFfzNoRoom =
+        service === 'ffz' &&
+        response.status === 404 &&
+        body.includes('No such room');
+
+      if (!isExpectedFfzNoRoom) {
+        const logFailure = response.status >= 500 ? log.error : log.warn;
+        logFailure(`${method} ${path} ${response.status}`, {
+          name: errorName,
+          exceptionName,
+          tags: {
+            service,
+            method,
+            status: String(response.status),
+            endpoint: String(context.endpoint ?? path),
+          },
+          // Group by service + method + path + status so each broken endpoint
+          // creates exactly one Sentry issue regardless of query params.
+          fingerprint: [service, method, path, String(response.status)],
+          action: 'response_error_status',
+          ...context,
+        });
+      }
 
       throw new ApiError(
         body || `${method} ${path} ${response.status}`,

--- a/src/services/api/__tests__/Client.test.ts
+++ b/src/services/api/__tests__/Client.test.ts
@@ -202,6 +202,38 @@ describe('createApiClient', () => {
     expect(jest.mocked(logger.api.error)).not.toHaveBeenCalled();
   });
 
+  test('does not log the benign FFZ "No such room" 404', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(
+        { status: 404, error: 'Not Found', message: 'No such room' },
+        404,
+      ),
+    );
+    const client = createApiClient({
+      baseURL: 'https://api.frankerfacez.com/v1',
+      logPrefix: 'ffz',
+    });
+
+    await expect(client.get('/room/id/999')).rejects.toBeInstanceOf(ApiError);
+
+    expect(jest.mocked(logger.ffz.warn)).not.toHaveBeenCalled();
+    expect(jest.mocked(logger.ffz.error)).not.toHaveBeenCalled();
+  });
+
+  test('still logs other FFZ 404s that are not "No such room"', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ message: 'Not Found' }, 404),
+    );
+    const client = createApiClient({
+      baseURL: 'https://api.frankerfacez.com/v1',
+      logPrefix: 'ffz',
+    });
+
+    await expect(client.get('/set/global')).rejects.toBeInstanceOf(ApiError);
+
+    expect(jest.mocked(logger.ffz.warn)).toHaveBeenCalledTimes(1);
+  });
+
   test('logs 5xx failures at error level', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ message: 'boom' }, 500));
     const client = createApiClient({ baseURL: 'https://api.test/helix' });

--- a/src/services/ffz-service.ts
+++ b/src/services/ffz-service.ts
@@ -24,7 +24,11 @@ interface FFzErrorResponse {
  * that is a benign empty result, not a failure worth logging.
  */
 function isNoSuchRoomError(error: unknown): boolean {
-  return error instanceof ApiError && error.status === 404;
+  return (
+    error instanceof ApiError &&
+    error.status === 404 &&
+    error.message.includes('No such room')
+  );
 }
 
 function toFfzStaticUrl(emoteId: number, scale: '2x' | '4x'): string {

--- a/src/services/ffz-service.ts
+++ b/src/services/ffz-service.ts
@@ -9,6 +9,7 @@ import type {
 import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
 import { logger } from '@app/utils/logger';
 
+import { ApiError } from './api/Client';
 import { ffzApi } from './api/clients';
 import { buildSanitisedEmote } from './emote-provider';
 
@@ -16,6 +17,16 @@ interface FFzErrorResponse {
   status: number;
   error: string;
   message: string;
+}
+
+/**
+ * FFZ returns a 404 "No such room" for any channel that has never configured
+ * FFZ. That is an expected, benign outcome - the channel simply has no FFZ
+ * emotes or badges - so callers treat it as an empty result rather than a
+ * failure to log and re-throw.
+ */
+function isNoSuchRoomError(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 404;
 }
 
 function toFfzStaticUrl(emoteId: number, scale: '2x' | '4x'): string {
@@ -152,6 +163,9 @@ export const ffzService = {
 
       return sanitisedBadges;
     } catch (error) {
+      if (isNoSuchRoomError(error)) {
+        return [];
+      }
       logger.ffz.warn('Failed to fetch channel FFZ badges', {
         name: 'ffz_badges_warning',
         error,
@@ -188,6 +202,9 @@ export const ffzService = {
       }
       return [];
     } catch (error) {
+      if (isNoSuchRoomError(error)) {
+        return [];
+      }
       logger.ffz.warn(`Failed to fetch channel FFZ emotes for ${channelId}`, {
         name: 'ffz_emotes_warning',
         error,

--- a/src/services/ffz-service.ts
+++ b/src/services/ffz-service.ts
@@ -20,10 +20,8 @@ interface FFzErrorResponse {
 }
 
 /**
- * FFZ returns a 404 "No such room" for any channel that has never configured
- * FFZ. That is an expected, benign outcome - the channel simply has no FFZ
- * emotes or badges - so callers treat it as an empty result rather than a
- * failure to log and re-throw.
+ * FFZ returns a 404 "No such room" for channels that have never configured FFZ;
+ * that is a benign empty result, not a failure worth logging.
  */
 function isNoSuchRoomError(error: unknown): boolean {
   return error instanceof ApiError && error.status === 404;


### PR DESCRIPTION
Closes #696

## Problem

When a channel's content is gated behind a login-required content-classification gate ("you must log in or create an account to continue"), the gate renders over the custom player but its **log in** / **create an account** links can't be tapped.

## Root cause

The custom player draws foam's own controls over a non-interactive WebView (`pointerEvents='none'`). It flips the WebView back to interactive via `hasContentGate` - but nothing in the custom-player injected-script path ever emitted a `contentGateDetected` message, so `hasContentGate` was always `false`. The plumbing (`allowsTwitchInteraction`, `containerScrollable`, `onContentGateChange`) already existed and was tested; only the emitter was missing.

The anonymous mature gate is a non-issue because `buildTwitchContentGateAcceptScript` auto-clicks its continue button. The login-required gate has no continue button, so it just sits there, unclickable.

## Fix

Add `buildTwitchContentGateWatcherScript`, injected only on the custom-player path (`showOverlayControls && !clip`). It watches the DOM for a content-classification gate and reports it as **blocking** only when there's no auto-clickable continue button - i.e. login is required. That posts `contentGateDetected { hasContentGate: true }`, which re-enables WebView interaction so the user can reach the login link, and `false` once the gate clears.

- The anonymous mature gate still auto-accepts and is never reported as blocking.
- Keyed on the same `content-classification-gate` wildcard the accept script already uses, so it doesn't depend on gate copy/localization.
- Only posts on a state change, so the bridge isn't spammed each tick.

## Testing

- New unit test for the watcher script in `twitchPlayerSource.test.ts`
- Full `StreamPlayer` / `twitchPlayerSource` / `playerBridgeInterpreter` suites pass (87 tests)
- Typecheck + lint clean