### PR TITLE
fix(updates): drain in-flight fetches before applying an OTA update

### DIFF
--- a/src/hooks/useOTAUpdates.ts
+++ b/src/hooks/useOTAUpdates.ts
@@ -15,6 +15,7 @@ import {
 } from 'expo-updates';
 
 import i18next from '@app/i18n/i18next';
+import { queryClient } from '@app/lib/react-query/query-client';
 import { countOtaMetric } from '@app/lib/sentry';
 import { theme } from '@app/styles/themes';
 import {
@@ -25,6 +26,13 @@ import { logger } from '@app/utils/logger';
 
 const MINIMUM_MINIMIZE_TIME = 15 * 60e3; // 15 minutes
 const INITIAL_CHECK_DELAY = 3e3; // 3 seconds
+
+// reloadAsync() invalidates the JS runtime; an in-flight expo/fetch request
+// still settling on a background queue then destroys its JSI Promise/Object
+// against the dead runtime and crashes (EXC_BAD_ACCESS in ~Pointer, #699). We
+// cancel queries to abort their AbortController-backed fetches, then wait this
+// long for the native teardown to drain before reloading.
+const RELOAD_DRAIN_DELAY = 250; // ms
 
 const OTA_RELOAD_SCREEN_OPTIONS = {
   backgroundColor: theme.color.background.dark,
@@ -139,9 +147,18 @@ export function useOTAUpdates() {
 
   const applyUpdate = useCallback(async () => {
     try {
+      // Deliberately sequential: abort in-flight fetches, let the native
+      // teardown drain, then reload. Parallelising would reintroduce #699.
+      /* eslint-disable react-doctor/async-parallel */
+      await queryClient.cancelQueries();
+      await new Promise<void>(resolve => {
+        setTimeout(resolve, RELOAD_DRAIN_DELAY);
+      });
+
       await reloadAsync({
         reloadScreenOptions: OTA_RELOAD_SCREEN_OPTIONS,
       });
+      /* eslint-enable react-doctor/async-parallel */
     } catch (error) {
       const parsedError =
         error instanceof Error ? error : new Error(String(error));

--- a/src/hooks/useOTAUpdates.ts
+++ b/src/hooks/useOTAUpdates.ts
@@ -147,9 +147,7 @@ export function useOTAUpdates() {
 
   const applyUpdate = useCallback(async () => {
     try {
-      // Deliberately sequential: abort in-flight fetches, let the native
-      // teardown drain, then reload. Parallelising would reintroduce #699.
-      /* eslint-disable react-doctor/async-parallel */
+      /* eslint-disable react-doctor/async-parallel -- must stay sequential; parallelising reintroduces #699 */
       await queryClient.cancelQueries();
       await new Promise<void>(resolve => {
         setTimeout(resolve, RELOAD_DRAIN_DELAY);

--- a/src/hooks/useOTAUpdates.ts
+++ b/src/hooks/useOTAUpdates.ts
@@ -15,7 +15,6 @@ import {
 } from 'expo-updates';
 
 import i18next from '@app/i18n/i18next';
-import { queryClient } from '@app/lib/react-query/query-client';
 import { countOtaMetric } from '@app/lib/sentry';
 import { theme } from '@app/styles/themes';
 import {
@@ -26,13 +25,6 @@ import { logger } from '@app/utils/logger';
 
 const MINIMUM_MINIMIZE_TIME = 15 * 60e3; // 15 minutes
 const INITIAL_CHECK_DELAY = 3e3; // 3 seconds
-
-// reloadAsync() invalidates the JS runtime; an in-flight expo/fetch request
-// still settling on a background queue then destroys its JSI Promise/Object
-// against the dead runtime and crashes (EXC_BAD_ACCESS in ~Pointer, #699). We
-// cancel queries to abort their AbortController-backed fetches, then wait this
-// long for the native teardown to drain before reloading.
-const RELOAD_DRAIN_DELAY = 250; // ms
 
 const OTA_RELOAD_SCREEN_OPTIONS = {
   backgroundColor: theme.color.background.dark,
@@ -147,16 +139,9 @@ export function useOTAUpdates() {
 
   const applyUpdate = useCallback(async () => {
     try {
-      /* eslint-disable react-doctor/async-parallel -- must stay sequential; parallelising reintroduces #699 */
-      await queryClient.cancelQueries();
-      await new Promise<void>(resolve => {
-        setTimeout(resolve, RELOAD_DRAIN_DELAY);
-      });
-
       await reloadAsync({
         reloadScreenOptions: OTA_RELOAD_SCREEN_OPTIONS,
       });
-      /* eslint-enable react-doctor/async-parallel */
     } catch (error) {
       const parsedError =
         error instanceof Error ? error : new Error(String(error));
@@ -215,8 +200,6 @@ export function useOTAUpdates() {
   checkForUpdatesRef.current = checkForUpdates;
   const promptAndReloadRef = useRef(promptAndReload);
   promptAndReloadRef.current = promptAndReload;
-  const applyUpdateRef = useRef(applyUpdate);
-  applyUpdateRef.current = applyUpdate;
 
   useEffect(() => {
     if (!shouldReceiveUpdates || ranInitialCheck.current) {
@@ -286,7 +269,7 @@ export function useOTAUpdates() {
       return;
     }
 
-    const unsubscribe = subscribeToAppStateTransitions(async transition => {
+    const unsubscribe = subscribeToAppStateTransitions(transition => {
       if (isForegroundTransition(transition)) {
         const shouldUpdate =
           isProduction ||
@@ -295,26 +278,28 @@ export function useOTAUpdates() {
         if (shouldUpdate) {
           if (getIsUpdatePending()) {
             if (isProduction) {
+              // Do not force a reload here: reloadAsync() races the reconnect
+              // refetch burst that fires on the same foreground and tears down
+              // the runtime mid-fetch (#699). The update is already downloaded,
+              // so expo-updates applies it on the next cold start.
               logger.main.info(
-                'App foregrounded with pending update, reloading',
+                'App foregrounded with pending update, deferring to cold start',
                 {
                   name: 'ota_updates_service_info',
                   category: 'ota',
-                  action: 'foreground_auto_reload',
+                  action: 'foreground_defer_to_cold_start',
                   timeSinceMinimize: Date.now() - lastMinimize.current,
                   isProduction,
                 },
               );
 
-              countOtaMetric('ota.update.applied', {
+              countOtaMetric('ota.update.deferred', {
                 category: 'ota',
                 environment: isProduction ? 'production' : 'non-production',
                 platform: Platform.OS,
-                method: 'auto_on_foreground',
+                method: 'cold_start',
                 channel: Updates.channel || 'unknown',
               });
-
-              await applyUpdateRef.current();
             } else {
               promptAndReloadRef.current();
             }

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -307,7 +307,8 @@ export type OtaMetrics =
   | 'ota.update.fetched'
   | 'ota.update.pending'
   | 'ota.update.alert_shown'
-  | 'ota.update.applied';
+  | 'ota.update.applied'
+  | 'ota.update.deferred';
 
 const RESERVED_LOG_META_KEYS = new Set([
   'name',


### PR DESCRIPTION
Fixes #699.

## The crash

Native `EXC_BAD_ACCESS` (null-pointer deref) in `facebook::jsi::Pointer::~Pointer`. Seer + a code trace ([#699](https://github.com/luke-h1/foam/issues/699)) pinned it: `Updates.reloadAsync()` invalidates the JS runtime while an in-flight `expo/fetch` request is still settling on a background dispatch queue. When that response's queued JSI `Promise`/`Object` wrappers are released, their destructors dereference the now-null runtime and crash.

**Reachable race:** on app foreground, `useOTAUpdates` auto-applies a pending production update by calling `reloadAsync()` at the same moment `query-provider`'s reconnect path (`onlineManager.setOnline(true)` + `refetchOnReconnect: true`) fires a burst of `expo/fetch` queries through `Client.ts`. The reload tears down the runtime mid-flight.

## The fix

Stop force-reloading on foreground for production. The update has already been downloaded (`fetchUpdateAsync`), so it's pending - and expo-updates applies pending updates on the next launch anyway. Deferring the apply to the next cold start removes the reload/fetch race entirely: there is no programmatic `reloadAsync()` racing the reconnect burst.

- **Production:** foreground with a pending update now logs `foreground_defer_to_cold_start` and emits an `ota.update.deferred` metric instead of reloading. The update applies on the next cold start.
- **Internal:** unchanged - still shows the user-initiated relaunch prompt. A reload triggered by an explicit tap happens seconds after foreground, well after the reconnect burst has settled, so it isn't the automatic race.

### Why not drain in-flight fetches instead?

An earlier revision tried `queryClient.cancelQueries()` + a short drain delay before reloading. That doesn't work: neither the queryFns nor `Client.ts` thread react-query's `AbortSignal` down to `expo/fetch` (`request()` mints its own `AbortController` purely for the timeout, and the public `get/post` methods take no `signal`). So `cancelQueries()` only flips cache entries to cancelled - the underlying HTTP requests keep running and can still settle post-reload. Making that path real would require plumbing `AbortSignal` through every service method and queryFn app-wide. The cold-start defer is race-free with no plumbing.

## Trade-off

Production updates now apply on the next cold start rather than immediately on foreground. For the silent auto-apply path this is barely perceptible, and it's the common Expo pattern. If immediate-foreground apply must be preserved, the alternative is the app-wide `AbortSignal` plumbing described above; worth an upstream `expo-updates` report either way.

## Testing

`ts:check`, `eslint`, `prettier` clean. No behavior change to the check/download/prompt logic or the internal relaunch prompt; only the production foreground apply is deferred.
