### PR TITLE
fix(chat): fix 7TV badges/cosmetics loading and emote sheet

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -1,7 +1,9 @@
-import { memo, useCallback, useEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { View } from 'react-native';
 import { KeyboardStickyView } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { useSelector } from '@legendapp/state/react';
 
 import { useAuthContext } from '@app/context/AuthContext';
 import { BenchFrameProbe } from '@app/dev/imageBenchmark/BenchFrameProbe.gate';
@@ -195,6 +197,14 @@ export const Chat = memo(
       user,
     });
 
+    const cosmeticBindingsVersion = useSelector(() =>
+      chatStore$.cosmeticBindingsVersion.get(),
+    );
+    const emoteReprocessKey = useMemo(
+      () => `${chatAssetPreferenceKey}|${cosmeticBindingsVersion}`,
+      [chatAssetPreferenceKey, cosmeticBindingsVersion],
+    );
+
     return (
       <CachedEmotesProvider channelId={channelId}>
         <View
@@ -210,7 +220,7 @@ export const Chat = memo(
             emoteLoadStatus={emoteLoadStatus}
             messages$={messages$}
             processedMessageIdsRef={processedMessageIdsRef}
-            reprocessKey={chatAssetPreferenceKey}
+            reprocessKey={emoteReprocessKey}
           />
           <View style={styles.keyboardAvoidingView}>
             <View style={styles.chatContainer}>

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -3,13 +3,12 @@ import { View } from 'react-native';
 import { KeyboardStickyView } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { useSelector } from '@legendapp/state/react';
-
 import { useAuthContext } from '@app/context/AuthContext';
 import { BenchFrameProbe } from '@app/dev/imageBenchmark/BenchFrameProbe.gate';
 import { CachedEmotesProvider } from '@app/Providers/CachedEmotesProvider/CachedEmotesProvider';
 import { setChatFrontTrimSuspended } from '@app/store/chat/actions/messages';
 import { chatStore$ } from '@app/store/chat/observables/chatStore';
+import { useCosmeticBindingsVersion } from '@app/store/chat/react/selectors';
 import {
   useChatRenderPreferences,
   useUpdatePreferences,
@@ -197,9 +196,7 @@ export const Chat = memo(
       user,
     });
 
-    const cosmeticBindingsVersion = useSelector(() =>
-      chatStore$.cosmeticBindingsVersion.get(),
-    );
+    const cosmeticBindingsVersion = useCosmeticBindingsVersion();
     const emoteReprocessKey = `${chatAssetPreferenceKey}|${cosmeticBindingsVersion}`;
 
     return (

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import { memo, useCallback, useEffect, useRef } from 'react';
 import { View } from 'react-native';
 import { KeyboardStickyView } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -200,10 +200,7 @@ export const Chat = memo(
     const cosmeticBindingsVersion = useSelector(() =>
       chatStore$.cosmeticBindingsVersion.get(),
     );
-    const emoteReprocessKey = useMemo(
-      () => `${chatAssetPreferenceKey}|${cosmeticBindingsVersion}`,
-      [chatAssetPreferenceKey, cosmeticBindingsVersion],
-    );
+    const emoteReprocessKey = `${chatAssetPreferenceKey}|${cosmeticBindingsVersion}`;
 
     return (
       <CachedEmotesProvider channelId={channelId}>

--- a/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
+++ b/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
@@ -115,6 +115,7 @@ jest.mock('@app/store/chat/actions/cosmetics', () => ({
   fetchAndCacheUserCosmetics: jest.fn(),
   getUserBadge: jest.fn(),
   getUserBadgeId: jest.fn(),
+  getUserPaintId: jest.fn(),
   hasUserPaint: jest.fn(() => false),
   requestUserCosmeticsViaPresence: jest.fn(() => Promise.resolve()),
 }));

--- a/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
+++ b/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
@@ -114,6 +114,9 @@ jest.mock('@app/store/chat/actions/channelLoad', () => ({
 jest.mock('@app/store/chat/actions/cosmetics', () => ({
   fetchAndCacheUserCosmetics: jest.fn(),
   getUserBadge: jest.fn(),
+  getUserBadgeId: jest.fn(),
+  hasUserPaint: jest.fn(() => false),
+  requestUserCosmeticsViaPresence: jest.fn(() => Promise.resolve()),
 }));
 
 jest.mock('@app/store/chat/react/selectors', () => ({
@@ -123,6 +126,9 @@ jest.mock('@app/store/chat/react/selectors', () => ({
 
 jest.mock('@app/store/chat/observables/chatStore', () => ({
   chatStore$: {
+    cosmeticBindingsVersion: {
+      get: jest.fn(() => 0),
+    },
     currentChannelId: {
       set: jest.fn(),
     },

--- a/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
+++ b/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
@@ -122,6 +122,7 @@ jest.mock('@app/store/chat/actions/cosmetics', () => ({
 
 jest.mock('@app/store/chat/react/selectors', () => ({
   useChannelEmoteData: jest.fn(() => null),
+  useCosmeticBindingsVersion: jest.fn(() => 0),
   useMessages: jest.fn(() => []),
 }));
 

--- a/src/components/Chat/components/ChatInputShell.tsx
+++ b/src/components/Chat/components/ChatInputShell.tsx
@@ -248,7 +248,6 @@ export const ChatInputShell = memo(function ChatInputShell({
       ? findBadges({
           userstate: optimisticUserstate,
           chatterinoBadges: emoteData.chatterinoBadges,
-          chatUsers: [],
           ffzChannelBadges: emoteData.ffzChannelBadges,
           ffzGlobalBadges: emoteData.ffzGlobalBadges,
           twitchChannelBadges: emoteData.twitchChannelBadges,

--- a/src/components/Chat/components/EmoteSheet/EmoteSheet.tsx
+++ b/src/components/Chat/components/EmoteSheet/EmoteSheet.tsx
@@ -16,7 +16,7 @@ import { ProviderChip } from './ProviderChip';
 import { emoteSheetScrollActivity } from './util/emoteSheetScrollActivity';
 
 export type { EmotePickerItem };
-import { useMemo, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { LayoutChangeEvent } from 'react-native';
 
@@ -54,14 +54,6 @@ export function EmoteSheet({
       setLayoutWidth(current => (current === nextWidth ? current : nextWidth));
     }
   };
-
-  const setRailExtraData = useMemo(
-    () => ({
-      activeSetId: sheet.activeSetId,
-      onScrollToSet: sheet.handleScrollToSet,
-    }),
-    [sheet.activeSetId, sheet.handleScrollToSet],
-  );
 
   return (
     <BottomSheet
@@ -150,7 +142,7 @@ export function EmoteSheet({
                     },
                   ]}
                   drawDistance={(sheet.cellSize + 4) * 8}
-                  showsVerticalScrollIndicator={true}
+                  showsVerticalScrollIndicator
                   nestedScrollEnabled
                   indicatorStyle='white' // todo - once we have light theme, adjust this
                   style={styles.list}
@@ -173,7 +165,10 @@ export function EmoteSheet({
                   keyExtractor={set => set.id}
                   nestedScrollEnabled
                   renderItem={renderSetRailItem}
-                  extraData={setRailExtraData}
+                  extraData={{
+                    activeSetId: sheet.activeSetId,
+                    onScrollToSet: sheet.handleScrollToSet,
+                  }}
                   showsHorizontalScrollIndicator={false}
                   contentContainerStyle={styles.categoryBarContent}
                 />

--- a/src/components/Chat/components/EmoteSheet/EmoteSheet.tsx
+++ b/src/components/Chat/components/EmoteSheet/EmoteSheet.tsx
@@ -16,7 +16,7 @@ import { ProviderChip } from './ProviderChip';
 import { emoteSheetScrollActivity } from './util/emoteSheetScrollActivity';
 
 export type { EmotePickerItem };
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { LayoutChangeEvent } from 'react-native';
 
@@ -54,6 +54,14 @@ export function EmoteSheet({
       setLayoutWidth(current => (current === nextWidth ? current : nextWidth));
     }
   };
+
+  const setRailExtraData = useMemo(
+    () => ({
+      activeSetId: sheet.activeSetId,
+      onScrollToSet: sheet.handleScrollToSet,
+    }),
+    [sheet.activeSetId, sheet.handleScrollToSet],
+  );
 
   return (
     <BottomSheet
@@ -165,10 +173,7 @@ export function EmoteSheet({
                   keyExtractor={set => set.id}
                   nestedScrollEnabled
                   renderItem={renderSetRailItem}
-                  extraData={{
-                    activeSetId: sheet.activeSetId,
-                    onScrollToSet: sheet.handleScrollToSet,
-                  }}
+                  extraData={setRailExtraData}
                   showsHorizontalScrollIndicator={false}
                   contentContainerStyle={styles.categoryBarContent}
                 />

--- a/src/components/Chat/components/EmoteSheet/EmoteSheet.tsx
+++ b/src/components/Chat/components/EmoteSheet/EmoteSheet.tsx
@@ -142,8 +142,9 @@ export function EmoteSheet({
                     },
                   ]}
                   drawDistance={(sheet.cellSize + 4) * 8}
-                  showsVerticalScrollIndicator={false}
+                  showsVerticalScrollIndicator={true}
                   nestedScrollEnabled
+                  indicatorStyle='white' // todo - once we have light theme, adjust this
                   style={styles.list}
                 />
               )}

--- a/src/components/Chat/hooks/__tests__/__fixtures__/useChatCosmetics.fixture.ts
+++ b/src/components/Chat/hooks/__tests__/__fixtures__/useChatCosmetics.fixture.ts
@@ -1,6 +1,10 @@
 type CachedCosmeticsMocks = {
-  getUserBadgeId: jest.Mock<string | undefined, [string]>;
-  getUserPaintId: jest.Mock<string | undefined, [string]>;
+  getUserBadgeId: jest.MockedFunction<
+    (ttvUserId: string) => string | undefined
+  >;
+  getUserPaintId: jest.MockedFunction<
+    (ttvUserId: string) => string | undefined
+  >;
 };
 
 export function setCachedCosmetics(

--- a/src/components/Chat/hooks/__tests__/__fixtures__/useChatCosmetics.fixture.ts
+++ b/src/components/Chat/hooks/__tests__/__fixtures__/useChatCosmetics.fixture.ts
@@ -1,0 +1,24 @@
+type CachedCosmeticsMocks = {
+  getUserBadgeId: jest.Mock<string | undefined, [string]>;
+  getUserPaintId: jest.Mock<string | undefined, [string]>;
+};
+
+export function setCachedCosmetics(
+  mocks: CachedCosmeticsMocks,
+  {
+    badgeId,
+    paintId,
+    twitchUserId,
+  }: {
+    badgeId?: string;
+    paintId?: string;
+    twitchUserId: string;
+  },
+): void {
+  mocks.getUserBadgeId.mockImplementation(userId =>
+    userId === twitchUserId ? badgeId : undefined,
+  );
+  mocks.getUserPaintId.mockImplementation(userId =>
+    userId === twitchUserId ? paintId : undefined,
+  );
+}

--- a/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
@@ -3,14 +3,13 @@ import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { sevenTvService } from '@app/services/seventv-service';
 import {
   fetchAndCacheUserCosmetics,
+  getUserBadge,
+  getUserBadgeId,
+  hasUserPaint,
   requestUserCosmeticsViaPresence,
 } from '@app/store/chat/actions/cosmetics';
 
 import { useChatCosmetics } from '../useChatCosmetics';
-
-type MockObservableValue<T> = {
-  peek: jest.Mock<T | undefined, []>;
-};
 
 jest.mock('@app/services/seventv-service', () => ({
   sevenTvService: {
@@ -19,9 +18,22 @@ jest.mock('@app/services/seventv-service', () => ({
 }));
 
 jest.mock('@app/store/chat/actions/cosmetics', () => ({
-  fetchAndCacheUserCosmetics: jest.fn(() => Promise.resolve()),
+  fetchAndCacheUserCosmetics: jest.fn(),
+  getUserBadge: jest.fn(),
+  getUserBadgeId: jest.fn(),
+  hasUserPaint: jest.fn(),
   requestUserCosmeticsViaPresence: jest.fn(() => Promise.resolve()),
 }));
+
+jest.mock('@app/utils/logger', () => ({
+  logger: {
+    stv: { debug: jest.fn() },
+  },
+}));
+
+type MockObservableValue<T> = {
+  peek: jest.Mock<T | undefined, []>;
+};
 
 jest.mock('@app/store/chat/observables/chatStore', () => ({
   chatStore$: {
@@ -30,18 +42,11 @@ jest.mock('@app/store/chat/observables/chatStore', () => ({
   },
 }));
 
-jest.mock('@app/utils/logger', () => ({
-  logger: {
-    stvWs: {
-      debug: jest.fn(),
-      info: jest.fn(),
-      warn: jest.fn(),
-    },
-  },
-}));
-
-const mockGetSevenTvUserId = jest.mocked(sevenTvService.get7tvUserId);
+const mockGet7tvUserId = jest.mocked(sevenTvService.get7tvUserId);
 const mockFetchAndCacheUserCosmetics = jest.mocked(fetchAndCacheUserCosmetics);
+const mockGetUserBadge = jest.mocked(getUserBadge);
+const mockGetUserBadgeId = jest.mocked(getUserBadgeId);
+const mockHasUserPaint = jest.mocked(hasUserPaint);
 const mockRequestUserCosmeticsViaPresence = jest.mocked(
   requestUserCosmeticsViaPresence,
 );
@@ -72,31 +77,52 @@ function setCachedCosmetics({
 describe('useChatCosmetics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGet7tvUserId.mockResolvedValue('7tv-user-1');
+    mockFetchAndCacheUserCosmetics.mockResolvedValue('ttv-self');
+    mockGetUserBadge.mockReturnValue(undefined);
+    mockGetUserBadgeId.mockReturnValue(undefined);
+    mockHasUserPaint.mockReturnValue(false);
     Object.keys(mockChatStore.userBadgeIds).forEach(key => {
       delete mockChatStore.userBadgeIds[key];
     });
     Object.keys(mockChatStore.userPaintIds).forEach(key => {
       delete mockChatStore.userPaintIds[key];
     });
-    mockGetSevenTvUserId.mockResolvedValue('7tv-user-1');
-    mockFetchAndCacheUserCosmetics.mockResolvedValue(null);
-    mockRequestUserCosmeticsViaPresence.mockResolvedValue(undefined);
   });
 
-  test('fetches current user cosmetics after mount', async () => {
+  test('bootstraps the signed-in user cosmetics on mount', async () => {
     renderHook(() =>
       useChatCosmetics({
-        userId: 'current-user',
+        userId: 'ttv-self',
       }),
     );
 
     await waitFor(() => {
-      expect(mockGetSevenTvUserId).toHaveBeenCalledWith('current-user');
-      expect(mockFetchAndCacheUserCosmetics).toHaveBeenCalledWith('7tv-user-1');
+      expect(mockGet7tvUserId.mock.calls).toEqual([['ttv-self']]);
+      expect(mockFetchAndCacheUserCosmetics.mock.calls).toEqual([
+        ['7tv-user-1'],
+      ]);
     });
   });
 
-  test('requests chatter cosmetics through the presence push', async () => {
+  test('skips self bootstrap when paint and badge bindings are already known', async () => {
+    mockHasUserPaint.mockReturnValue(true);
+    mockGetUserBadgeId.mockReturnValue('badge-1');
+
+    renderHook(() =>
+      useChatCosmetics({
+        userId: 'ttv-self',
+      }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockFetchAndCacheUserCosmetics).not.toHaveBeenCalled();
+  });
+
+  test('requests cosmetics via passive presence for visible chatters', async () => {
     const { result } = renderHook(() =>
       useChatCosmetics({
         userId: null,
@@ -115,12 +141,21 @@ describe('useChatCosmetics', () => {
     ).toBe(true);
   });
 
-  test('does not refetch users that already have cached paint and badge cosmetics', async () => {
+  test('does not refetch users that already have cached paint and renderable badge cosmetics', async () => {
     setCachedCosmetics({
       badgeId: 'badge-1',
       paintId: 'paint-1',
       twitchUserId: 'cached-user',
     });
+    mockGetUserBadge.mockReturnValue({
+      id: 'badge-1',
+      url: 'https://cdn.7tv.app/badge/badge-1/4x.webp',
+      type: '7TV Badge',
+      title: 'Supporter',
+      set: 'badge-1',
+      provider: '7tv',
+    });
+
     const { result } = renderHook(() =>
       useChatCosmetics({
         userId: null,
@@ -137,11 +172,13 @@ describe('useChatCosmetics', () => {
     ).toBe(true);
   });
 
-  test('retries a previously fetched user when retryMissingBadge is requested and no badge is cached', async () => {
+  test('retries a previously fetched user when retryMissingBadge is requested and no renderable badge exists', async () => {
     setCachedCosmetics({
       paintId: 'paint-1',
       twitchUserId: 'retry-user',
     });
+    mockGetUserBadge.mockReturnValue(undefined);
+
     const { result } = renderHook(() =>
       useChatCosmetics({
         userId: null,
@@ -160,5 +197,8 @@ describe('useChatCosmetics', () => {
       ['retry-user'],
       ['retry-user'],
     ]);
+    expect(
+      result.current.fetchedCosmeticsUsersRef.current.has('retry-user'),
+    ).toBe(true);
   });
 });

--- a/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
@@ -153,9 +153,35 @@ describe('useChatCosmetics', () => {
     ).toBe(true);
   });
 
-  test('retries a previously fetched user when retryMissingBadge is requested and no renderable badge exists', async () => {
+  test('does not refetch paint-only users when retryMissingBadge is requested', async () => {
     setCachedCosmetics({
       paintId: 'paint-1',
+      twitchUserId: 'paint-only-user',
+    });
+    mockGetUserBadge.mockReturnValue(undefined);
+
+    const { result } = renderHook(() =>
+      useChatCosmetics({
+        userId: null,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.fetchUserCosmetics('paint-only-user');
+      await result.current.fetchUserCosmetics('paint-only-user', {
+        retryMissingBadge: true,
+      });
+    });
+
+    expect(mockRequestUserCosmeticsViaPresence.mock.calls).toEqual([]);
+    expect(
+      result.current.fetchedCosmeticsUsersRef.current.has('paint-only-user'),
+    ).toBe(true);
+  });
+
+  test('retries a previously fetched user when retryMissingBadge is requested and a badge binding lacks a renderable definition', async () => {
+    setCachedCosmetics({
+      badgeId: 'badge-1',
       twitchUserId: 'retry-user',
     });
     mockGetUserBadge.mockReturnValue(undefined);
@@ -180,6 +206,28 @@ describe('useChatCosmetics', () => {
     ]);
     expect(
       result.current.fetchedCosmeticsUsersRef.current.has('retry-user'),
+    ).toBe(true);
+  });
+
+  test('does not refetch users that already have cached paint-only cosmetics', async () => {
+    setCachedCosmetics({
+      paintId: 'paint-1',
+      twitchUserId: 'paint-only-user',
+    });
+
+    const { result } = renderHook(() =>
+      useChatCosmetics({
+        userId: null,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.fetchUserCosmetics('paint-only-user');
+    });
+
+    expect(mockRequestUserCosmeticsViaPresence).not.toHaveBeenCalled();
+    expect(
+      result.current.fetchedCosmeticsUsersRef.current.has('paint-only-user'),
     ).toBe(true);
   });
 });

--- a/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
@@ -6,7 +6,6 @@ import {
   getUserBadge,
   getUserBadgeId,
   getUserPaintId,
-  hasUserPaint,
   requestUserCosmeticsViaPresence,
 } from '@app/store/chat/actions/cosmetics';
 
@@ -23,7 +22,6 @@ jest.mock('@app/store/chat/actions/cosmetics', () => ({
   getUserBadge: jest.fn(),
   getUserBadgeId: jest.fn(),
   getUserPaintId: jest.fn(),
-  hasUserPaint: jest.fn(),
   requestUserCosmeticsViaPresence: jest.fn(() => Promise.resolve()),
 }));
 
@@ -38,7 +36,6 @@ const mockFetchAndCacheUserCosmetics = jest.mocked(fetchAndCacheUserCosmetics);
 const mockGetUserBadge = jest.mocked(getUserBadge);
 const mockGetUserBadgeId = jest.mocked(getUserBadgeId);
 const mockGetUserPaintId = jest.mocked(getUserPaintId);
-const mockHasUserPaint = jest.mocked(hasUserPaint);
 const mockRequestUserCosmeticsViaPresence = jest.mocked(
   requestUserCosmeticsViaPresence,
 );
@@ -68,7 +65,6 @@ describe('useChatCosmetics', () => {
     mockGetUserBadge.mockReturnValue(undefined);
     mockGetUserBadgeId.mockReturnValue(undefined);
     mockGetUserPaintId.mockReturnValue(undefined);
-    mockHasUserPaint.mockReturnValue(false);
   });
 
   test('bootstraps the signed-in user cosmetics on mount', async () => {
@@ -87,8 +83,19 @@ describe('useChatCosmetics', () => {
   });
 
   test('skips self bootstrap when paint and badge bindings are already known', async () => {
-    mockHasUserPaint.mockReturnValue(true);
-    mockGetUserBadgeId.mockReturnValue('badge-1');
+    setCachedCosmetics({
+      badgeId: 'badge-1',
+      paintId: 'paint-1',
+      twitchUserId: 'ttv-self',
+    });
+    mockGetUserBadge.mockReturnValue({
+      id: 'badge-1',
+      url: 'https://cdn.7tv.app/badge/badge-1/4x.webp',
+      type: '7TV Badge',
+      title: 'Supporter',
+      set: 'badge-1',
+      provider: '7tv',
+    });
 
     renderHook(() =>
       useChatCosmetics({
@@ -100,6 +107,26 @@ describe('useChatCosmetics', () => {
       await Promise.resolve();
     });
 
+    expect(mockFetchAndCacheUserCosmetics).not.toHaveBeenCalled();
+  });
+
+  test('skips self bootstrap when only paint is known', async () => {
+    setCachedCosmetics({
+      paintId: 'paint-1',
+      twitchUserId: 'ttv-self',
+    });
+
+    renderHook(() =>
+      useChatCosmetics({
+        userId: 'ttv-self',
+      }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGet7tvUserId).not.toHaveBeenCalled();
     expect(mockFetchAndCacheUserCosmetics).not.toHaveBeenCalled();
   });
 

--- a/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
@@ -230,4 +230,28 @@ describe('useChatCosmetics', () => {
       result.current.fetchedCosmeticsUsersRef.current.has('paint-only-user'),
     ).toBe(true);
   });
+
+  test('does not retry users whose cosmetics fetch failed', async () => {
+    mockRequestUserCosmeticsViaPresence.mockRejectedValue(
+      new Error('presence failed'),
+    );
+
+    const { result } = renderHook(() =>
+      useChatCosmetics({
+        userId: null,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.fetchUserCosmetics('failed-user');
+      await result.current.fetchUserCosmetics('failed-user');
+    });
+
+    expect(mockRequestUserCosmeticsViaPresence.mock.calls).toEqual([
+      ['failed-user'],
+    ]);
+    expect(
+      result.current.fetchedCosmeticsUsersRef.current.has('failed-user'),
+    ).toBe(true);
+  });
 });

--- a/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
@@ -5,6 +5,7 @@ import {
   fetchAndCacheUserCosmetics,
   getUserBadge,
   getUserBadgeId,
+  getUserPaintId,
   hasUserPaint,
   requestUserCosmeticsViaPresence,
 } from '@app/store/chat/actions/cosmetics';
@@ -21,6 +22,7 @@ jest.mock('@app/store/chat/actions/cosmetics', () => ({
   fetchAndCacheUserCosmetics: jest.fn(),
   getUserBadge: jest.fn(),
   getUserBadgeId: jest.fn(),
+  getUserPaintId: jest.fn(),
   hasUserPaint: jest.fn(),
   requestUserCosmeticsViaPresence: jest.fn(() => Promise.resolve()),
 }));
@@ -31,31 +33,15 @@ jest.mock('@app/utils/logger', () => ({
   },
 }));
 
-type MockObservableValue<T> = {
-  peek: jest.Mock<T | undefined, []>;
-};
-
-jest.mock('@app/store/chat/observables/chatStore', () => ({
-  chatStore$: {
-    userBadgeIds: {},
-    userPaintIds: {},
-  },
-}));
-
 const mockGet7tvUserId = jest.mocked(sevenTvService.get7tvUserId);
 const mockFetchAndCacheUserCosmetics = jest.mocked(fetchAndCacheUserCosmetics);
 const mockGetUserBadge = jest.mocked(getUserBadge);
 const mockGetUserBadgeId = jest.mocked(getUserBadgeId);
+const mockGetUserPaintId = jest.mocked(getUserPaintId);
 const mockHasUserPaint = jest.mocked(hasUserPaint);
 const mockRequestUserCosmeticsViaPresence = jest.mocked(
   requestUserCosmeticsViaPresence,
 );
-
-const mockChatStore = jest.requireMock('@app/store/chat/observables/chatStore')
-  .chatStore$ as {
-  userBadgeIds: Record<string, MockObservableValue<string>>;
-  userPaintIds: Record<string, MockObservableValue<string>>;
-};
 
 function setCachedCosmetics({
   badgeId,
@@ -66,12 +52,12 @@ function setCachedCosmetics({
   paintId?: string;
   twitchUserId: string;
 }) {
-  mockChatStore.userBadgeIds[twitchUserId] = {
-    peek: jest.fn(() => badgeId),
-  };
-  mockChatStore.userPaintIds[twitchUserId] = {
-    peek: jest.fn(() => paintId),
-  };
+  mockGetUserBadgeId.mockImplementation(userId =>
+    userId === twitchUserId ? badgeId : undefined,
+  );
+  mockGetUserPaintId.mockImplementation(userId =>
+    userId === twitchUserId ? paintId : undefined,
+  );
 }
 
 describe('useChatCosmetics', () => {
@@ -81,13 +67,8 @@ describe('useChatCosmetics', () => {
     mockFetchAndCacheUserCosmetics.mockResolvedValue('ttv-self');
     mockGetUserBadge.mockReturnValue(undefined);
     mockGetUserBadgeId.mockReturnValue(undefined);
+    mockGetUserPaintId.mockReturnValue(undefined);
     mockHasUserPaint.mockReturnValue(false);
-    Object.keys(mockChatStore.userBadgeIds).forEach(key => {
-      delete mockChatStore.userBadgeIds[key];
-    });
-    Object.keys(mockChatStore.userPaintIds).forEach(key => {
-      delete mockChatStore.userPaintIds[key];
-    });
   });
 
   test('bootstraps the signed-in user cosmetics on mount', async () => {

--- a/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChatCosmetics.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@app/store/chat/actions/cosmetics';
 
 import { useChatCosmetics } from '../useChatCosmetics';
+import { setCachedCosmetics } from './__fixtures__/useChatCosmetics.fixture';
 
 jest.mock('@app/services/seventv-service', () => ({
   sevenTvService: {
@@ -40,23 +41,6 @@ const mockRequestUserCosmeticsViaPresence = jest.mocked(
   requestUserCosmeticsViaPresence,
 );
 
-function setCachedCosmetics({
-  badgeId,
-  paintId,
-  twitchUserId,
-}: {
-  badgeId?: string;
-  paintId?: string;
-  twitchUserId: string;
-}) {
-  mockGetUserBadgeId.mockImplementation(userId =>
-    userId === twitchUserId ? badgeId : undefined,
-  );
-  mockGetUserPaintId.mockImplementation(userId =>
-    userId === twitchUserId ? paintId : undefined,
-  );
-}
-
 describe('useChatCosmetics', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -83,11 +67,17 @@ describe('useChatCosmetics', () => {
   });
 
   test('skips self bootstrap when paint and badge bindings are already known', async () => {
-    setCachedCosmetics({
-      badgeId: 'badge-1',
-      paintId: 'paint-1',
-      twitchUserId: 'ttv-self',
-    });
+    setCachedCosmetics(
+      {
+        getUserBadgeId: mockGetUserBadgeId,
+        getUserPaintId: mockGetUserPaintId,
+      },
+      {
+        badgeId: 'badge-1',
+        paintId: 'paint-1',
+        twitchUserId: 'ttv-self',
+      },
+    );
     mockGetUserBadge.mockReturnValue({
       id: 'badge-1',
       url: 'https://cdn.7tv.app/badge/badge-1/4x.webp',
@@ -111,10 +101,16 @@ describe('useChatCosmetics', () => {
   });
 
   test('skips self bootstrap when only paint is known', async () => {
-    setCachedCosmetics({
-      paintId: 'paint-1',
-      twitchUserId: 'ttv-self',
-    });
+    setCachedCosmetics(
+      {
+        getUserBadgeId: mockGetUserBadgeId,
+        getUserPaintId: mockGetUserPaintId,
+      },
+      {
+        paintId: 'paint-1',
+        twitchUserId: 'ttv-self',
+      },
+    );
 
     renderHook(() =>
       useChatCosmetics({
@@ -150,11 +146,17 @@ describe('useChatCosmetics', () => {
   });
 
   test('does not refetch users that already have cached paint and renderable badge cosmetics', async () => {
-    setCachedCosmetics({
-      badgeId: 'badge-1',
-      paintId: 'paint-1',
-      twitchUserId: 'cached-user',
-    });
+    setCachedCosmetics(
+      {
+        getUserBadgeId: mockGetUserBadgeId,
+        getUserPaintId: mockGetUserPaintId,
+      },
+      {
+        badgeId: 'badge-1',
+        paintId: 'paint-1',
+        twitchUserId: 'cached-user',
+      },
+    );
     mockGetUserBadge.mockReturnValue({
       id: 'badge-1',
       url: 'https://cdn.7tv.app/badge/badge-1/4x.webp',
@@ -181,10 +183,16 @@ describe('useChatCosmetics', () => {
   });
 
   test('does not refetch paint-only users when retryMissingBadge is requested', async () => {
-    setCachedCosmetics({
-      paintId: 'paint-1',
-      twitchUserId: 'paint-only-user',
-    });
+    setCachedCosmetics(
+      {
+        getUserBadgeId: mockGetUserBadgeId,
+        getUserPaintId: mockGetUserPaintId,
+      },
+      {
+        paintId: 'paint-1',
+        twitchUserId: 'paint-only-user',
+      },
+    );
     mockGetUserBadge.mockReturnValue(undefined);
 
     const { result } = renderHook(() =>
@@ -207,10 +215,16 @@ describe('useChatCosmetics', () => {
   });
 
   test('retries a previously fetched user when retryMissingBadge is requested and a badge binding lacks a renderable definition', async () => {
-    setCachedCosmetics({
-      badgeId: 'badge-1',
-      twitchUserId: 'retry-user',
-    });
+    setCachedCosmetics(
+      {
+        getUserBadgeId: mockGetUserBadgeId,
+        getUserPaintId: mockGetUserPaintId,
+      },
+      {
+        badgeId: 'badge-1',
+        twitchUserId: 'retry-user',
+      },
+    );
     mockGetUserBadge.mockReturnValue(undefined);
 
     const { result } = renderHook(() =>
@@ -237,10 +251,16 @@ describe('useChatCosmetics', () => {
   });
 
   test('does not refetch users that already have cached paint-only cosmetics', async () => {
-    setCachedCosmetics({
-      paintId: 'paint-1',
-      twitchUserId: 'paint-only-user',
-    });
+    setCachedCosmetics(
+      {
+        getUserBadgeId: mockGetUserBadgeId,
+        getUserPaintId: mockGetUserPaintId,
+      },
+      {
+        paintId: 'paint-1',
+        twitchUserId: 'paint-only-user',
+      },
+    );
 
     const { result } = renderHook(() =>
       useChatCosmetics({

--- a/src/components/Chat/hooks/__tests__/useChatEmoteLoader.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChatEmoteLoader.test.ts
@@ -171,6 +171,37 @@ describe('useChatEmoteLoader', () => {
     });
   });
 
+  test('force-refetches when the active channel cache disappears without a version bump', async () => {
+    const controller = arrangeAbortController();
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useChatEmoteLoader({ channelId: 'channel-1', enabled }),
+      { initialProps: { enabled: true } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('success');
+    });
+    expect(mockLoadChannelResources).toHaveBeenCalledTimes(1);
+
+    chatStore$.persisted.channelCaches.set({});
+
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+
+    await waitFor(() => {
+      expect(mockLoadChannelResources).toHaveBeenCalledTimes(2);
+    });
+    expect(
+      mockLoadChannelResources.mock.calls[1]?.[0],
+    ).toEqual<LoadChannelResourcesOptions>({
+      channelId: 'channel-1',
+      forceRefresh: true,
+      signal: controller.signal,
+      twitchUserId: 'viewer-id',
+    });
+  });
+
   test('cancel aborts the active load and marks the hook cancelled while mounted', () => {
     const { result } = renderHook(() =>
       useChatEmoteLoader({ channelId: 'channel-1', enabled: false }),

--- a/src/components/Chat/hooks/__tests__/useChatSevenTvCallbacks.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChatSevenTvCallbacks.test.ts
@@ -7,16 +7,14 @@ import {
   addPaint,
   removeBadge,
   removePaint,
-  removeUserBadge,
-  removeUserPaint,
-  setUserBadge,
-  setUserPaint,
   updateBadge,
   updatePaint,
 } from '@app/store/chat/actions/cosmetics';
 import {
   applyCosmeticCreateEvent,
   applyEntitlementCreateEvent,
+  applyEntitlementDeleteEvent,
+  applyEntitlementUpdateEvent,
 } from '@app/store/chat/actions/cosmeticsBridge';
 import type { BadgeData, PaintData } from '@app/types/seventv/cosmetics';
 import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
@@ -56,6 +54,9 @@ jest.mock('@app/store/chat/actions/cosmetics', () => ({
 jest.mock('@app/store/chat/actions/cosmeticsBridge', () => ({
   applyCosmeticCreateEvent: jest.fn(),
   applyEntitlementCreateEvent: jest.fn(),
+  applyEntitlementDeleteEvent: jest.fn(),
+  applyEntitlementResetEvent: jest.fn(),
+  applyEntitlementUpdateEvent: jest.fn(),
 }));
 
 jest.mock('@app/utils/logger', () => ({
@@ -288,7 +289,7 @@ describe('useChatSevenTvCallbacks', () => {
   });
 
   describe('onEntitlementCreate', () => {
-    test('delegates to applyEntitlementCreateEvent with missing-definition requests enabled', () => {
+    test('delegates to applyEntitlementCreateEvent', () => {
       const { result } = renderHook(() =>
         useChatSevenTvCallbacks(defaultProps),
       );
@@ -321,9 +322,7 @@ describe('useChatSevenTvCallbacks', () => {
         result.current.onEntitlementCreate(data);
       });
 
-      expect(mockApplyEntitlementCreateEvent.mock.calls).toEqual([
-        [data, { requestMissingDefinitions: true }],
-      ]);
+      expect(mockApplyEntitlementCreateEvent.mock.calls).toEqual([[data]]);
     });
   });
 
@@ -456,59 +455,36 @@ describe('useChatSevenTvCallbacks', () => {
   });
 
   describe('onEntitlementUpdate', () => {
-    test('sets user paint and badge when ttvUserId and ids provided', () => {
+    test('delegates entitlement updates to the bridge', () => {
+      const updateData = createEntitlementUpdateData({
+        ttvUserId: 'ttv-1',
+        paintId: 'paint-1',
+        badgeId: 'badge-1',
+      });
       const { result } = renderHook(() =>
         useChatSevenTvCallbacks(defaultProps),
       );
 
       act(() => {
-        result.current.onEntitlementUpdate(
-          createEntitlementUpdateData({
-            ttvUserId: 'ttv-1',
-            paintId: 'paint-1',
-            badgeId: 'badge-1',
-          }),
-        );
+        result.current.onEntitlementUpdate(updateData);
       });
 
-      expect(setUserPaint).toHaveBeenCalledWith('ttv-1', 'paint-1');
-      expect(setUserBadge).toHaveBeenCalledWith('ttv-1', 'badge-1');
-    });
-
-    test('removes user paint/badge when ids are null', () => {
-      const { result } = renderHook(() =>
-        useChatSevenTvCallbacks(defaultProps),
-      );
-
-      act(() => {
-        result.current.onEntitlementUpdate(
-          createEntitlementUpdateData({
-            ttvUserId: 'ttv-1',
-            paintId: null,
-            badgeId: null,
-          }),
-        );
-      });
-
-      expect(removeUserPaint).toHaveBeenCalledWith('ttv-1');
-      expect(removeUserBadge).toHaveBeenCalledWith('ttv-1');
+      expect(applyEntitlementUpdateEvent).toHaveBeenCalledWith(updateData);
     });
   });
 
   describe('onEntitlementDelete', () => {
-    test('removes user paint and badge for ttvUserId', () => {
+    test('delegates entitlement deletes to the bridge', () => {
+      const deleteData = createEntitlementDeleteData({ ttvUserId: 'ttv-1' });
       const { result } = renderHook(() =>
         useChatSevenTvCallbacks(defaultProps),
       );
 
       act(() => {
-        result.current.onEntitlementDelete(
-          createEntitlementDeleteData({ ttvUserId: 'ttv-1' }),
-        );
+        result.current.onEntitlementDelete(deleteData);
       });
 
-      expect(removeUserPaint).toHaveBeenCalledWith('ttv-1');
-      expect(removeUserBadge).toHaveBeenCalledWith('ttv-1');
+      expect(applyEntitlementDeleteEvent).toHaveBeenCalledWith(deleteData);
     });
   });
 });

--- a/src/components/Chat/hooks/useChatCosmetics.ts
+++ b/src/components/Chat/hooks/useChatCosmetics.ts
@@ -79,9 +79,10 @@ export function useChatCosmetics(options: { userId?: string | null } = {}) {
       return;
     }
 
+    fetchedCosmeticsUsersRef.current.add(twitchUserId);
+
     try {
       await requestUserCosmeticsViaPresence(twitchUserId);
-      fetchedCosmeticsUsersRef.current.add(twitchUserId);
     } catch (error) {
       logger.stv.debug(
         `Failed to fetch cosmetics for user ${twitchUserId}:`,

--- a/src/components/Chat/hooks/useChatCosmetics.ts
+++ b/src/components/Chat/hooks/useChatCosmetics.ts
@@ -6,18 +6,18 @@ import {
   fetchAndCacheUserCosmetics,
   getUserBadge,
   getUserBadgeId,
+  getUserPaintId,
   hasUserPaint,
   requestUserCosmeticsViaPresence,
 } from '@app/store/chat/actions/cosmetics';
-import { chatStore$ } from '@app/store/chat/observables/chatStore';
 import { logger } from '@app/utils/logger';
 
 function hasRenderableCosmetics(twitchUserId: string): boolean {
-  const badgeId = chatStore$.userBadgeIds[twitchUserId]?.peek();
+  const badgeId = getUserBadgeId(twitchUserId);
   const renderableBadge = badgeId
     ? getUserBadge(twitchUserId)?.url?.trim()
     : undefined;
-  const paintId = chatStore$.userPaintIds[twitchUserId]?.peek();
+  const paintId = getUserPaintId(twitchUserId);
 
   return Boolean(paintId && renderableBadge);
 }
@@ -62,7 +62,7 @@ export function useChatCosmetics(options: { userId?: string | null } = {}) {
       retryMissingBadge?: boolean;
     } = {},
   ) => {
-    const existingBadgeId = chatStore$.userBadgeIds[twitchUserId]?.peek();
+    const existingBadgeId = getUserBadgeId(twitchUserId);
     const renderableBadge = existingBadgeId
       ? getUserBadge(twitchUserId)?.url?.trim()
       : undefined;
@@ -79,8 +79,15 @@ export function useChatCosmetics(options: { userId?: string | null } = {}) {
       return;
     }
 
-    await requestUserCosmeticsViaPresence(twitchUserId);
-    fetchedCosmeticsUsersRef.current.add(twitchUserId);
+    try {
+      await requestUserCosmeticsViaPresence(twitchUserId);
+      fetchedCosmeticsUsersRef.current.add(twitchUserId);
+    } catch (error) {
+      logger.stv.debug(
+        `Failed to fetch cosmetics for user ${twitchUserId}:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
   };
 
   return {

--- a/src/components/Chat/hooks/useChatCosmetics.ts
+++ b/src/components/Chat/hooks/useChatCosmetics.ts
@@ -57,7 +57,7 @@ export function useChatCosmetics(options: { userId?: string | null } = {}) {
 
   const fetchUserCosmetics = async (
     twitchUserId: string,
-    options: {
+    fetchOptions: {
       retryMissingBadge?: boolean;
     } = {},
   ) => {
@@ -68,7 +68,7 @@ export function useChatCosmetics(options: { userId?: string | null } = {}) {
 
     if (
       fetchedCosmeticsUsersRef.current.has(twitchUserId) &&
-      (!options.retryMissingBadge || renderableBadge || !existingBadgeId)
+      (!fetchOptions.retryMissingBadge || renderableBadge || !existingBadgeId)
     ) {
       return;
     }

--- a/src/components/Chat/hooks/useChatCosmetics.ts
+++ b/src/components/Chat/hooks/useChatCosmetics.ts
@@ -19,7 +19,7 @@ function hasRenderableCosmetics(twitchUserId: string): boolean {
     : undefined;
   const paintId = getUserPaintId(twitchUserId);
 
-  return Boolean(paintId && renderableBadge);
+  return Boolean(paintId || renderableBadge);
 }
 
 export function useChatCosmetics(options: { userId?: string | null } = {}) {
@@ -69,7 +69,7 @@ export function useChatCosmetics(options: { userId?: string | null } = {}) {
 
     if (
       fetchedCosmeticsUsersRef.current.has(twitchUserId) &&
-      (!options.retryMissingBadge || renderableBadge)
+      (!options.retryMissingBadge || renderableBadge || !existingBadgeId)
     ) {
       return;
     }

--- a/src/components/Chat/hooks/useChatCosmetics.ts
+++ b/src/components/Chat/hooks/useChatCosmetics.ts
@@ -7,7 +7,6 @@ import {
   getUserBadge,
   getUserBadgeId,
   getUserPaintId,
-  hasUserPaint,
   requestUserCosmeticsViaPresence,
 } from '@app/store/chat/actions/cosmetics';
 import { logger } from '@app/utils/logger';
@@ -31,7 +30,7 @@ export function useChatCosmetics(options: { userId?: string | null } = {}) {
       return;
     }
 
-    if (hasUserPaint(userId) && getUserBadgeId(userId)) {
+    if (hasRenderableCosmetics(userId)) {
       return;
     }
 

--- a/src/components/Chat/hooks/useChatCosmetics.ts
+++ b/src/components/Chat/hooks/useChatCosmetics.ts
@@ -4,13 +4,57 @@ import { useLazyRef } from '@app/hooks/useLazyRef';
 import { sevenTvService } from '@app/services/seventv-service';
 import {
   fetchAndCacheUserCosmetics,
+  getUserBadge,
+  getUserBadgeId,
+  hasUserPaint,
   requestUserCosmeticsViaPresence,
 } from '@app/store/chat/actions/cosmetics';
 import { chatStore$ } from '@app/store/chat/observables/chatStore';
 import { logger } from '@app/utils/logger';
 
-export function useChatCosmetics({ userId }: { userId?: string | null }) {
+function hasRenderableCosmetics(twitchUserId: string): boolean {
+  const badgeId = chatStore$.userBadgeIds[twitchUserId]?.peek();
+  const renderableBadge = badgeId
+    ? getUserBadge(twitchUserId)?.url?.trim()
+    : undefined;
+  const paintId = chatStore$.userPaintIds[twitchUserId]?.peek();
+
+  return Boolean(paintId && renderableBadge);
+}
+
+export function useChatCosmetics(options: { userId?: string | null } = {}) {
+  const { userId } = options;
   const fetchedCosmeticsUsersRef = useLazyRef(() => new Set<string>());
+
+  useEffect(() => {
+    if (!userId) {
+      return;
+    }
+
+    if (hasUserPaint(userId) && getUserBadgeId(userId)) {
+      return;
+    }
+
+    let cancelled = false;
+    void sevenTvService
+      .get7tvUserId(userId)
+      .then(sevenTvUserId => {
+        if (cancelled || !sevenTvUserId) {
+          return null;
+        }
+        return fetchAndCacheUserCosmetics(sevenTvUserId);
+      })
+      .catch(error => {
+        logger.stv.debug(
+          `No 7TV cosmetics for current user ${userId}:`,
+          error instanceof Error ? error.message : error,
+        );
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
 
   const fetchUserCosmetics = async (
     twitchUserId: string,
@@ -19,62 +63,25 @@ export function useChatCosmetics({ userId }: { userId?: string | null }) {
     } = {},
   ) => {
     const existingBadgeId = chatStore$.userBadgeIds[twitchUserId]?.peek();
+    const renderableBadge = existingBadgeId
+      ? getUserBadge(twitchUserId)?.url?.trim()
+      : undefined;
+
     if (
       fetchedCosmeticsUsersRef.current.has(twitchUserId) &&
-      (!options.retryMissingBadge || existingBadgeId)
+      (!options.retryMissingBadge || renderableBadge)
     ) {
       return;
     }
 
-    const existingPaintId = chatStore$.userPaintIds[twitchUserId]?.peek();
-    if (existingPaintId && existingBadgeId) {
+    if (hasRenderableCosmetics(twitchUserId)) {
       fetchedCosmeticsUsersRef.current.add(twitchUserId);
-      logger.stvWs.debug(
-        `User ${twitchUserId} already has paint and badge cosmetics`,
-      );
       return;
     }
 
+    await requestUserCosmeticsViaPresence(twitchUserId);
     fetchedCosmeticsUsersRef.current.add(twitchUserId);
-
-    try {
-      await requestUserCosmeticsViaPresence(twitchUserId);
-    } catch (error) {
-      logger.stvWs.debug(
-        `Failed to fetch cosmetics for ${twitchUserId}:`,
-        error,
-      );
-    }
   };
-
-  useEffect(() => {
-    if (!userId) {
-      return;
-    }
-
-    let cancelled = false;
-
-    void (async () => {
-      try {
-        const sevenTvUserId = await sevenTvService.get7tvUserId(userId);
-
-        if (cancelled || !sevenTvUserId) {
-          return;
-        }
-
-        await fetchAndCacheUserCosmetics(sevenTvUserId);
-        logger.stvWs.info(`Fetched cosmetics for current user: ${userId}`);
-      } catch (error) {
-        if (!cancelled) {
-          logger.stvWs.warn('Failed to fetch current user cosmetics:', error);
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [userId]);
 
   return {
     fetchedCosmeticsUsersRef,

--- a/src/components/Chat/hooks/useChatEmoteLoader.ts
+++ b/src/components/Chat/hooks/useChatEmoteLoader.ts
@@ -165,7 +165,14 @@ export const useChatEmoteLoader = ({
     lastCosmeticsCacheVersionRef.current = cosmeticsCacheVersion;
 
     if (enabled && channelId) {
-      if (cacheCleared) {
+      const hasChannelCache = Boolean(
+        chatStore$.persisted.channelCaches[channelId]?.peek(),
+      );
+      const shouldForceRefresh =
+        cacheCleared ||
+        (currentChannelRef.current === channelId && !hasChannelCache);
+
+      if (cacheCleared || shouldForceRefresh) {
         currentChannelRef.current = null;
         void loadEmotesRef.current(true);
       } else if (currentChannelRef.current !== channelId) {

--- a/src/components/Chat/hooks/useChatEmoteLoader.ts
+++ b/src/components/Chat/hooks/useChatEmoteLoader.ts
@@ -172,7 +172,7 @@ export const useChatEmoteLoader = ({
         cacheCleared ||
         (currentChannelRef.current === channelId && !hasChannelCache);
 
-      if (cacheCleared || shouldForceRefresh) {
+      if (shouldForceRefresh) {
         currentChannelRef.current = null;
         void loadEmotesRef.current(true);
       } else if (currentChannelRef.current !== channelId) {

--- a/src/components/Chat/hooks/useChatSevenTvCallbacks.ts
+++ b/src/components/Chat/hooks/useChatSevenTvCallbacks.ts
@@ -4,6 +4,7 @@ import type {
   CosmeticUpdateCallbackData,
   EntitlementCreateCallbackData,
   EntitlementDeleteCallbackData,
+  EntitlementResetCallbackData,
   EntitlementUpdateCallbackData,
 } from '@app/hooks/useSeventvWs';
 import { countMetric } from '@app/lib/sentry';
@@ -12,16 +13,15 @@ import {
   addPaint,
   removeBadge,
   removePaint,
-  removeUserBadge,
-  removeUserPaint,
-  setUserBadge,
-  setUserPaint,
   updateBadge,
   updatePaint,
 } from '@app/store/chat/actions/cosmetics';
 import {
   applyCosmeticCreateEvent,
   applyEntitlementCreateEvent,
+  applyEntitlementDeleteEvent,
+  applyEntitlementResetEvent,
+  applyEntitlementUpdateEvent,
 } from '@app/store/chat/actions/cosmeticsBridge';
 import {
   findPersonalEmoteSetOwner,
@@ -78,7 +78,11 @@ function onCosmeticCreate(data: CosmeticCreateCallbackData) {
 }
 
 function onEntitlementCreate(data: EntitlementCreateCallbackData) {
-  applyEntitlementCreateEvent(data, { requestMissingDefinitions: true });
+  applyEntitlementCreateEvent(data);
+}
+
+function onEntitlementReset(data: EntitlementResetCallbackData) {
+  applyEntitlementResetEvent(data.sevenTvUserId);
 }
 
 function onCosmeticDelete(data: CosmeticDeleteCallbackData) {
@@ -88,26 +92,11 @@ function onCosmeticDelete(data: CosmeticDeleteCallbackData) {
 }
 
 function onEntitlementUpdate(data: EntitlementUpdateCallbackData) {
-  if (data.ttvUserId) {
-    if (data.paintId) {
-      setUserPaint(data.ttvUserId, data.paintId);
-    } else {
-      removeUserPaint(data.ttvUserId);
-    }
-    if (data.badgeId) {
-      setUserBadge(data.ttvUserId, data.badgeId);
-    } else {
-      removeUserBadge(data.ttvUserId);
-    }
-  }
+  applyEntitlementUpdateEvent(data);
 }
 
 function onEntitlementDelete(data: EntitlementDeleteCallbackData) {
-  if (data.ttvUserId) {
-    removeUserPaint(data.ttvUserId);
-    removeUserBadge(data.ttvUserId);
-    logger.stvWs.info(`Removed entitlements for user: ${data.ttvUserId}`);
-  }
+  applyEntitlementDeleteEvent(data);
 }
 
 export function useChatSevenTvCallbacks({
@@ -290,6 +279,7 @@ export function useChatSevenTvCallbacks({
     onEmoteSetUpdateForOtherSet,
     onCosmeticCreate,
     onEntitlementCreate,
+    onEntitlementReset,
     onCosmeticUpdate,
     onCosmeticDelete,
     onEntitlementUpdate,

--- a/src/components/Chat/hooks/useEmoteReprocessing.ts
+++ b/src/components/Chat/hooks/useEmoteReprocessing.ts
@@ -123,7 +123,6 @@ export function useEmoteReprocessing({
       const replacedBadges = findBadges({
         userstate: msg.userstate,
         chatterinoBadges: emoteData.chatterinoBadges,
-        chatUsers: [],
         ffzChannelBadges: emoteData.ffzChannelBadges,
         ffzGlobalBadges: emoteData.ffzGlobalBadges,
         twitchChannelBadges: emoteData.twitchChannelBadges,

--- a/src/components/Chat/util/sharedChatBadges.ts
+++ b/src/components/Chat/util/sharedChatBadges.ts
@@ -213,7 +213,6 @@ export function getMessageBadges({
   const foundBadges = findBadges({
     userstate,
     chatterinoBadges: emoteData.chatterinoBadges,
-    chatUsers: [],
     ffzChannelBadges: emoteData.ffzChannelBadges,
     ffzGlobalBadges: emoteData.ffzGlobalBadges,
     twitchChannelBadges: sourceChannelBadges ?? emoteData.twitchChannelBadges,

--- a/src/hooks/useSeventvWs.ts
+++ b/src/hooks/useSeventvWs.ts
@@ -14,6 +14,7 @@ import {
   EntitlementCreate,
   type EntitlementCreateCallbackData,
   type EntitlementDeleteCallbackData,
+  type EntitlementResetCallbackData,
   type EntitlementUpdateCallbackData,
   SevenTvEventData,
   SevenTvEventType,
@@ -51,6 +52,7 @@ export type {
   EntitlementCreate,
   EntitlementCreateCallbackData,
   EntitlementDeleteCallbackData,
+  EntitlementResetCallbackData,
   EntitlementUpdateCallbackData,
   SevenTvEventData,
   SevenTvEventType,
@@ -72,6 +74,7 @@ interface UseSeventvWsOptions {
   onEntitlementCreate?: (data: EntitlementCreateCallbackData) => void;
   onEntitlementUpdate?: (data: EntitlementUpdateCallbackData) => void;
   onEntitlementDelete?: (data: EntitlementDeleteCallbackData) => void;
+  onEntitlementReset?: (data: EntitlementResetCallbackData) => void;
   onEvent?: (
     eventType: SevenTvEventType,
     data: SevenTvEventData<SevenTvEventType>,
@@ -150,6 +153,7 @@ export function useSeventvWs(
   const entitlementCallbackRef = useRef(options?.onEntitlementCreate);
   const entitlementUpdateCallbackRef = useRef(options?.onEntitlementUpdate);
   const entitlementDeleteCallbackRef = useRef(options?.onEntitlementDelete);
+  const entitlementResetCallbackRef = useRef(options?.onEntitlementReset);
   const eventCallbackRef = useRef(options?.onEvent);
   const connectionTimestampRef = useRef<number | null>(null);
   const pathname = usePathname();
@@ -237,6 +241,7 @@ export function useSeventvWs(
   entitlementCallbackRef.current = options?.onEntitlementCreate;
   entitlementUpdateCallbackRef.current = options?.onEntitlementUpdate;
   entitlementDeleteCallbackRef.current = options?.onEntitlementDelete;
+  entitlementResetCallbackRef.current = options?.onEntitlementReset;
   eventCallbackRef.current = options?.onEvent;
   twitchChannelIdRef.current = options?.twitchChannelId;
   sevenTvEmoteSetIdRef.current = options?.sevenTvEmoteSetId;
@@ -507,6 +512,18 @@ export function useSeventvWs(
           });
         } catch (error) {
           logEventHandlerError('entitlement.delete', error);
+        }
+        break;
+      }
+
+      case 'applyEntitlementReset': {
+        logger.stvWs.info(`💚 Received WS 'entitlement.reset' event`);
+        try {
+          entitlementResetCallbackRef.current?.({
+            sevenTvUserId: decision.sevenTvUserId,
+          });
+        } catch (error) {
+          logEventHandlerError('entitlement.reset', error);
         }
         break;
       }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -32,6 +32,10 @@ const en = {
     emotesRefreshed: 'Refreshed emotes and badges',
     providerLoadFailed:
       "Couldn't load emotes and badges from {{providers}}, falling back to cached emotes/badges",
+    providerLoadFailedNoCache:
+      "Couldn't load emotes and badges from {{providers}}",
+    channelResourcesFailed:
+      "Couldn't load channel emotes and badges. Try refreshing.",
     messageActions: {
       eyebrow: 'Selected message',
       title: 'Message Actions',

--- a/src/services/__tests__/sevenTvBridge.test.ts
+++ b/src/services/__tests__/sevenTvBridge.test.ts
@@ -1,0 +1,42 @@
+import { sevenTvApi } from '@app/services/api/clients';
+import { sevenTvService } from '@app/services/seventv-service';
+
+jest.mock('@app/services/api/clients', () => ({
+  sevenTvApi: {
+    post: jest.fn(),
+  },
+}));
+
+const mockSevenTvApiPost = jest.mocked(sevenTvApi.post);
+
+describe('sevenTvService.fetchBridgedCosmetics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns an empty array without calling the bridge when no logins are provided', async () => {
+    await expect(sevenTvService.fetchBridgedCosmetics([])).resolves.toEqual([]);
+    expect(mockSevenTvApiPost).not.toHaveBeenCalled();
+  });
+
+  test('queries the bridge with username identifiers', async () => {
+    mockSevenTvApiPost.mockResolvedValue([]);
+
+    await sevenTvService.fetchBridgedCosmetics(['Cinna', 'destiny']);
+
+    expect(mockSevenTvApiPost.mock.calls).toEqual([
+      [
+        '/bridge/event-api',
+        { identifiers: ['username:Cinna', 'username:destiny'] },
+      ],
+    ]);
+  });
+
+  test('normalises a non-array bridge response to an empty array', async () => {
+    mockSevenTvApiPost.mockResolvedValue(null);
+
+    await expect(
+      sevenTvService.fetchBridgedCosmetics(['cinna']),
+    ).resolves.toEqual([]);
+  });
+});

--- a/src/services/__tests__/sevenTvBridge.test.ts
+++ b/src/services/__tests__/sevenTvBridge.test.ts
@@ -39,4 +39,13 @@ describe('sevenTvService.fetchBridgedCosmetics', () => {
       sevenTvService.fetchBridgedCosmetics(['cinna']),
     ).resolves.toEqual([]);
   });
+
+  test('returns bridge events unchanged when the API responds with an array', async () => {
+    const events = [{ type: 'cosmetic.create', body: { id: 'abc' } }];
+    mockSevenTvApiPost.mockResolvedValue(events);
+
+    await expect(
+      sevenTvService.fetchBridgedCosmetics(['cinna']),
+    ).resolves.toEqual(events);
+  });
 });

--- a/src/services/seventv-service.ts
+++ b/src/services/seventv-service.ts
@@ -30,6 +30,8 @@ import type {
 } from '@app/types/emote';
 import type {
   PaintData,
+  SevenTvEventData,
+  SevenTvEventType,
   UserCosmeticsInfo,
 } from '@app/types/seventv/cosmetics';
 import type {
@@ -331,6 +333,27 @@ export const sevenTvService = {
           }
         : null,
     };
+  },
+
+  /**
+   * Bulk EventAPI bridge lookup. Identifiers must be Twitch logins as
+   * `username:<login>`; numeric `id:` identifiers are rejected by the API.
+   *
+   * The live endpoint only synthesises `cosmetic.create` AVATAR dispatches for
+   * users with an active profile picture. It does not replay paint, badge, or
+   * entitlement events, so this cannot backfill chat cosmetics.
+   */
+  fetchBridgedCosmetics: async (
+    twitchLogins: string[],
+  ): Promise<SevenTvEventData<SevenTvEventType>[]> => {
+    if (twitchLogins.length === 0) {
+      return [];
+    }
+    const events = await sevenTvApi.post<SevenTvEventData<SevenTvEventType>[]>(
+      '/bridge/event-api',
+      { identifiers: twitchLogins.map(login => `username:${login}`) },
+    );
+    return Array.isArray(events) ? events : [];
   },
 
   /**

--- a/src/store/chat/__tests__/__fixtures__/cosmeticsBridge.fixture.ts
+++ b/src/store/chat/__tests__/__fixtures__/cosmeticsBridge.fixture.ts
@@ -1,0 +1,37 @@
+import type { EntitlementCreate } from '@app/types/seventv/cosmetics';
+
+export function createBadgeEntitlement(
+  badgeId: string,
+  ttvUserId: string,
+  entitlementId = `entitlement-${badgeId}`,
+): EntitlementCreate {
+  return {
+    id: entitlementId,
+    kind: 0,
+    object: {
+      id: entitlementId,
+      kind: 'BADGE',
+      ref_id: badgeId,
+      user: {
+        id: 'stv-user-1',
+        username: 'user',
+        display_name: 'User',
+        avatar_url: '',
+        style: { badge_id: badgeId },
+        role_ids: { length: 0 },
+        connections: {
+          0: {
+            id: ttvUserId,
+            platform: 'TWITCH',
+            username: 'user',
+            display_name: 'User',
+            linked_at: 0,
+            emote_capacity: 0,
+            emote_set_id: '',
+          },
+          length: 1,
+        },
+      },
+    },
+  };
+}

--- a/src/store/chat/__tests__/channelLoad.test.ts
+++ b/src/store/chat/__tests__/channelLoad.test.ts
@@ -18,6 +18,7 @@ import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
 import type { UserInfoResponse } from '@app/types/twitch/user';
 
 import {
+  clearCache,
   clearPersonalEmotesCache,
   clearSubscriberProfilesCache,
   loadChannelResources,
@@ -464,9 +465,79 @@ describe('loadChannelResources cache fallback', () => {
       .join('');
     expect(text).toContain('BTTV');
     expect(text).toContain('FFZ');
-    expect(text).toContain('falling back to cached emotes/badges');
+    expect(text).toContain("Couldn't load emotes and badges");
+    expect(text).not.toContain('falling back');
     expect(text).not.toContain('Twitch');
     expect(text).not.toContain('7TV');
+  });
+
+  test('posts a fallback system message when failed providers still have cached slices', async () => {
+    chatStore$.messages.set([]);
+    chatStore$.persisted.channelCaches.set({
+      [channelId]: {
+        ...emptyEmoteData,
+        badges: [badge('ffz-global-badge-cached')],
+        badgesLastUpdated: 2_000,
+        bttvGlobalEmotes: [bttvEmote('bttv-global-cached', 'Global BTTV')],
+        emotes: [
+          bttvEmote('bttv-global-cached', 'Global BTTV'),
+          twitchEmote('existing-emote'),
+        ],
+        ffzGlobalBadges: [badge('ffz-global-badge-cached')],
+        lastUpdated: 9_000,
+        twitchChannelEmotes: [twitchEmote('existing-emote')],
+      },
+    });
+
+    mockGetBttvGlobalEmotes.mockRejectedValue(new Error('TimeoutError'));
+    mockGetFfzGlobalBadges.mockRejectedValue(new Error('TimeoutError'));
+
+    await expect(
+      loadChannelResources({ channelId, forceRefresh: true, twitchUserId }),
+    ).resolves.toBe(true);
+
+    const systemMessages = chatStore$.messages
+      .peek()
+      .filter(message => message.sender === 'System');
+    expect(systemMessages).toHaveLength(1);
+
+    const text = systemMessages[0]!.message
+      .flatMap(part => (part.type === 'text' ? [part.content] : []))
+      .join('');
+    expect(text).toContain('BTTV');
+    expect(text).toContain('FFZ');
+    expect(text).toContain('falling back to cached emotes/badges');
+  });
+
+  test('posts a system message when stale badge refresh requests reject', async () => {
+    chatStore$.messages.set([]);
+    jest.spyOn(Date, 'now').mockReturnValue(3_700_000);
+    chatStore$.persisted.channelCaches.set({
+      [channelId]: {
+        ...emptyEmoteData,
+        badges: [badge('ffz-global-badge-cached')],
+        badgesLastUpdated: 0,
+        emotes: [twitchEmote('existing-emote')],
+        ffzGlobalBadges: [badge('ffz-global-badge-cached')],
+        lastUpdated: 9_000,
+        twitchChannelEmotes: [twitchEmote('existing-emote')],
+      },
+    });
+
+    mockGetFfzGlobalBadges.mockRejectedValue(new Error('TimeoutError'));
+
+    await expect(loadChannelResources({ channelId })).resolves.toBe(true);
+
+    const systemMessages = chatStore$.messages
+      .peek()
+      .filter(message => message.sender === 'System');
+    expect(systemMessages).toHaveLength(1);
+
+    const text = systemMessages[0]!.message
+      .flatMap(part => (part.type === 'text' ? [part.content] : []))
+      .join('');
+    expect(text).toContain('FFZ');
+    expect(text).toContain('falling back to cached emotes/badges');
   });
 
   test('posts no system message when every provider fetch succeeds', async () => {
@@ -478,6 +549,25 @@ describe('loadChannelResources cache fallback', () => {
       .peek()
       .filter(message => message.sender === 'System');
     expect(systemMessages).toEqual([]);
+  });
+
+  test('clearCache bumps cosmeticsCacheVersion so the emote loader refetches', () => {
+    chatStore$.cosmeticsCacheVersion.set(3);
+    chatStore$.persisted.channelCaches.set({
+      [channelId]: {
+        ...emptyEmoteData,
+        emotes: [twitchEmote('existing-emote')],
+        lastUpdated: 9_000,
+        twitchChannelEmotes: [twitchEmote('existing-emote')],
+      },
+    });
+
+    clearCache(channelId);
+
+    expect(chatStore$.cosmeticsCacheVersion.peek()).toBe(4);
+    expect(
+      chatStore$.persisted.channelCaches.peek()[channelId],
+    ).toBeUndefined();
   });
 });
 

--- a/src/store/chat/__tests__/cosmetics.test.ts
+++ b/src/store/chat/__tests__/cosmetics.test.ts
@@ -4,6 +4,7 @@ import {
   getUserBadge,
   requestUserCosmeticsViaPresence,
 } from '@app/store/chat/actions/cosmetics';
+import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
 import { getSevenTvSessionId } from '@app/utils/seventv/sevenTvSessionId';
 
 jest.mock('@app/components/Chat/util/normalizeSevenTvCosmetics', () => ({
@@ -100,7 +101,7 @@ describe('getUserBadge', () => {
   });
 
   test('returns the stored badge definition when present', () => {
-    const badge = {
+    const badge: SanitisedBadgeSet = {
       id: 'badge-1',
       url: 'https://cdn.7tv.app/badge/badge-1/4x.webp',
       type: '7TV Badge',
@@ -117,7 +118,7 @@ describe('getUserBadge', () => {
       set: jest.fn(),
     };
 
-    expect(getUserBadge('ttv-1')).toEqual(badge);
+    expect(getUserBadge('ttv-1')).toEqual<SanitisedBadgeSet>(badge);
     expect(mockReportMissingBadge).not.toHaveBeenCalled();
   });
 

--- a/src/store/chat/__tests__/cosmetics.test.ts
+++ b/src/store/chat/__tests__/cosmetics.test.ts
@@ -1,7 +1,23 @@
 import { storageService } from '@app/lib/storage';
 import { sevenTvService } from '@app/services/seventv-service';
-import { requestUserCosmeticsViaPresence } from '@app/store/chat/actions/cosmetics';
+import {
+  getUserBadge,
+  requestUserCosmeticsViaPresence,
+} from '@app/store/chat/actions/cosmetics';
 import { getSevenTvSessionId } from '@app/utils/seventv/sevenTvSessionId';
+
+jest.mock('@app/components/Chat/util/normalizeSevenTvCosmetics', () => ({
+  buildSevenTvBadgeImageUrl: jest.fn(
+    (badgeId: string) => `https://cdn.7tv.app/badge/${badgeId}/4x.webp`,
+  ),
+  normalizeSevenTvBadge: jest.fn((badge: Record<string, unknown>) => badge),
+}));
+
+jest.mock('@app/store/chat/actions/missingBadges', () => ({
+  clearAllMissingBadges: jest.fn(),
+  clearMissingBadge: jest.fn(),
+  reportMissingBadge: jest.fn(),
+}));
 
 jest.mock('@app/services/seventv-service', () => ({
   sevenTvService: {
@@ -27,8 +43,23 @@ jest.mock('@app/lib/storage', () => ({
 jest.mock('@app/store/chat/observables/chatStore', () => ({
   chatStore$: {
     currentChannelId: { peek: jest.fn(() => 'channel-1') },
+    badges: {},
+    userBadgeIds: {},
   },
 }));
+
+import { reportMissingBadge } from '@app/store/chat/actions/missingBadges';
+import { chatStore$ } from '@app/store/chat/observables/chatStore';
+
+type MockObservableValue<T> = {
+  peek: jest.Mock<T, []>;
+  set: jest.Mock<void, [T]>;
+};
+
+const mockChatStore = chatStore$ as unknown as {
+  badges: Record<string, MockObservableValue<unknown>>;
+  userBadgeIds: Record<string, MockObservableValue<string>>;
+};
 
 jest.mock('@app/store/chat/observables/cosmeticsPersistence', () => ({
   writePersistedCosmetics: jest.fn(),
@@ -51,6 +82,78 @@ const mockGetUserCosmeticsGql = jest.mocked(sevenTvService.getUserCosmeticsGql);
 const mockSendPresence = jest.mocked(sevenTvService.sendPresence);
 const mockGetSessionId = jest.mocked(getSevenTvSessionId);
 const mockGetString = jest.mocked(storageService.getString);
+const mockReportMissingBadge = jest.mocked(reportMissingBadge);
+
+describe('getUserBadge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(mockChatStore.userBadgeIds).forEach(key => {
+      delete mockChatStore.userBadgeIds[key];
+    });
+    Object.keys(mockChatStore.badges).forEach(key => {
+      delete mockChatStore.badges[key];
+    });
+  });
+
+  test('returns undefined when the user has no badge binding', () => {
+    expect(getUserBadge('ttv-1')).toBeUndefined();
+  });
+
+  test('returns the stored badge definition when present', () => {
+    const badge = {
+      id: 'badge-1',
+      url: 'https://cdn.7tv.app/badge/badge-1/4x.webp',
+      type: '7TV Badge',
+      title: 'Supporter',
+      set: 'badge-1',
+      provider: '7tv',
+    };
+    mockChatStore.userBadgeIds['ttv-1'] = {
+      peek: jest.fn(() => 'badge-1'),
+      set: jest.fn(),
+    };
+    mockChatStore.badges['badge-1'] = {
+      peek: jest.fn(() => badge),
+      set: jest.fn(),
+    };
+
+    expect(getUserBadge('ttv-1')).toEqual(badge);
+    expect(mockReportMissingBadge).not.toHaveBeenCalled();
+  });
+
+  test('returns undefined and tracks the missing definition when bound but not loaded', () => {
+    mockChatStore.userBadgeIds['ttv-scummy'] = {
+      peek: jest.fn(() => '01GAF994D8000E8VNG1S1RMTBC'),
+      set: jest.fn(),
+    };
+
+    expect(getUserBadge('ttv-scummy')).toBeUndefined();
+    expect(mockReportMissingBadge.mock.calls).toEqual([
+      ['01GAF994D8000E8VNG1S1RMTBC', 'ttv-scummy'],
+    ]);
+  });
+
+  test('returns undefined when the stored definition has an empty url', () => {
+    mockChatStore.userBadgeIds['ttv-1'] = {
+      peek: jest.fn(() => 'badge-1'),
+      set: jest.fn(),
+    };
+    mockChatStore.badges['badge-1'] = {
+      peek: jest.fn(() => ({
+        id: 'badge-1',
+        url: '',
+        type: '7TV Badge',
+        title: 'Supporter',
+        set: 'badge-1',
+        provider: '7tv',
+      })),
+      set: jest.fn(),
+    };
+
+    expect(getUserBadge('ttv-1')).toBeUndefined();
+    expect(mockReportMissingBadge.mock.calls).toEqual([['badge-1', 'ttv-1']]);
+  });
+});
 
 describe('requestUserCosmeticsViaPresence', () => {
   beforeEach(() => {

--- a/src/store/chat/__tests__/cosmetics.test.ts
+++ b/src/store/chat/__tests__/cosmetics.test.ts
@@ -1,6 +1,7 @@
 import { storageService } from '@app/lib/storage';
 import { sevenTvService } from '@app/services/seventv-service';
 import {
+  type CachedUserCosmetics,
   getUserBadge,
   requestUserCosmeticsViaPresence,
   syncCachedUserCosmeticsFromStore,
@@ -204,24 +205,25 @@ describe('syncCachedUserCosmeticsFromStore', () => {
 
     syncCachedUserCosmeticsFromStore('stv-user-1', 'ttv-1');
 
+    const expectedCosmetics: CachedUserCosmetics = {
+      badge: {
+        id: 'badge-1',
+        provider: '7tv',
+        set: 'badge-1',
+        title: 'Supporter',
+        type: '7TV Badge',
+        url: 'https://cdn.7tv.app/badge/badge-1/4x.webp',
+      },
+      badgeId: 'badge-1',
+      expiresAt: Date.now() + TWO_HOURS_MS,
+      paint: undefined,
+      paintId: null,
+      ttvUserId: 'ttv-1',
+    };
     expect(mockSet.mock.calls).toEqual([
       [
         'sevenTvUserCosmetics_user-cosmetics:stv-user-1',
-        {
-          badge: {
-            id: 'badge-1',
-            provider: '7tv',
-            set: 'badge-1',
-            title: 'Supporter',
-            type: '7TV Badge',
-            url: 'https://cdn.7tv.app/badge/badge-1/4x.webp',
-          },
-          badgeId: 'badge-1',
-          expiresAt: Date.now() + TWO_HOURS_MS,
-          paint: undefined,
-          paintId: null,
-          ttvUserId: 'ttv-1',
-        },
+        expectedCosmetics,
         'seven_tv_cache',
         { expiry: new Date(Date.now() + TWO_HOURS_MS) },
       ],
@@ -231,17 +233,18 @@ describe('syncCachedUserCosmeticsFromStore', () => {
   test('writes a 30m negative-cache expiry when the user has no cosmetic bindings', () => {
     syncCachedUserCosmeticsFromStore('stv-user-1', 'ttv-1');
 
+    const expectedCosmetics: CachedUserCosmetics = {
+      badge: undefined,
+      badgeId: null,
+      expiresAt: Date.now() + THIRTY_MINUTES_MS,
+      paint: undefined,
+      paintId: null,
+      ttvUserId: 'ttv-1',
+    };
     expect(mockSet.mock.calls).toEqual([
       [
         'sevenTvUserCosmetics_user-cosmetics:stv-user-1',
-        {
-          badge: undefined,
-          badgeId: null,
-          expiresAt: Date.now() + THIRTY_MINUTES_MS,
-          paint: undefined,
-          paintId: null,
-          ttvUserId: 'ttv-1',
-        },
+        expectedCosmetics,
         'seven_tv_cache',
         { expiry: new Date(Date.now() + THIRTY_MINUTES_MS) },
       ],

--- a/src/store/chat/__tests__/cosmetics.test.ts
+++ b/src/store/chat/__tests__/cosmetics.test.ts
@@ -3,6 +3,7 @@ import { sevenTvService } from '@app/services/seventv-service';
 import {
   getUserBadge,
   requestUserCosmeticsViaPresence,
+  syncCachedUserCosmeticsFromStore,
 } from '@app/store/chat/actions/cosmetics';
 import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
 import { getSevenTvSessionId } from '@app/utils/seventv/sevenTvSessionId';
@@ -45,7 +46,9 @@ jest.mock('@app/store/chat/observables/chatStore', () => ({
   chatStore$: {
     currentChannelId: { peek: jest.fn(() => 'channel-1') },
     badges: {},
+    paints: {},
     userBadgeIds: {},
+    userPaintIds: {},
   },
 }));
 
@@ -59,7 +62,9 @@ type MockObservableValue<T> = {
 
 const mockChatStore = chatStore$ as unknown as {
   badges: Record<string, MockObservableValue<unknown>>;
-  userBadgeIds: Record<string, MockObservableValue<string>>;
+  paints: Record<string, MockObservableValue<unknown>>;
+  userBadgeIds: Record<string, MockObservableValue<string | null>>;
+  userPaintIds: Record<string, MockObservableValue<string | null>>;
 };
 
 jest.mock('@app/store/chat/observables/cosmeticsPersistence', () => ({
@@ -83,6 +88,7 @@ const mockGetUserCosmeticsGql = jest.mocked(sevenTvService.getUserCosmeticsGql);
 const mockSendPresence = jest.mocked(sevenTvService.sendPresence);
 const mockGetSessionId = jest.mocked(getSevenTvSessionId);
 const mockGetString = jest.mocked(storageService.getString);
+const mockSet = jest.mocked(storageService.set);
 const mockReportMissingBadge = jest.mocked(reportMissingBadge);
 
 describe('getUserBadge', () => {
@@ -153,6 +159,93 @@ describe('getUserBadge', () => {
 
     expect(getUserBadge('ttv-1')).toBeUndefined();
     expect(mockReportMissingBadge.mock.calls).toEqual([['badge-1', 'ttv-1']]);
+  });
+});
+
+describe('syncCachedUserCosmeticsFromStore', () => {
+  const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
+  const THIRTY_MINUTES_MS = 30 * 60 * 1000;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    jest.clearAllMocks();
+    Object.keys(mockChatStore.userBadgeIds).forEach(key => {
+      delete mockChatStore.userBadgeIds[key];
+    });
+    Object.keys(mockChatStore.userPaintIds).forEach(key => {
+      delete mockChatStore.userPaintIds[key];
+    });
+    Object.keys(mockChatStore.badges).forEach(key => {
+      delete mockChatStore.badges[key];
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('writes a 2h cache expiry when the user has cosmetic bindings', () => {
+    mockChatStore.userBadgeIds['ttv-1'] = {
+      peek: jest.fn(() => 'badge-1'),
+      set: jest.fn(),
+    };
+    mockChatStore.badges['badge-1'] = {
+      peek: jest.fn(() => ({
+        id: 'badge-1',
+        url: 'https://cdn.7tv.app/badge/badge-1/4x.webp',
+        type: '7TV Badge',
+        title: 'Supporter',
+        set: 'badge-1',
+        provider: '7tv',
+      })),
+      set: jest.fn(),
+    };
+
+    syncCachedUserCosmeticsFromStore('stv-user-1', 'ttv-1');
+
+    expect(mockSet.mock.calls).toEqual([
+      [
+        'sevenTvUserCosmetics_user-cosmetics:stv-user-1',
+        {
+          badge: {
+            id: 'badge-1',
+            provider: '7tv',
+            set: 'badge-1',
+            title: 'Supporter',
+            type: '7TV Badge',
+            url: 'https://cdn.7tv.app/badge/badge-1/4x.webp',
+          },
+          badgeId: 'badge-1',
+          expiresAt: Date.now() + TWO_HOURS_MS,
+          paint: undefined,
+          paintId: null,
+          ttvUserId: 'ttv-1',
+        },
+        'seven_tv_cache',
+        { expiry: new Date(Date.now() + TWO_HOURS_MS) },
+      ],
+    ]);
+  });
+
+  test('writes a 30m negative-cache expiry when the user has no cosmetic bindings', () => {
+    syncCachedUserCosmeticsFromStore('stv-user-1', 'ttv-1');
+
+    expect(mockSet.mock.calls).toEqual([
+      [
+        'sevenTvUserCosmetics_user-cosmetics:stv-user-1',
+        {
+          badge: undefined,
+          badgeId: null,
+          expiresAt: Date.now() + THIRTY_MINUTES_MS,
+          paint: undefined,
+          paintId: null,
+          ttvUserId: 'ttv-1',
+        },
+        'seven_tv_cache',
+        { expiry: new Date(Date.now() + THIRTY_MINUTES_MS) },
+      ],
+    ]);
   });
 });
 

--- a/src/store/chat/__tests__/cosmeticsBridge.test.ts
+++ b/src/store/chat/__tests__/cosmeticsBridge.test.ts
@@ -35,11 +35,31 @@ jest.mock('@app/store/chat/actions/personalEmotes', () => ({
   handlePersonalEmoteSetEntitlement: jest.fn(),
 }));
 
-jest.mock('@app/store/chat/observables/chatStore', () => ({
-  chatStore$: {
-    currentChannelId: { peek: jest.fn(() => 'channel-1') },
-  },
-}));
+jest.mock('@app/store/chat/observables/chatStore', () => {
+  const createRecordObservable = <T>(initial: Record<string, T>) => {
+    let value: Record<string, T> = initial;
+    return {
+      peek: () => value,
+      set: (next: Record<string, T>) => {
+        value = next;
+      },
+    };
+  };
+
+  return {
+    chatStore$: {
+      currentChannelId: { peek: jest.fn(() => 'channel-1') },
+      sevenTvUserLinks: {
+        twitchIdsBySevenTvUserId: createRecordObservable<string[]>({}),
+        sevenTvUserIdByTwitchId: createRecordObservable<string>({}),
+        twitchIdByEntitlementId: createRecordObservable<{
+          kind: 'BADGE' | 'PAINT' | 'EMOTE_SET';
+          twitchUserId: string;
+        }>({}),
+      },
+    },
+  };
+});
 
 jest.mock('@app/utils/logger', () => ({
   logger: {

--- a/src/store/chat/__tests__/cosmeticsBridge.test.ts
+++ b/src/store/chat/__tests__/cosmeticsBridge.test.ts
@@ -438,4 +438,33 @@ describe('applyEntitlementDeleteEvent', () => {
     expect(mockRemoveUserPaint).not.toHaveBeenCalled();
     expect(mockRemoveUserBadge.mock.calls).toEqual([['ttv-1']]);
   });
+
+  test('does not clear paint or badge when an evicted entitlement delete still has a twitch user id', () => {
+    for (let index = 0; index <= 2000; index += 1) {
+      applyEntitlementCreateEvent({
+        entitlement: createBadgeEntitlement(
+          `badge-${index}`,
+          'ttv-1',
+          `entitlement-${index}`,
+        ),
+        kind: 'BADGE',
+        ttvUserId: 'ttv-1',
+        paintId: null,
+        badgeId: `badge-${index}`,
+      });
+    }
+
+    mockRemoveUserPaint.mockClear();
+    mockRemoveUserBadge.mockClear();
+    mockSyncCachedUserCosmeticsFromStore.mockClear();
+
+    applyEntitlementDeleteEvent({
+      entitlementId: 'entitlement-0',
+      ttvUserId: 'ttv-1',
+    });
+
+    expect(mockRemoveUserPaint).not.toHaveBeenCalled();
+    expect(mockRemoveUserBadge).not.toHaveBeenCalled();
+    expect(mockSyncCachedUserCosmeticsFromStore).not.toHaveBeenCalled();
+  });
 });

--- a/src/store/chat/__tests__/cosmeticsBridge.test.ts
+++ b/src/store/chat/__tests__/cosmeticsBridge.test.ts
@@ -17,6 +17,8 @@ import {
 import { handlePersonalEmoteSetEntitlement } from '@app/store/chat/actions/personalEmotes';
 import type { EntitlementCreate } from '@app/types/seventv/cosmetics';
 
+import { createBadgeEntitlement } from './__fixtures__/cosmeticsBridge.fixture';
+
 jest.mock('@app/store/chat/actions/cosmetics', () => ({
   addBadge: jest.fn(),
   addPaint: jest.fn(),
@@ -58,42 +60,6 @@ const mockRemoveUserPaint = jest.mocked(removeUserPaint);
 const mockHandlePersonalEmoteSetEntitlement = jest.mocked(
   handlePersonalEmoteSetEntitlement,
 );
-
-function createBadgeEntitlement(
-  badgeId: string,
-  ttvUserId: string,
-  entitlementId = `entitlement-${badgeId}`,
-): EntitlementCreate {
-  return {
-    id: entitlementId,
-    kind: 0,
-    object: {
-      id: entitlementId,
-      kind: 'BADGE',
-      ref_id: badgeId,
-      user: {
-        id: 'stv-user-1',
-        username: 'user',
-        display_name: 'User',
-        avatar_url: '',
-        style: { badge_id: badgeId },
-        role_ids: { length: 0 },
-        connections: {
-          0: {
-            id: ttvUserId,
-            platform: 'TWITCH',
-            username: 'user',
-            display_name: 'User',
-            linked_at: 0,
-            emote_capacity: 0,
-            emote_set_id: '',
-          },
-          length: 1,
-        },
-      },
-    },
-  };
-}
 
 describe('applyEntitlementCreateEvent', () => {
   beforeEach(() => {
@@ -312,7 +278,7 @@ describe('applyEntitlementDeleteEvent', () => {
     clearEntitlementUserLinkState();
   });
 
-  test('clears bindings and syncs the per-user cache', () => {
+  test('clears only the badge binding for a remembered badge entitlement delete', () => {
     applyEntitlementCreateEvent({
       entitlement: createBadgeEntitlement('badge-1', 'ttv-1'),
       kind: 'BADGE',
@@ -326,7 +292,7 @@ describe('applyEntitlementDeleteEvent', () => {
       ttvUserId: 'ttv-1',
     });
 
-    expect(mockRemoveUserPaint.mock.calls).toEqual([['ttv-1']]);
+    expect(mockRemoveUserPaint).not.toHaveBeenCalled();
     expect(mockRemoveUserBadge.mock.calls).toEqual([['ttv-1']]);
     expect(mockSyncCachedUserCosmeticsFromStore.mock.calls.at(-1)).toEqual([
       'stv-user-1',
@@ -334,7 +300,7 @@ describe('applyEntitlementDeleteEvent', () => {
     ]);
   });
 
-  test('resolves the twitch user from a remembered entitlement id when delete arrives without one', () => {
+  test('clears only the badge binding when delete resolves the twitch user from a remembered entitlement id', () => {
     applyEntitlementCreateEvent({
       entitlement: createBadgeEntitlement('badge-1', 'ttv-1'),
       kind: 'BADGE',
@@ -348,12 +314,41 @@ describe('applyEntitlementDeleteEvent', () => {
       ttvUserId: null,
     });
 
-    expect(mockRemoveUserPaint.mock.calls).toEqual([['ttv-1']]);
+    expect(mockRemoveUserPaint).not.toHaveBeenCalled();
     expect(mockRemoveUserBadge.mock.calls).toEqual([['ttv-1']]);
     expect(mockSyncCachedUserCosmeticsFromStore.mock.calls.at(-1)).toEqual([
       'stv-user-1',
       'ttv-1',
     ]);
+  });
+
+  test('clears only the paint binding for a remembered paint entitlement delete', () => {
+    const entitlement: EntitlementCreate = {
+      id: 'entitlement-paint-1',
+      kind: 0,
+      object: {
+        id: 'entitlement-paint-1',
+        kind: 'PAINT',
+        ref_id: 'paint-1',
+        user: createBadgeEntitlement('badge-1', 'ttv-1').object.user,
+      },
+    };
+
+    applyEntitlementCreateEvent({
+      entitlement,
+      kind: 'PAINT',
+      ttvUserId: 'ttv-1',
+      paintId: 'paint-1',
+      badgeId: null,
+    });
+
+    applyEntitlementDeleteEvent({
+      entitlementId: 'entitlement-paint-1',
+      ttvUserId: null,
+    });
+
+    expect(mockRemoveUserPaint.mock.calls).toEqual([['ttv-1']]);
+    expect(mockRemoveUserBadge).not.toHaveBeenCalled();
   });
 
   test('evicts the oldest remembered entitlement id at the link cap', () => {
@@ -387,7 +382,7 @@ describe('applyEntitlementDeleteEvent', () => {
       ttvUserId: null,
     });
 
-    expect(mockRemoveUserPaint.mock.calls).toEqual([['ttv-1']]);
+    expect(mockRemoveUserPaint).not.toHaveBeenCalled();
     expect(mockRemoveUserBadge.mock.calls).toEqual([['ttv-1']]);
   });
 });

--- a/src/store/chat/__tests__/cosmeticsBridge.test.ts
+++ b/src/store/chat/__tests__/cosmeticsBridge.test.ts
@@ -1,21 +1,31 @@
 import {
-  fetchUserCosmeticsByTwitchId,
   getBadge,
   getPaint,
+  removeUserBadge,
+  removeUserPaint,
   setUserBadge,
   setUserPaint,
+  syncCachedUserCosmeticsFromStore,
 } from '@app/store/chat/actions/cosmetics';
-import { applyEntitlementCreateEvent } from '@app/store/chat/actions/cosmeticsBridge';
-import type { EntitlementCreate } from '@app/types/seventv/cosmetics';
+import {
+  applyEntitlementCreateEvent,
+  applyEntitlementDeleteEvent,
+  applyEntitlementResetEvent,
+  applyEntitlementUpdateEvent,
+  clearEntitlementUserLinkState,
+} from '@app/store/chat/actions/cosmeticsBridge';
+import { handlePersonalEmoteSetEntitlement } from '@app/store/chat/actions/personalEmotes';
 
 jest.mock('@app/store/chat/actions/cosmetics', () => ({
   addBadge: jest.fn(),
   addPaint: jest.fn(),
-  fetchUserCosmeticsByTwitchId: jest.fn(() => Promise.resolve()),
   getBadge: jest.fn(),
   getPaint: jest.fn(),
+  removeUserBadge: jest.fn(),
+  removeUserPaint: jest.fn(),
   setUserBadge: jest.fn(),
   setUserPaint: jest.fn(),
+  syncCachedUserCosmeticsFromStore: jest.fn(),
 }));
 
 jest.mock('@app/store/chat/actions/personalEmotes', () => ({
@@ -35,13 +45,18 @@ jest.mock('@app/utils/logger', () => ({
   },
 }));
 
-const mockFetchUserCosmeticsByTwitchId = jest.mocked(
-  fetchUserCosmeticsByTwitchId,
-);
 const mockGetBadge = jest.mocked(getBadge);
 const mockGetPaint = jest.mocked(getPaint);
 const mockSetUserBadge = jest.mocked(setUserBadge);
 const mockSetUserPaint = jest.mocked(setUserPaint);
+const mockSyncCachedUserCosmeticsFromStore = jest.mocked(
+  syncCachedUserCosmeticsFromStore,
+);
+const mockRemoveUserBadge = jest.mocked(removeUserBadge);
+const mockRemoveUserPaint = jest.mocked(removeUserPaint);
+const mockHandlePersonalEmoteSetEntitlement = jest.mocked(
+  handlePersonalEmoteSetEntitlement,
+);
 
 function createBadgeEntitlement(
   badgeId: string,
@@ -81,68 +96,12 @@ function createBadgeEntitlement(
 describe('applyEntitlementCreateEvent', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    clearEntitlementUserLinkState();
     mockGetBadge.mockReturnValue(undefined);
     mockGetPaint.mockReturnValue(undefined);
   });
 
-  test('binds the badge and fetches cosmetics over v4 GQL when the definition is missing', () => {
-    applyEntitlementCreateEvent(
-      {
-        entitlement: createBadgeEntitlement('badge-1', 'ttv-1'),
-        kind: 'BADGE',
-        ttvUserId: 'ttv-1',
-        paintId: null,
-        badgeId: 'badge-1',
-      },
-      { requestMissingDefinitions: true },
-    );
-
-    expect(mockSetUserBadge.mock.calls).toEqual([['ttv-1', 'badge-1']]);
-    expect(mockFetchUserCosmeticsByTwitchId.mock.calls).toEqual([['ttv-1']]);
-  });
-
-  test('does not fetch when the badge definition is already loaded', () => {
-    mockGetBadge.mockReturnValue({
-      id: 'badge-1',
-      provider: '7tv',
-      set: 'badge-1',
-      title: 'Badge',
-      type: '7TV Badge',
-      url: 'https://cdn.7tv.app/badge/badge-1/4x.webp',
-    });
-
-    applyEntitlementCreateEvent(
-      {
-        entitlement: createBadgeEntitlement('badge-1', 'ttv-1'),
-        kind: 'BADGE',
-        ttvUserId: 'ttv-1',
-        paintId: null,
-        badgeId: 'badge-1',
-      },
-      { requestMissingDefinitions: true },
-    );
-
-    expect(mockSetUserBadge.mock.calls).toEqual([['ttv-1', 'badge-1']]);
-    expect(mockFetchUserCosmeticsByTwitchId).not.toHaveBeenCalled();
-  });
-
-  test('never fetches when requestMissingDefinitions is false', () => {
-    applyEntitlementCreateEvent(
-      {
-        entitlement: createBadgeEntitlement('badge-1', 'ttv-1'),
-        kind: 'BADGE',
-        ttvUserId: 'ttv-1',
-        paintId: null,
-        badgeId: 'badge-1',
-      },
-      { requestMissingDefinitions: false },
-    );
-
-    expect(mockSetUserBadge.mock.calls).toEqual([['ttv-1', 'badge-1']]);
-    expect(mockFetchUserCosmeticsByTwitchId).not.toHaveBeenCalled();
-  });
-
-  test('binds paints and fetches missing paint definitions over v4 GQL', () => {
+  test('binds paints without fetching missing definitions', () => {
     const entitlement: EntitlementCreate = {
       id: 'entitlement-paint-1',
       kind: 0,
@@ -154,18 +113,143 @@ describe('applyEntitlementCreateEvent', () => {
       },
     };
 
-    applyEntitlementCreateEvent(
-      {
-        entitlement,
-        kind: 'PAINT',
-        ttvUserId: 'ttv-1',
-        paintId: 'paint-1',
-        badgeId: null,
-      },
-      { requestMissingDefinitions: true },
-    );
+    applyEntitlementCreateEvent({
+      entitlement,
+      kind: 'PAINT',
+      ttvUserId: 'ttv-1',
+      paintId: 'paint-1',
+      badgeId: null,
+    });
 
     expect(mockSetUserPaint.mock.calls).toEqual([['ttv-1', 'paint-1']]);
-    expect(mockFetchUserCosmeticsByTwitchId.mock.calls).toEqual([['ttv-1']]);
+  });
+
+  test('binds the badge without issuing an HTTP cosmetics fetch', () => {
+    applyEntitlementCreateEvent({
+      entitlement: createBadgeEntitlement('badge-1', 'ttv-1'),
+      kind: 'BADGE',
+      ttvUserId: 'ttv-1',
+      paintId: null,
+      badgeId: 'badge-1',
+    });
+
+    expect(mockSetUserBadge.mock.calls).toEqual([['ttv-1', 'badge-1']]);
+    expect(mockSyncCachedUserCosmeticsFromStore.mock.calls).toEqual([
+      ['stv-user-1', 'ttv-1'],
+    ]);
+  });
+
+  test('binds style paint and badge on EMOTE_SET entitlements', () => {
+    const entitlement: EntitlementCreate = {
+      id: 'entitlement-emote-set-1',
+      kind: 0,
+      object: {
+        id: 'entitlement-emote-set-1',
+        kind: 'EMOTE_SET',
+        ref_id: 'emote-set-1',
+        user: createBadgeEntitlement('badge-1', 'ttv-scummy').object.user,
+      },
+    };
+
+    applyEntitlementCreateEvent({
+      entitlement,
+      kind: 'EMOTE_SET',
+      ttvUserId: 'ttv-scummy',
+      paintId: 'paint-1',
+      badgeId: 'badge-scummy',
+    });
+
+    expect(mockSetUserPaint.mock.calls).toEqual([['ttv-scummy', 'paint-1']]);
+    expect(mockSetUserBadge.mock.calls).toEqual([
+      ['ttv-scummy', 'badge-scummy'],
+    ]);
+    expect(mockHandlePersonalEmoteSetEntitlement.mock.calls).toEqual([
+      ['ttv-scummy', 'emote-set-1', 'channel-1'],
+    ]);
+  });
+});
+
+describe('applyEntitlementResetEvent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearEntitlementUserLinkState();
+  });
+
+  test('clears paint and badge bindings for linked Twitch users', () => {
+    applyEntitlementCreateEvent({
+      entitlement: createBadgeEntitlement('badge-1', 'ttv-1'),
+      kind: 'BADGE',
+      ttvUserId: 'ttv-1',
+      paintId: null,
+      badgeId: 'badge-1',
+    });
+
+    applyEntitlementResetEvent('stv-user-1');
+
+    expect(mockRemoveUserPaint.mock.calls).toEqual([['ttv-1']]);
+    expect(mockRemoveUserBadge.mock.calls).toEqual([['ttv-1']]);
+    expect(mockSyncCachedUserCosmeticsFromStore.mock.calls).toEqual([
+      ['stv-user-1', 'ttv-1'],
+      ['stv-user-1', 'ttv-1'],
+    ]);
+  });
+});
+
+describe('applyEntitlementUpdateEvent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearEntitlementUserLinkState();
+  });
+
+  test('updates bindings and syncs the per-user cache', () => {
+    applyEntitlementCreateEvent({
+      entitlement: createBadgeEntitlement('badge-1', 'ttv-1'),
+      kind: 'BADGE',
+      ttvUserId: 'ttv-1',
+      paintId: null,
+      badgeId: 'badge-1',
+    });
+
+    applyEntitlementUpdateEvent({
+      ttvUserId: 'ttv-1',
+      paintId: 'paint-1',
+      badgeId: 'badge-2',
+    });
+
+    expect(mockSetUserPaint.mock.calls).toEqual([['ttv-1', 'paint-1']]);
+    expect(mockSetUserBadge.mock.calls).toEqual([
+      ['ttv-1', 'badge-1'],
+      ['ttv-1', 'badge-2'],
+    ]);
+    expect(mockSyncCachedUserCosmeticsFromStore.mock.calls.at(-1)).toEqual([
+      'stv-user-1',
+      'ttv-1',
+    ]);
+  });
+});
+
+describe('applyEntitlementDeleteEvent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearEntitlementUserLinkState();
+  });
+
+  test('clears bindings and syncs the per-user cache', () => {
+    applyEntitlementCreateEvent({
+      entitlement: createBadgeEntitlement('badge-1', 'ttv-1'),
+      kind: 'BADGE',
+      ttvUserId: 'ttv-1',
+      paintId: null,
+      badgeId: 'badge-1',
+    });
+
+    applyEntitlementDeleteEvent({ ttvUserId: 'ttv-1' });
+
+    expect(mockRemoveUserPaint.mock.calls).toEqual([['ttv-1']]);
+    expect(mockRemoveUserBadge.mock.calls).toEqual([['ttv-1']]);
+    expect(mockSyncCachedUserCosmeticsFromStore.mock.calls.at(-1)).toEqual([
+      'stv-user-1',
+      'ttv-1',
+    ]);
   });
 });

--- a/src/store/chat/__tests__/cosmeticsBridge.test.ts
+++ b/src/store/chat/__tests__/cosmeticsBridge.test.ts
@@ -194,6 +194,27 @@ describe('applyEntitlementResetEvent', () => {
       ['stv-user-1', 'ttv-1'],
     ]);
   });
+
+  test('clears reverse 7TV user links when entitlements reset', () => {
+    applyEntitlementCreateEvent({
+      entitlement: createBadgeEntitlement('badge-1', 'ttv-1'),
+      kind: 'BADGE',
+      ttvUserId: 'ttv-1',
+      paintId: null,
+      badgeId: 'badge-1',
+    });
+
+    applyEntitlementResetEvent('stv-user-1');
+    mockSyncCachedUserCosmeticsFromStore.mockClear();
+
+    applyEntitlementUpdateEvent({
+      ttvUserId: 'ttv-1',
+      paintId: 'paint-1',
+      badgeId: null,
+    });
+
+    expect(mockSyncCachedUserCosmeticsFromStore).not.toHaveBeenCalled();
+  });
 });
 
 describe('applyEntitlementUpdateEvent', () => {

--- a/src/store/chat/__tests__/cosmeticsBridge.test.ts
+++ b/src/store/chat/__tests__/cosmeticsBridge.test.ts
@@ -62,12 +62,13 @@ const mockHandlePersonalEmoteSetEntitlement = jest.mocked(
 function createBadgeEntitlement(
   badgeId: string,
   ttvUserId: string,
+  entitlementId = `entitlement-${badgeId}`,
 ): EntitlementCreate {
   return {
-    id: `entitlement-${badgeId}`,
+    id: entitlementId,
     kind: 0,
     object: {
-      id: `entitlement-${badgeId}`,
+      id: entitlementId,
       kind: 'BADGE',
       ref_id: badgeId,
       user: {
@@ -215,6 +216,28 @@ describe('applyEntitlementResetEvent', () => {
 
     expect(mockSyncCachedUserCosmeticsFromStore).not.toHaveBeenCalled();
   });
+
+  test('forgets remembered entitlement ids when entitlements reset', () => {
+    applyEntitlementCreateEvent({
+      entitlement: createBadgeEntitlement('badge-1', 'ttv-1'),
+      kind: 'BADGE',
+      ttvUserId: 'ttv-1',
+      paintId: null,
+      badgeId: 'badge-1',
+    });
+
+    applyEntitlementResetEvent('stv-user-1');
+    mockRemoveUserPaint.mockClear();
+    mockRemoveUserBadge.mockClear();
+
+    applyEntitlementDeleteEvent({
+      entitlementId: 'entitlement-badge-1',
+      ttvUserId: null,
+    });
+
+    expect(mockRemoveUserPaint).not.toHaveBeenCalled();
+    expect(mockRemoveUserBadge).not.toHaveBeenCalled();
+  });
 });
 
 describe('applyEntitlementUpdateEvent', () => {
@@ -298,5 +321,40 @@ describe('applyEntitlementDeleteEvent', () => {
       'stv-user-1',
       'ttv-1',
     ]);
+  });
+
+  test('evicts the oldest remembered entitlement id at the link cap', () => {
+    for (let index = 0; index <= 2000; index += 1) {
+      applyEntitlementCreateEvent({
+        entitlement: createBadgeEntitlement(
+          `badge-${index}`,
+          'ttv-1',
+          `entitlement-${index}`,
+        ),
+        kind: 'BADGE',
+        ttvUserId: 'ttv-1',
+        paintId: null,
+        badgeId: `badge-${index}`,
+      });
+    }
+
+    mockRemoveUserPaint.mockClear();
+    mockRemoveUserBadge.mockClear();
+
+    applyEntitlementDeleteEvent({
+      entitlementId: 'entitlement-0',
+      ttvUserId: null,
+    });
+
+    expect(mockRemoveUserPaint).not.toHaveBeenCalled();
+    expect(mockRemoveUserBadge).not.toHaveBeenCalled();
+
+    applyEntitlementDeleteEvent({
+      entitlementId: 'entitlement-2000',
+      ttvUserId: null,
+    });
+
+    expect(mockRemoveUserPaint.mock.calls).toEqual([['ttv-1']]);
+    expect(mockRemoveUserBadge.mock.calls).toEqual([['ttv-1']]);
   });
 });

--- a/src/store/chat/__tests__/cosmeticsBridge.test.ts
+++ b/src/store/chat/__tests__/cosmeticsBridge.test.ts
@@ -270,6 +270,59 @@ describe('applyEntitlementUpdateEvent', () => {
       'ttv-1',
     ]);
   });
+
+  test('does not remove existing cosmetics when an update omits paint or badge ids', () => {
+    applyEntitlementCreateEvent({
+      entitlement: createBadgeEntitlement('badge-1', 'ttv-1'),
+      kind: 'BADGE',
+      ttvUserId: 'ttv-1',
+      paintId: null,
+      badgeId: 'badge-1',
+    });
+    applyEntitlementCreateEvent({
+      entitlement: {
+        id: 'entitlement-paint-1',
+        kind: 0,
+        object: {
+          id: 'entitlement-paint-1',
+          kind: 'PAINT',
+          ref_id: 'paint-1',
+          user: createBadgeEntitlement('badge-1', 'ttv-1').object.user,
+        },
+      },
+      kind: 'PAINT',
+      ttvUserId: 'ttv-1',
+      paintId: 'paint-1',
+      badgeId: null,
+    });
+
+    mockRemoveUserPaint.mockClear();
+    mockRemoveUserBadge.mockClear();
+    mockSyncCachedUserCosmeticsFromStore.mockClear();
+
+    applyEntitlementUpdateEvent({
+      ttvUserId: 'ttv-1',
+      paintId: null,
+      badgeId: null,
+    });
+
+    expect(mockRemoveUserPaint).not.toHaveBeenCalled();
+    expect(mockRemoveUserBadge).not.toHaveBeenCalled();
+    expect(mockSyncCachedUserCosmeticsFromStore).not.toHaveBeenCalled();
+
+    applyEntitlementUpdateEvent({
+      ttvUserId: 'ttv-1',
+      paintId: 'paint-2',
+      badgeId: null,
+    });
+
+    expect(mockSetUserPaint.mock.calls.at(-1)).toEqual(['ttv-1', 'paint-2']);
+    expect(mockRemoveUserBadge).not.toHaveBeenCalled();
+    expect(mockSyncCachedUserCosmeticsFromStore.mock.calls.at(-1)).toEqual([
+      'stv-user-1',
+      'ttv-1',
+    ]);
+  });
 });
 
 describe('applyEntitlementDeleteEvent', () => {

--- a/src/store/chat/__tests__/cosmeticsBridge.test.ts
+++ b/src/store/chat/__tests__/cosmeticsBridge.test.ts
@@ -15,6 +15,7 @@ import {
   clearEntitlementUserLinkState,
 } from '@app/store/chat/actions/cosmeticsBridge';
 import { handlePersonalEmoteSetEntitlement } from '@app/store/chat/actions/personalEmotes';
+import type { EntitlementCreate } from '@app/types/seventv/cosmetics';
 
 jest.mock('@app/store/chat/actions/cosmetics', () => ({
   addBadge: jest.fn(),
@@ -243,7 +244,32 @@ describe('applyEntitlementDeleteEvent', () => {
       badgeId: 'badge-1',
     });
 
-    applyEntitlementDeleteEvent({ ttvUserId: 'ttv-1' });
+    applyEntitlementDeleteEvent({
+      entitlementId: 'entitlement-badge-1',
+      ttvUserId: 'ttv-1',
+    });
+
+    expect(mockRemoveUserPaint.mock.calls).toEqual([['ttv-1']]);
+    expect(mockRemoveUserBadge.mock.calls).toEqual([['ttv-1']]);
+    expect(mockSyncCachedUserCosmeticsFromStore.mock.calls.at(-1)).toEqual([
+      'stv-user-1',
+      'ttv-1',
+    ]);
+  });
+
+  test('resolves the twitch user from a remembered entitlement id when delete arrives without one', () => {
+    applyEntitlementCreateEvent({
+      entitlement: createBadgeEntitlement('badge-1', 'ttv-1'),
+      kind: 'BADGE',
+      ttvUserId: 'ttv-1',
+      paintId: null,
+      badgeId: 'badge-1',
+    });
+
+    applyEntitlementDeleteEvent({
+      entitlementId: 'entitlement-badge-1',
+      ttvUserId: null,
+    });
 
     expect(mockRemoveUserPaint.mock.calls).toEqual([['ttv-1']]);
     expect(mockRemoveUserBadge.mock.calls).toEqual([['ttv-1']]);

--- a/src/store/chat/__tests__/cosmeticsBridge.test.ts
+++ b/src/store/chat/__tests__/cosmeticsBridge.test.ts
@@ -238,6 +238,39 @@ describe('applyEntitlementResetEvent', () => {
     expect(mockRemoveUserPaint).not.toHaveBeenCalled();
     expect(mockRemoveUserBadge).not.toHaveBeenCalled();
   });
+
+  test('forgets every remembered entitlement id for a user when entitlements reset', () => {
+    applyEntitlementCreateEvent({
+      entitlement: createBadgeEntitlement('badge-1', 'ttv-1', 'entitlement-1'),
+      kind: 'BADGE',
+      ttvUserId: 'ttv-1',
+      paintId: null,
+      badgeId: 'badge-1',
+    });
+    applyEntitlementCreateEvent({
+      entitlement: createBadgeEntitlement('badge-2', 'ttv-1', 'entitlement-2'),
+      kind: 'BADGE',
+      ttvUserId: 'ttv-1',
+      paintId: null,
+      badgeId: 'badge-2',
+    });
+
+    applyEntitlementResetEvent('stv-user-1');
+    mockRemoveUserPaint.mockClear();
+    mockRemoveUserBadge.mockClear();
+
+    applyEntitlementDeleteEvent({
+      entitlementId: 'entitlement-1',
+      ttvUserId: null,
+    });
+    applyEntitlementDeleteEvent({
+      entitlementId: 'entitlement-2',
+      ttvUserId: null,
+    });
+
+    expect(mockRemoveUserPaint).not.toHaveBeenCalled();
+    expect(mockRemoveUserBadge).not.toHaveBeenCalled();
+  });
 });
 
 describe('applyEntitlementUpdateEvent', () => {

--- a/src/store/chat/actions/__tests__/channelResources.test.ts
+++ b/src/store/chat/actions/__tests__/channelResources.test.ts
@@ -6,8 +6,10 @@ import { logger } from '@app/utils/logger';
 import {
   buildBadgeResourceSpecs,
   buildEmoteResourceSpecs,
+  collectFailedProviderLabels,
   type EmoteCacheKey,
   type EmoteResourceSpec,
+  hadCachedResourcesForFailedSpecs,
   reconcileSettledSpecs,
   reportResourceResults,
   ResourceFetchTimeoutError,
@@ -254,5 +256,50 @@ describe('reportResourceResults', () => {
 
     expect(logger.chat.warn).toHaveBeenCalledTimes(1);
     expect(logger.chat.info).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('hadCachedResourcesForFailedSpecs', () => {
+  test('returns true when a rejected spec still has cached items', () => {
+    const settled: SettledSpec<EmoteCacheKey, SanitisedEmote>[] = [
+      {
+        spec: spec('twitchChannelEmotes'),
+        result: { status: 'rejected', reason: new Error('boom') },
+      },
+    ];
+    const existingCache: ChannelCacheType = {
+      ...emptyEmoteData,
+      twitchChannelEmotes: [emote('cached')],
+    };
+
+    expect(hadCachedResourcesForFailedSpecs(existingCache, settled)).toBe(true);
+  });
+
+  test('returns false when a rejected spec has no cached fallback', () => {
+    const settled: SettledSpec<EmoteCacheKey, SanitisedEmote>[] = [
+      {
+        spec: spec('twitchChannelEmotes'),
+        result: { status: 'rejected', reason: new Error('boom') },
+      },
+    ];
+
+    expect(hadCachedResourcesForFailedSpecs(undefined, settled)).toBe(false);
+  });
+});
+
+describe('collectFailedProviderLabels', () => {
+  test('returns stable provider labels for rejected resources', () => {
+    const settled: SettledSpec<EmoteCacheKey, SanitisedEmote>[] = [
+      {
+        spec: spec('bttvGlobalEmotes'),
+        result: { status: 'rejected', reason: new Error('boom') },
+      },
+      {
+        spec: spec('twitchChannelEmotes'),
+        result: { status: 'fulfilled', value: [emote('ok')] },
+      },
+    ];
+
+    expect(collectFailedProviderLabels(settled)).toEqual(['BTTV']);
   });
 });

--- a/src/store/chat/actions/channelLoad.ts
+++ b/src/store/chat/actions/channelLoad.ts
@@ -347,6 +347,8 @@ const loadChannelResourcesInternal = async (
     });
 
     if (plan.kind === 'cached' && existingCache) {
+      const cachedRefreshSettled: ProviderFailureSettled[] = [];
+
       if (plan.fetchEmoteSetId) {
         if (exitIfAborted(signal, true)) {
           return false;
@@ -402,7 +404,7 @@ const loadChannelResourcesInternal = async (
           trigger: 'cached_subscriber_emotes_refresh',
         });
 
-        notifyProviderLoadFailures(channelId, subscriberSettled, existingCache);
+        cachedRefreshSettled.push(...subscriberSettled);
 
         const subscriberResult = subscriberSettled[0]?.result;
         const subscriberEmotes =
@@ -441,7 +443,7 @@ const loadChannelResourcesInternal = async (
           trigger: 'cached_badges_refresh',
         });
 
-        notifyProviderLoadFailures(channelId, badgeSettled, existingCache);
+        cachedRefreshSettled.push(...badgeSettled);
 
         const badgeByKey = reconcileSettledSpecs(badgeSettled, {
           channelId,
@@ -492,6 +494,13 @@ const loadChannelResourcesInternal = async (
           screen: 'chat',
         });
       }
+
+      notifyProviderLoadFailures(
+        channelId,
+        cachedRefreshSettled,
+        existingCache,
+      );
+
       batch(() => {
         chatStore$.currentChannelId.set(channelId);
         chatStore$.loadingState.set('COMPLETED');

--- a/src/store/chat/actions/channelLoad.ts
+++ b/src/store/chat/actions/channelLoad.ts
@@ -37,6 +37,7 @@ import {
   combineUniqueById,
   deduplicateById,
   type EmoteResourceSets,
+  hadCachedResourcesForFailedSpecs,
   reconcileSettledSpecs,
   reportResourceResults,
   settleSpecs,
@@ -86,6 +87,32 @@ const exitIfAborted = (
   }
   return true;
 };
+
+type ProviderFailureSettled = Parameters<
+  typeof collectFailedProviderLabels
+>[0][number];
+
+function notifyProviderLoadFailures(
+  channelId: string,
+  settled: readonly ProviderFailureSettled[],
+  existingCache: ChannelCacheType | undefined,
+): void {
+  const failedProviders = collectFailedProviderLabels(settled);
+  if (failedProviders.length === 0) {
+    return;
+  }
+
+  const hadCache = hadCachedResourcesForFailedSpecs(existingCache, settled);
+  addMessage(
+    createSystemMessage(
+      channelId,
+      i18next.t(
+        hadCache ? 'chat:providerLoadFailed' : 'chat:providerLoadFailedNoCache',
+        { providers: failedProviders.join(', ') },
+      ),
+    ),
+  );
+}
 
 export {
   clearPersonalEmotesCache,
@@ -375,6 +402,8 @@ const loadChannelResourcesInternal = async (
           trigger: 'cached_subscriber_emotes_refresh',
         });
 
+        notifyProviderLoadFailures(channelId, subscriberSettled, existingCache);
+
         const subscriberResult = subscriberSettled[0]?.result;
         const subscriberEmotes =
           subscriberResult?.status === 'fulfilled'
@@ -411,6 +440,8 @@ const loadChannelResourcesInternal = async (
           settled: badgeSettled,
           trigger: 'cached_badges_refresh',
         });
+
+        notifyProviderLoadFailures(channelId, badgeSettled, existingCache);
 
         const badgeByKey = reconcileSettledSpecs(badgeSettled, {
           channelId,
@@ -604,20 +635,11 @@ const loadChannelResourcesInternal = async (
       chatStore$.loadingState.set('COMPLETED');
     });
 
-    const failedProviders = collectFailedProviderLabels([
-      ...emoteSettled,
-      ...badgeSettled,
-    ]);
-    if (failedProviders.length > 0) {
-      addMessage(
-        createSystemMessage(
-          channelId,
-          i18next.t('chat:providerLoadFailed', {
-            providers: failedProviders.join(', '),
-          }),
-        ),
-      );
-    }
+    notifyProviderLoadFailures(
+      channelId,
+      [...emoteSettled, ...badgeSettled],
+      existingCache,
+    );
 
     if (twitchUserId) {
       void notify7TVPresence(twitchUserId, channelId);
@@ -647,6 +669,9 @@ const loadChannelResourcesInternal = async (
       channel_id: channelId,
       screen: 'chat',
     });
+    addMessage(
+      createSystemMessage(channelId, i18next.t('chat:channelResourcesFailed')),
+    );
     chatStore$.loadingState.set('ERROR');
     return false;
   }
@@ -721,6 +746,8 @@ export const clearCache = (channelId?: string) => {
         chatStore$.currentChannelId.set(null);
       }
     });
+    clearGlobalResourceCache();
+    chatStore$.cosmeticsCacheVersion.set(version => version + 1);
   } else {
     batch(() => {
       chatStore$.persisted.channelCaches.set({});
@@ -729,6 +756,7 @@ export const clearCache = (channelId?: string) => {
       chatStore$.loadingState.set('IDLE');
     });
     clearGlobalResourceCache();
+    chatStore$.cosmeticsCacheVersion.set(version => version + 1);
   }
 };
 

--- a/src/store/chat/actions/channelResources.ts
+++ b/src/store/chat/actions/channelResources.ts
@@ -497,3 +497,25 @@ export const collectFailedProviderLabels = (
   }
   return labels;
 };
+
+/**
+ * True when at least one rejected resource spec still has a non-empty slice in
+ * the channel cache to fall back to.
+ */
+export const hadCachedResourcesForFailedSpecs = (
+  existingCache: ChannelCacheType | undefined,
+  settled: readonly AnySettledSpec[],
+): boolean => {
+  if (!existingCache) {
+    return false;
+  }
+
+  return settled.some(({ result, spec }) => {
+    if (result.status !== 'rejected') {
+      return false;
+    }
+
+    const cached = existingCache[spec.key as keyof ChannelCacheType];
+    return Array.isArray(cached) && cached.length > 0;
+  });
+};

--- a/src/store/chat/actions/cosmetics.ts
+++ b/src/store/chat/actions/cosmetics.ts
@@ -494,11 +494,25 @@ export const getUserBadgeId = (ttvUserId: string): string | undefined =>
   chatStore$.userBadgeIds[ttvUserId]?.peek();
 
 export const updateBadge = (badge: SanitisedBadgeSet) => {
-  if (badge.id) {
-    const cell = chatStore$.badges[badge.id];
-    cell?.set(badge);
-    refreshCachedUserCosmeticsForDefinition(badge.id);
+  if (!badge.id) {
+    return;
   }
+
+  const normalizedBadge = normalizeSevenTvBadge(badge);
+  if (!normalizedBadge.url?.trim()) {
+    return;
+  }
+
+  const cell = chatStore$.badges[badge.id];
+  const previousUrl = cell?.peek()?.url?.trim();
+  cell?.set(normalizedBadge);
+  clearMissingBadge(badge.id);
+
+  if (previousUrl !== normalizedBadge.url.trim()) {
+    bumpCosmeticBindingsVersion();
+  }
+
+  refreshCachedUserCosmeticsForDefinition(badge.id);
 };
 
 export const removeBadge = (badgeId: string) => {

--- a/src/store/chat/actions/cosmetics.ts
+++ b/src/store/chat/actions/cosmetics.ts
@@ -186,6 +186,17 @@ function getUserCosmeticsCacheExpiry(hasCosmetics: boolean): number {
   );
 }
 
+function resolveRenderableBadge(
+  badgeId: string | null,
+): SanitisedBadgeSet | undefined {
+  if (!badgeId) {
+    return undefined;
+  }
+
+  const badge = getBadge(badgeId);
+  return badge?.url?.trim() ? badge : undefined;
+}
+
 function buildCachedUserCosmeticsFromStore(
   ttvUserId: string,
 ): CachedUserCosmetics {
@@ -193,7 +204,7 @@ function buildCachedUserCosmeticsFromStore(
   const badgeId = chatStore$.userBadgeIds[ttvUserId]?.peek() ?? null;
 
   return {
-    badge: badgeId ? getBadge(badgeId) : undefined,
+    badge: resolveRenderableBadge(badgeId),
     badgeId,
     expiresAt: getUserCosmeticsCacheExpiry(Boolean(paintId || badgeId)),
     paint: paintId ? getPaint(paintId) : undefined,
@@ -358,7 +369,7 @@ export const addPaint = (paint: PaintData) => {
 export const getPaint = (paintId: string): PaintData | undefined =>
   chatStore$.paints[paintId]?.peek();
 
-const getUserPaintId = (ttvUserId: string): string | undefined =>
+export const getUserPaintId = (ttvUserId: string): string | undefined =>
   chatStore$.userPaintIds[ttvUserId]?.peek();
 
 let userPaintFlagInvalidatorAttached = false;
@@ -538,8 +549,13 @@ export const removePaint = (paintId: string) => {
 
 export const removeUserPaint = (ttvUserId: string) => {
   const current = chatStore$.userPaintIds.peek();
+  if (!(ttvUserId in current)) {
+    return;
+  }
+
   const { [ttvUserId]: _, ...rest } = current;
   chatStore$.userPaintIds.set(rest);
+  bumpCosmeticBindingsVersion();
 };
 
 export const clearPaints = () => {

--- a/src/store/chat/actions/cosmetics.ts
+++ b/src/store/chat/actions/cosmetics.ts
@@ -30,6 +30,10 @@ import {
 
 export { getMissingBadgeIds, hasMissingBadges } from './missingBadges';
 
+export const bumpCosmeticBindingsVersion = (): void => {
+  chatStore$.cosmeticBindingsVersion.set(version => version + 1);
+};
+
 const COSMETICS_PERSIST_DEBOUNCE_MS = 4000;
 let cosmeticsPersistTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -54,8 +58,8 @@ export const scheduleCosmeticsPersist = (): void => {
 };
 
 const USER_COSMETICS_CACHE_PREFIX = 'user-cosmetics:';
-// Keep persisted 7TV user cosmetics for at most 12 hours before refetching.
-const USER_COSMETICS_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
+// Keep persisted 7TV user cosmetics for at most 2 hours before refetching.
+const USER_COSMETICS_CACHE_TTL_MS = 2 * 60 * 60 * 1000;
 const USER_COSMETICS_NEGATIVE_CACHE_TTL_MS = 30 * 60 * 1000;
 const SEVEN_TV_CACHE_NAMESPACE = 'seven_tv_cache';
 
@@ -173,6 +177,55 @@ function setCachedUserCosmetics(
   );
 }
 
+function getUserCosmeticsCacheExpiry(hasCosmetics: boolean): number {
+  return (
+    Date.now() +
+    (hasCosmetics
+      ? USER_COSMETICS_CACHE_TTL_MS
+      : USER_COSMETICS_NEGATIVE_CACHE_TTL_MS)
+  );
+}
+
+function buildCachedUserCosmeticsFromStore(
+  ttvUserId: string,
+): CachedUserCosmetics {
+  const paintId = chatStore$.userPaintIds[ttvUserId]?.peek() ?? null;
+  const badgeId = chatStore$.userBadgeIds[ttvUserId]?.peek() ?? null;
+
+  return {
+    badge: badgeId ? getBadge(badgeId) : undefined,
+    badgeId,
+    expiresAt: getUserCosmeticsCacheExpiry(Boolean(paintId || badgeId)),
+    paint: paintId ? getPaint(paintId) : undefined,
+    paintId,
+    ttvUserId,
+  };
+}
+
+/**
+ * Mirror live chatStore bindings into the per-user GQL cache after a 7TV push.
+ */
+export const syncCachedUserCosmeticsFromStore = (
+  sevenTvUserId: string,
+  ttvUserId: string,
+): void => {
+  setCachedUserCosmetics(
+    sevenTvUserId,
+    buildCachedUserCosmeticsFromStore(ttvUserId),
+  );
+};
+
+function refreshCachedUserCosmeticsForDefinition(cosmeticId: string): void {
+  for (const [sevenTvUserId, cached] of sessionCosmeticsCache.entries()) {
+    if (
+      cached.ttvUserId &&
+      (cached.paintId === cosmeticId || cached.badgeId === cosmeticId)
+    ) {
+      syncCachedUserCosmeticsFromStore(sevenTvUserId, cached.ttvUserId);
+    }
+  }
+}
+
 export const fetchAndCacheUserCosmetics = async (
   sevenTvUserId: string,
 ): Promise<string | null> => {
@@ -198,11 +251,7 @@ export const fetchAndCacheUserCosmetics = async (
       const cachedCosmetics: CachedUserCosmetics = {
         badge,
         badgeId: cosmetics.badgeId,
-        expiresAt:
-          Date.now() +
-          (paint || badge
-            ? USER_COSMETICS_CACHE_TTL_MS
-            : USER_COSMETICS_NEGATIVE_CACHE_TTL_MS),
+        expiresAt: getUserCosmeticsCacheExpiry(Boolean(paint || badge)),
         paint,
         paintId: cosmetics.paintId,
         ttvUserId: cosmetics.ttvUserId,
@@ -271,10 +320,12 @@ export const clearUserCosmeticsCache = () => {
   );
   clearPaintsAndBadges();
   chatStore$.cosmeticsCacheVersion.set(version => version + 1);
+  bumpCosmeticBindingsVersion();
 };
 
 export const setUserPaint = (ttvUserId: string, paintId: string): void => {
   const current = chatStore$.userPaintIds.peek();
+  const previousPaintId = current[ttvUserId];
 
   if (
     !(ttvUserId in current) &&
@@ -289,14 +340,18 @@ export const setUserPaint = (ttvUserId: string, paintId: string): void => {
     chatStore$.userPaintIds[ttvUserId]?.set(paintId);
   }
 
+  if (previousPaintId !== paintId) {
+    bumpCosmeticBindingsVersion();
+  }
+
   scheduleCosmeticsPersist();
 };
 
 export const addPaint = (paint: PaintData) => {
   if (paint.id) {
-    const cell = chatStore$.paints[paint.id];
-    cell?.set(paint);
+    chatStore$.paints[paint.id]?.set(paint);
     scheduleCosmeticsPersist();
+    refreshCachedUserCosmeticsForDefinition(paint.id);
   }
 };
 
@@ -348,12 +403,26 @@ export const hasUserPaint = (ttvUserId?: string): boolean => {
 };
 
 export const addBadge = (badge: SanitisedBadgeSet) => {
-  if (badge.id) {
-    const cell = chatStore$.badges[badge.id];
-    cell?.set(badge);
-    clearMissingBadge(badge.id);
-    scheduleCosmeticsPersist();
+  if (!badge.id) {
+    return;
   }
+
+  const normalizedBadge = normalizeSevenTvBadge(badge);
+  if (!normalizedBadge.url?.trim()) {
+    return;
+  }
+
+  const cell = chatStore$.badges[badge.id];
+  const previousUrl = cell?.peek()?.url?.trim();
+  cell?.set(normalizedBadge);
+  clearMissingBadge(badge.id);
+  scheduleCosmeticsPersist();
+
+  if (previousUrl !== normalizedBadge.url.trim()) {
+    bumpCosmeticBindingsVersion();
+  }
+
+  refreshCachedUserCosmeticsForDefinition(badge.id);
 };
 
 export const getBadge = (badgeId: string): SanitisedBadgeSet | undefined => {
@@ -366,6 +435,7 @@ export const getBadge = (badgeId: string): SanitisedBadgeSet | undefined => {
 
 export const setUserBadge = (ttvUserId: string, badgeId: string): void => {
   const current = chatStore$.userBadgeIds.peek();
+  const previousBadgeId = current[ttvUserId];
 
   if (
     !(ttvUserId in current) &&
@@ -386,6 +456,10 @@ export const setUserBadge = (ttvUserId: string, badgeId: string): void => {
     reportMissingBadge(badgeId, ttvUserId);
   }
 
+  if (previousBadgeId !== badgeId) {
+    bumpCosmeticBindingsVersion();
+  }
+
   scheduleCosmeticsPersist();
 };
 
@@ -397,11 +471,12 @@ export const getUserBadge = (
     return undefined;
   }
   const badge = getBadge(badgeId);
-  if (!badge) {
-    reportMissingBadge(badgeId, ttvUserId);
-    return undefined;
+  if (badge?.url?.trim()) {
+    return badge;
   }
-  return badge;
+
+  reportMissingBadge(badgeId, ttvUserId);
+  return undefined;
 };
 
 export const getUserBadgeId = (ttvUserId: string): string | undefined =>
@@ -411,6 +486,7 @@ export const updateBadge = (badge: SanitisedBadgeSet) => {
   if (badge.id) {
     const cell = chatStore$.badges[badge.id];
     cell?.set(badge);
+    refreshCachedUserCosmeticsForDefinition(badge.id);
   }
 };
 
@@ -431,14 +507,19 @@ export const removeBadge = (badgeId: string) => {
 
 export const removeUserBadge = (ttvUserId: string) => {
   const current = chatStore$.userBadgeIds.peek();
+  if (!(ttvUserId in current)) {
+    return;
+  }
+
   const { [ttvUserId]: _, ...rest } = current;
   chatStore$.userBadgeIds.set(rest);
+  bumpCosmeticBindingsVersion();
 };
 
 export const updatePaint = (paint: PaintData) => {
   if (paint.id) {
-    const cell = chatStore$.paints[paint.id];
-    cell?.set(paint);
+    chatStore$.paints[paint.id]?.set(paint);
+    refreshCachedUserCosmeticsForDefinition(paint.id);
   }
 };
 

--- a/src/store/chat/actions/cosmetics.ts
+++ b/src/store/chat/actions/cosmetics.ts
@@ -63,7 +63,7 @@ const USER_COSMETICS_CACHE_TTL_MS = 2 * 60 * 60 * 1000;
 const USER_COSMETICS_NEGATIVE_CACHE_TTL_MS = 30 * 60 * 1000;
 const SEVEN_TV_CACHE_NAMESPACE = 'seven_tv_cache';
 
-type CachedUserCosmetics = {
+export type CachedUserCosmetics = {
   badge?: SanitisedBadgeSet;
   badgeId: string | null;
   expiresAt: number;
@@ -177,36 +177,21 @@ function setCachedUserCosmetics(
   );
 }
 
-function getUserCosmeticsCacheExpiry(hasCosmetics: boolean): number {
-  return (
-    Date.now() +
-    (hasCosmetics
-      ? USER_COSMETICS_CACHE_TTL_MS
-      : USER_COSMETICS_NEGATIVE_CACHE_TTL_MS)
-  );
-}
-
-function resolveRenderableBadge(
-  badgeId: string | null,
-): SanitisedBadgeSet | undefined {
-  if (!badgeId) {
-    return undefined;
-  }
-
-  const badge = getBadge(badgeId);
-  return badge?.url?.trim() ? badge : undefined;
-}
-
 function buildCachedUserCosmeticsFromStore(
   ttvUserId: string,
 ): CachedUserCosmetics {
   const paintId = chatStore$.userPaintIds[ttvUserId]?.peek() ?? null;
   const badgeId = chatStore$.userBadgeIds[ttvUserId]?.peek() ?? null;
+  const badge = badgeId ? getBadge(badgeId) : undefined;
 
   return {
-    badge: resolveRenderableBadge(badgeId),
+    badge: badge?.url?.trim() ? badge : undefined,
     badgeId,
-    expiresAt: getUserCosmeticsCacheExpiry(Boolean(paintId || badgeId)),
+    expiresAt:
+      Date.now() +
+      (paintId || badgeId
+        ? USER_COSMETICS_CACHE_TTL_MS
+        : USER_COSMETICS_NEGATIVE_CACHE_TTL_MS),
     paint: paintId ? getPaint(paintId) : undefined,
     paintId,
     ttvUserId,
@@ -264,7 +249,11 @@ export const fetchAndCacheUserCosmetics = async (
       const cachedCosmetics: CachedUserCosmetics = {
         badge,
         badgeId: cosmetics.badgeId,
-        expiresAt: getUserCosmeticsCacheExpiry(Boolean(paint || badge)),
+        expiresAt:
+          Date.now() +
+          (paint || badge
+            ? USER_COSMETICS_CACHE_TTL_MS
+            : USER_COSMETICS_NEGATIVE_CACHE_TTL_MS),
         paint,
         paintId: cosmetics.paintId,
         ttvUserId: cosmetics.ttvUserId,

--- a/src/store/chat/actions/cosmetics.ts
+++ b/src/store/chat/actions/cosmetics.ts
@@ -227,7 +227,9 @@ export const syncCachedUserCosmeticsFromStore = (
 };
 
 function refreshCachedUserCosmeticsForDefinition(cosmeticId: string): void {
-  for (const [sevenTvUserId, cached] of sessionCosmeticsCache.entries()) {
+  for (const [sevenTvUserId, cached] of Array.from(
+    sessionCosmeticsCache.entries(),
+  )) {
     if (
       cached.ttvUserId &&
       (cached.paintId === cosmeticId || cached.badgeId === cosmeticId)

--- a/src/store/chat/actions/cosmeticsBridge.ts
+++ b/src/store/chat/actions/cosmeticsBridge.ts
@@ -231,11 +231,13 @@ export const applyEntitlementDeleteEvent = (data: {
 }): void => {
   const rememberedLink = twitchIdByEntitlementId.get(data.entitlementId);
   const ttvUserId = data.ttvUserId ?? rememberedLink?.twitchUserId ?? null;
-  if (!ttvUserId) {
+  // Without a remembered kind we cannot tell paint from badge; clearing both
+  // would drop the user's remaining cosmetic after an eviction or late delete.
+  if (!ttvUserId || !rememberedLink) {
     return;
   }
 
-  switch (rememberedLink?.kind) {
+  switch (rememberedLink.kind) {
     case 'PAINT':
       removeUserPaint(ttvUserId);
       break;
@@ -243,10 +245,6 @@ export const applyEntitlementDeleteEvent = (data: {
       removeUserBadge(ttvUserId);
       break;
     case 'EMOTE_SET':
-      break;
-    default:
-      removeUserPaint(ttvUserId);
-      removeUserBadge(ttvUserId);
       break;
   }
 

--- a/src/store/chat/actions/cosmeticsBridge.ts
+++ b/src/store/chat/actions/cosmeticsBridge.ts
@@ -28,6 +28,38 @@ const twitchIdsBySevenTvUserId = new Map<string, Set<string>>();
 const sevenTvUserIdByTwitchId = new Map<string, string>();
 const twitchIdByEntitlementId = new Map<string, string>();
 
+function forgetEntitlementIdsForTwitchUsers(
+  twitchUserIds: Iterable<string>,
+): void {
+  const twitchIds = new Set(twitchUserIds);
+  if (twitchIds.size === 0) {
+    return;
+  }
+
+  for (const [entitlementId, twitchUserId] of twitchIdByEntitlementId) {
+    if (twitchIds.has(twitchUserId)) {
+      twitchIdByEntitlementId.delete(entitlementId);
+    }
+  }
+}
+
+function rememberEntitlementTwitchLink(
+  entitlementId: string,
+  twitchUserId: string,
+): void {
+  if (
+    twitchIdByEntitlementId.size >= MAX_SEVEN_TV_USER_LINK_ENTRIES &&
+    !twitchIdByEntitlementId.has(entitlementId)
+  ) {
+    const oldest = twitchIdByEntitlementId.keys().next().value;
+    if (oldest !== undefined) {
+      twitchIdByEntitlementId.delete(oldest);
+    }
+  }
+
+  twitchIdByEntitlementId.set(entitlementId, twitchUserId);
+}
+
 function rememberSevenTvUserTwitchLink(
   sevenTvUserId: string,
   twitchUserId: string,
@@ -38,9 +70,13 @@ function rememberSevenTvUserTwitchLink(
     if (twitchIdsBySevenTvUserId.size >= MAX_SEVEN_TV_USER_LINK_ENTRIES) {
       const oldest = twitchIdsBySevenTvUserId.keys().next().value;
       if (oldest !== undefined) {
-        twitchIdsBySevenTvUserId.get(oldest)?.forEach(twitchId => {
+        const evictedTwitchIds = twitchIdsBySevenTvUserId.get(oldest);
+        evictedTwitchIds?.forEach(twitchId => {
           sevenTvUserIdByTwitchId.delete(twitchId);
         });
+        if (evictedTwitchIds) {
+          forgetEntitlementIdsForTwitchUsers(evictedTwitchIds);
+        }
         twitchIdsBySevenTvUserId.delete(oldest);
       }
     }
@@ -110,7 +146,7 @@ export const applyEntitlementCreateEvent = (data: {
   }
 
   if (ttvUserId && entitlement.id) {
-    twitchIdByEntitlementId.set(entitlement.id, ttvUserId);
+    rememberEntitlementTwitchLink(entitlement.id, ttvUserId);
   }
 
   if (kind === 'EMOTE_SET' && ttvUserId) {
@@ -159,6 +195,7 @@ export const applyEntitlementResetEvent = (sevenTvUserId: string): void => {
     syncCachedUserCosmeticsFromStore(sevenTvUserId, twitchUserId);
     sevenTvUserIdByTwitchId.delete(twitchUserId);
   });
+  forgetEntitlementIdsForTwitchUsers(twitchIds);
   twitchIdsBySevenTvUserId.delete(sevenTvUserId);
   logger.stvWs.info(`Reset entitlements for 7TV user: ${sevenTvUserId}`);
 };

--- a/src/store/chat/actions/cosmeticsBridge.ts
+++ b/src/store/chat/actions/cosmeticsBridge.ts
@@ -36,7 +36,9 @@ function forgetEntitlementIdsForTwitchUsers(
     return;
   }
 
-  for (const [entitlementId, twitchUserId] of twitchIdByEntitlementId) {
+  for (const [entitlementId, twitchUserId] of Array.from(
+    twitchIdByEntitlementId.entries(),
+  )) {
     if (twitchIds.has(twitchUserId)) {
       twitchIdByEntitlementId.delete(entitlementId);
     }

--- a/src/store/chat/actions/cosmeticsBridge.ts
+++ b/src/store/chat/actions/cosmeticsBridge.ts
@@ -26,6 +26,7 @@ import { handlePersonalEmoteSetEntitlement } from './personalEmotes';
 const MAX_SEVEN_TV_USER_LINK_ENTRIES = 2000;
 const twitchIdsBySevenTvUserId = new Map<string, Set<string>>();
 const sevenTvUserIdByTwitchId = new Map<string, string>();
+const twitchIdByEntitlementId = new Map<string, string>();
 
 function rememberSevenTvUserTwitchLink(
   sevenTvUserId: string,
@@ -106,6 +107,10 @@ export const applyEntitlementCreateEvent = (data: {
 
   if (ttvUserId && sevenTvUserId) {
     rememberSevenTvUserTwitchLink(sevenTvUserId, ttvUserId);
+  }
+
+  if (ttvUserId && entitlement.id) {
+    twitchIdByEntitlementId.set(entitlement.id, ttvUserId);
   }
 
   if (kind === 'EMOTE_SET' && ttvUserId) {
@@ -190,19 +195,24 @@ export const applyEntitlementUpdateEvent = (data: {
 };
 
 export const applyEntitlementDeleteEvent = (data: {
+  entitlementId: string;
   ttvUserId: string | null;
 }): void => {
-  if (!data.ttvUserId) {
+  const ttvUserId =
+    data.ttvUserId ?? twitchIdByEntitlementId.get(data.entitlementId) ?? null;
+  if (!ttvUserId) {
     return;
   }
 
-  removeUserPaint(data.ttvUserId);
-  removeUserBadge(data.ttvUserId);
-  syncUserCosmeticsCacheForTwitchUser(data.ttvUserId);
-  logger.stvWs.info(`Removed entitlements for user: ${data.ttvUserId}`);
+  removeUserPaint(ttvUserId);
+  removeUserBadge(ttvUserId);
+  syncUserCosmeticsCacheForTwitchUser(ttvUserId);
+  twitchIdByEntitlementId.delete(data.entitlementId);
+  logger.stvWs.info(`Removed entitlements for user: ${ttvUserId}`);
 };
 
 export const clearEntitlementUserLinkState = (): void => {
   twitchIdsBySevenTvUserId.clear();
   sevenTvUserIdByTwitchId.clear();
+  twitchIdByEntitlementId.clear();
 };

--- a/src/store/chat/actions/cosmeticsBridge.ts
+++ b/src/store/chat/actions/cosmeticsBridge.ts
@@ -24,12 +24,12 @@ import {
 import { handlePersonalEmoteSetEntitlement } from './personalEmotes';
 
 const MAX_SEVEN_TV_USER_LINK_ENTRIES = 2000;
-const twitchIdsBySevenTvUserId = new Map<string, Set<string>>();
-const sevenTvUserIdByTwitchId = new Map<string, string>();
-const twitchIdByEntitlementId = new Map<
-  string,
-  { kind: 'BADGE' | 'PAINT' | 'EMOTE_SET'; twitchUserId: string }
->();
+
+const entitlementLinks$ = chatStore$.sevenTvUserLinks.twitchIdByEntitlementId;
+const twitchIdsBySevenTvUserId$ =
+  chatStore$.sevenTvUserLinks.twitchIdsBySevenTvUserId;
+const sevenTvUserIdByTwitchId$ =
+  chatStore$.sevenTvUserLinks.sevenTvUserIdByTwitchId;
 
 function forgetEntitlementIdsForTwitchUsers(
   twitchUserIds: Iterable<string>,
@@ -39,12 +39,18 @@ function forgetEntitlementIdsForTwitchUsers(
     return;
   }
 
-  for (const [entitlementId, link] of Array.from(
-    twitchIdByEntitlementId.entries(),
-  )) {
+  const current = entitlementLinks$.peek();
+  const next: typeof current = {};
+  let changed = false;
+  for (const [entitlementId, link] of Object.entries(current)) {
     if (twitchIds.has(link.twitchUserId)) {
-      twitchIdByEntitlementId.delete(entitlementId);
+      changed = true;
+      continue;
     }
+    next[entitlementId] = link;
+  }
+  if (changed) {
+    entitlementLinks$.set(next);
   }
 }
 
@@ -53,43 +59,56 @@ function rememberEntitlementTwitchLink(
   twitchUserId: string,
   kind: 'BADGE' | 'PAINT' | 'EMOTE_SET',
 ): void {
-  if (
-    twitchIdByEntitlementId.size >= MAX_SEVEN_TV_USER_LINK_ENTRIES &&
-    !twitchIdByEntitlementId.has(entitlementId)
-  ) {
-    const oldest = twitchIdByEntitlementId.keys().next().value;
-    if (oldest !== undefined) {
-      twitchIdByEntitlementId.delete(oldest);
+  const current = entitlementLinks$.peek();
+  const alreadyPresent = entitlementId in current;
+
+  const next: typeof current = { ...current };
+  if (!alreadyPresent) {
+    const oldest = Object.keys(next)[0];
+    if (
+      oldest !== undefined &&
+      Object.keys(next).length >= MAX_SEVEN_TV_USER_LINK_ENTRIES
+    ) {
+      delete next[oldest];
     }
   }
-
-  twitchIdByEntitlementId.set(entitlementId, { kind, twitchUserId });
+  next[entitlementId] = { kind, twitchUserId };
+  entitlementLinks$.set(next);
 }
 
 function rememberSevenTvUserTwitchLink(
   sevenTvUserId: string,
   twitchUserId: string,
 ): void {
-  sevenTvUserIdByTwitchId.set(twitchUserId, sevenTvUserId);
-  let twitchIds = twitchIdsBySevenTvUserId.get(sevenTvUserId);
-  if (!twitchIds) {
-    if (twitchIdsBySevenTvUserId.size >= MAX_SEVEN_TV_USER_LINK_ENTRIES) {
-      const oldest = twitchIdsBySevenTvUserId.keys().next().value;
-      if (oldest !== undefined) {
-        const evictedTwitchIds = twitchIdsBySevenTvUserId.get(oldest);
-        if (evictedTwitchIds) {
-          evictedTwitchIds.forEach(twitchId => {
-            sevenTvUserIdByTwitchId.delete(twitchId);
-          });
-          forgetEntitlementIdsForTwitchUsers(evictedTwitchIds);
-        }
-        twitchIdsBySevenTvUserId.delete(oldest);
+  const reverse = { ...sevenTvUserIdByTwitchId$.peek() };
+  reverse[twitchUserId] = sevenTvUserId;
+
+  const forward = { ...twitchIdsBySevenTvUserId$.peek() };
+  let existing = forward[sevenTvUserId];
+  if (!existing) {
+    const oldest = Object.keys(forward)[0];
+    if (
+      oldest !== undefined &&
+      Object.keys(forward).length >= MAX_SEVEN_TV_USER_LINK_ENTRIES
+    ) {
+      const evictedTwitchIds = forward[oldest];
+      if (evictedTwitchIds) {
+        evictedTwitchIds.forEach((twitchId: string) => {
+          delete reverse[twitchId];
+        });
+        forgetEntitlementIdsForTwitchUsers(evictedTwitchIds);
       }
+      delete forward[oldest];
     }
-    twitchIds = new Set();
-    twitchIdsBySevenTvUserId.set(sevenTvUserId, twitchIds);
+    existing = [];
+    forward[sevenTvUserId] = existing;
   }
-  twitchIds.add(twitchUserId);
+  if (!existing.includes(twitchUserId)) {
+    forward[sevenTvUserId] = [...existing, twitchUserId];
+  }
+
+  sevenTvUserIdByTwitchId$.set(reverse);
+  twitchIdsBySevenTvUserId$.set(forward);
 }
 
 export const applyCosmeticCreateEvent = (
@@ -179,24 +198,31 @@ export const applyEntitlementCreateEvent = (data: {
 };
 
 export const applyEntitlementResetEvent = (sevenTvUserId: string): void => {
-  const twitchIds = twitchIdsBySevenTvUserId.get(sevenTvUserId);
-  if (!twitchIds) {
+  const forward = twitchIdsBySevenTvUserId$.peek();
+  const twitchIds = forward[sevenTvUserId];
+  if (!twitchIds || twitchIds.length === 0) {
     return;
   }
 
+  const reverseNext = { ...sevenTvUserIdByTwitchId$.peek() };
   twitchIds.forEach(twitchUserId => {
     removeUserPaint(twitchUserId);
     removeUserBadge(twitchUserId);
     syncCachedUserCosmeticsFromStore(sevenTvUserId, twitchUserId);
-    sevenTvUserIdByTwitchId.delete(twitchUserId);
+    delete reverseNext[twitchUserId];
   });
   forgetEntitlementIdsForTwitchUsers(twitchIds);
-  twitchIdsBySevenTvUserId.delete(sevenTvUserId);
+
+  const forwardNext = { ...forward };
+  delete forwardNext[sevenTvUserId];
+
+  sevenTvUserIdByTwitchId$.set(reverseNext);
+  twitchIdsBySevenTvUserId$.set(forwardNext);
   logger.stvWs.info(`Reset entitlements for 7TV user: ${sevenTvUserId}`);
 };
 
 function syncUserCosmeticsCacheForTwitchUser(ttvUserId: string): void {
-  const sevenTvUserId = sevenTvUserIdByTwitchId.get(ttvUserId);
+  const sevenTvUserId = sevenTvUserIdByTwitchId$.peek()[ttvUserId];
   if (sevenTvUserId) {
     syncCachedUserCosmeticsFromStore(sevenTvUserId, ttvUserId);
   }
@@ -229,7 +255,8 @@ export const applyEntitlementDeleteEvent = (data: {
   entitlementId: string;
   ttvUserId: string | null;
 }): void => {
-  const rememberedLink = twitchIdByEntitlementId.get(data.entitlementId);
+  const current = entitlementLinks$.peek();
+  const rememberedLink = current[data.entitlementId];
   const ttvUserId = data.ttvUserId ?? rememberedLink?.twitchUserId ?? null;
   // Without a remembered kind we cannot tell paint from badge; clearing both
   // would drop the user's remaining cosmetic after an eviction or late delete.
@@ -249,12 +276,14 @@ export const applyEntitlementDeleteEvent = (data: {
   }
 
   syncUserCosmeticsCacheForTwitchUser(ttvUserId);
-  twitchIdByEntitlementId.delete(data.entitlementId);
+  const next = { ...current };
+  delete next[data.entitlementId];
+  entitlementLinks$.set(next);
   logger.stvWs.info(`Removed entitlements for user: ${ttvUserId}`);
 };
 
 export const clearEntitlementUserLinkState = (): void => {
-  twitchIdsBySevenTvUserId.clear();
-  sevenTvUserIdByTwitchId.clear();
-  twitchIdByEntitlementId.clear();
+  twitchIdsBySevenTvUserId$.set({});
+  sevenTvUserIdByTwitchId$.set({});
+  entitlementLinks$.set({});
 };

--- a/src/store/chat/actions/cosmeticsBridge.ts
+++ b/src/store/chat/actions/cosmeticsBridge.ts
@@ -26,7 +26,10 @@ import { handlePersonalEmoteSetEntitlement } from './personalEmotes';
 const MAX_SEVEN_TV_USER_LINK_ENTRIES = 2000;
 const twitchIdsBySevenTvUserId = new Map<string, Set<string>>();
 const sevenTvUserIdByTwitchId = new Map<string, string>();
-const twitchIdByEntitlementId = new Map<string, string>();
+const twitchIdByEntitlementId = new Map<
+  string,
+  { kind: 'BADGE' | 'PAINT' | 'EMOTE_SET'; twitchUserId: string }
+>();
 
 function forgetEntitlementIdsForTwitchUsers(
   twitchUserIds: Iterable<string>,
@@ -36,10 +39,10 @@ function forgetEntitlementIdsForTwitchUsers(
     return;
   }
 
-  for (const [entitlementId, twitchUserId] of Array.from(
+  for (const [entitlementId, link] of Array.from(
     twitchIdByEntitlementId.entries(),
   )) {
-    if (twitchIds.has(twitchUserId)) {
+    if (twitchIds.has(link.twitchUserId)) {
       twitchIdByEntitlementId.delete(entitlementId);
     }
   }
@@ -48,6 +51,7 @@ function forgetEntitlementIdsForTwitchUsers(
 function rememberEntitlementTwitchLink(
   entitlementId: string,
   twitchUserId: string,
+  kind: 'BADGE' | 'PAINT' | 'EMOTE_SET',
 ): void {
   if (
     twitchIdByEntitlementId.size >= MAX_SEVEN_TV_USER_LINK_ENTRIES &&
@@ -59,7 +63,7 @@ function rememberEntitlementTwitchLink(
     }
   }
 
-  twitchIdByEntitlementId.set(entitlementId, twitchUserId);
+  twitchIdByEntitlementId.set(entitlementId, { kind, twitchUserId });
 }
 
 function rememberSevenTvUserTwitchLink(
@@ -148,7 +152,7 @@ export const applyEntitlementCreateEvent = (data: {
   }
 
   if (ttvUserId && entitlement.id) {
-    rememberEntitlementTwitchLink(entitlement.id, ttvUserId);
+    rememberEntitlementTwitchLink(entitlement.id, ttvUserId, kind);
   }
 
   if (kind === 'EMOTE_SET' && ttvUserId) {
@@ -238,14 +242,27 @@ export const applyEntitlementDeleteEvent = (data: {
   entitlementId: string;
   ttvUserId: string | null;
 }): void => {
-  const ttvUserId =
-    data.ttvUserId ?? twitchIdByEntitlementId.get(data.entitlementId) ?? null;
+  const rememberedLink = twitchIdByEntitlementId.get(data.entitlementId);
+  const ttvUserId = data.ttvUserId ?? rememberedLink?.twitchUserId ?? null;
   if (!ttvUserId) {
     return;
   }
 
-  removeUserPaint(ttvUserId);
-  removeUserBadge(ttvUserId);
+  switch (rememberedLink?.kind) {
+    case 'PAINT':
+      removeUserPaint(ttvUserId);
+      break;
+    case 'BADGE':
+      removeUserBadge(ttvUserId);
+      break;
+    case 'EMOTE_SET':
+      break;
+    default:
+      removeUserPaint(ttvUserId);
+      removeUserBadge(ttvUserId);
+      break;
+  }
+
   syncUserCosmeticsCacheForTwitchUser(ttvUserId);
   twitchIdByEntitlementId.delete(data.entitlementId);
   logger.stvWs.info(`Removed entitlements for user: ${ttvUserId}`);

--- a/src/store/chat/actions/cosmeticsBridge.ts
+++ b/src/store/chat/actions/cosmeticsBridge.ts
@@ -77,10 +77,10 @@ function rememberSevenTvUserTwitchLink(
       const oldest = twitchIdsBySevenTvUserId.keys().next().value;
       if (oldest !== undefined) {
         const evictedTwitchIds = twitchIdsBySevenTvUserId.get(oldest);
-        evictedTwitchIds?.forEach(twitchId => {
-          sevenTvUserIdByTwitchId.delete(twitchId);
-        });
         if (evictedTwitchIds) {
+          evictedTwitchIds.forEach(twitchId => {
+            sevenTvUserIdByTwitchId.delete(twitchId);
+          });
           forgetEntitlementIdsForTwitchUsers(evictedTwitchIds);
         }
         twitchIdsBySevenTvUserId.delete(oldest);
@@ -178,9 +178,6 @@ export const applyEntitlementCreateEvent = (data: {
   }
 };
 
-/**
- * Clear paint and badge bindings for every Twitch account linked to a 7TV user.
- */
 export const applyEntitlementResetEvent = (sevenTvUserId: string): void => {
   const twitchIds = twitchIdsBySevenTvUserId.get(sevenTvUserId);
   if (!twitchIds) {

--- a/src/store/chat/actions/cosmeticsBridge.ts
+++ b/src/store/chat/actions/cosmeticsBridge.ts
@@ -13,13 +13,41 @@ import { chatStore$ } from '../observables/chatStore';
 import {
   addBadge,
   addPaint,
-  fetchUserCosmeticsByTwitchId,
   getBadge,
   getPaint,
+  removeUserBadge,
+  removeUserPaint,
   setUserBadge,
   setUserPaint,
+  syncCachedUserCosmeticsFromStore,
 } from './cosmetics';
 import { handlePersonalEmoteSetEntitlement } from './personalEmotes';
+
+const MAX_SEVEN_TV_USER_LINK_ENTRIES = 2000;
+const twitchIdsBySevenTvUserId = new Map<string, Set<string>>();
+const sevenTvUserIdByTwitchId = new Map<string, string>();
+
+function rememberSevenTvUserTwitchLink(
+  sevenTvUserId: string,
+  twitchUserId: string,
+): void {
+  sevenTvUserIdByTwitchId.set(twitchUserId, sevenTvUserId);
+  let twitchIds = twitchIdsBySevenTvUserId.get(sevenTvUserId);
+  if (!twitchIds) {
+    if (twitchIdsBySevenTvUserId.size >= MAX_SEVEN_TV_USER_LINK_ENTRIES) {
+      const oldest = twitchIdsBySevenTvUserId.keys().next().value;
+      if (oldest !== undefined) {
+        twitchIdsBySevenTvUserId.get(oldest)?.forEach(twitchId => {
+          sevenTvUserIdByTwitchId.delete(twitchId);
+        });
+        twitchIdsBySevenTvUserId.delete(oldest);
+      }
+    }
+    twitchIds = new Set();
+    twitchIdsBySevenTvUserId.set(sevenTvUserId, twitchIds);
+  }
+  twitchIds.add(twitchUserId);
+}
 
 export const applyCosmeticCreateEvent = (
   cosmetic: CosmeticCreate,
@@ -48,42 +76,53 @@ export const applyCosmeticCreateEvent = (
   }
 };
 
+function bindEmoteSetStyleCosmetics(
+  ttvUserId: string,
+  paintId: string | null,
+  badgeId: string | null,
+): void {
+  if (paintId) {
+    setUserPaint(ttvUserId, paintId);
+  }
+  if (badgeId) {
+    setUserBadge(ttvUserId, badgeId);
+  }
+}
+
 /**
- * Bind an entitlement to its Twitch user. Fetches missing definitions over GQL
- * when `requestMissingDefinitions` is true.
+ * Bind an entitlement to its Twitch user. Paint and badge definitions are
+ * expected from `cosmetic.create` WebSocket events.
  */
-export const applyEntitlementCreateEvent = (
-  data: {
-    entitlement: EntitlementCreate;
-    kind: 'BADGE' | 'PAINT' | 'EMOTE_SET';
-    ttvUserId: string | null;
-    paintId: string | null;
-    badgeId: string | null;
-  },
-  options: { requestMissingDefinitions: boolean },
-): void => {
+export const applyEntitlementCreateEvent = (data: {
+  entitlement: EntitlementCreate;
+  kind: 'BADGE' | 'PAINT' | 'EMOTE_SET';
+  ttvUserId: string | null;
+  paintId: string | null;
+  badgeId: string | null;
+}): void => {
   const { entitlement, kind, ttvUserId } = data;
   const cosmeticId = entitlement.object.ref_id;
+  const sevenTvUserId = entitlement.object.user?.id;
+
+  if (ttvUserId && sevenTvUserId) {
+    rememberSevenTvUserTwitchLink(sevenTvUserId, ttvUserId);
+  }
+
+  if (kind === 'EMOTE_SET' && ttvUserId) {
+    bindEmoteSetStyleCosmetics(ttvUserId, data.paintId, data.badgeId);
+  }
 
   if (kind === 'PAINT') {
     const paintId = cosmeticId || data.paintId;
-    if (!paintId || !ttvUserId) {
-      return;
-    }
-    setUserPaint(ttvUserId, paintId);
-    if (!getPaint(paintId) && options.requestMissingDefinitions) {
-      void fetchUserCosmeticsByTwitchId(ttvUserId);
+    if (paintId && ttvUserId) {
+      setUserPaint(ttvUserId, paintId);
     }
   }
 
   if (kind === 'BADGE') {
     const badgeId = cosmeticId || data.badgeId;
-    if (!badgeId || !ttvUserId) {
-      return;
-    }
-    setUserBadge(ttvUserId, badgeId);
-    if (!getBadge(badgeId) && options.requestMissingDefinitions) {
-      void fetchUserCosmeticsByTwitchId(ttvUserId);
+    if (badgeId && ttvUserId) {
+      setUserBadge(ttvUserId, badgeId);
     }
   }
 
@@ -94,4 +133,76 @@ export const applyEntitlementCreateEvent = (
       chatStore$.currentChannelId.peek(),
     );
   }
+
+  if (ttvUserId && sevenTvUserId) {
+    syncCachedUserCosmeticsFromStore(sevenTvUserId, ttvUserId);
+  }
+};
+
+/**
+ * Clear paint and badge bindings for every Twitch account linked to a 7TV user.
+ */
+export const applyEntitlementResetEvent = (sevenTvUserId: string): void => {
+  const twitchIds = twitchIdsBySevenTvUserId.get(sevenTvUserId);
+  if (!twitchIds) {
+    return;
+  }
+
+  twitchIds.forEach(twitchUserId => {
+    removeUserPaint(twitchUserId);
+    removeUserBadge(twitchUserId);
+    syncCachedUserCosmeticsFromStore(sevenTvUserId, twitchUserId);
+  });
+  twitchIdsBySevenTvUserId.delete(sevenTvUserId);
+  logger.stvWs.info(`Reset entitlements for 7TV user: ${sevenTvUserId}`);
+};
+
+function syncUserCosmeticsCacheForTwitchUser(ttvUserId: string): void {
+  const sevenTvUserId = sevenTvUserIdByTwitchId.get(ttvUserId);
+  if (sevenTvUserId) {
+    syncCachedUserCosmeticsFromStore(sevenTvUserId, ttvUserId);
+  }
+}
+
+export const applyEntitlementUpdateEvent = (data: {
+  ttvUserId: string | null;
+  paintId: string | null;
+  badgeId: string | null;
+}): void => {
+  const { ttvUserId, paintId, badgeId } = data;
+  if (!ttvUserId) {
+    return;
+  }
+
+  if (paintId) {
+    setUserPaint(ttvUserId, paintId);
+  } else {
+    removeUserPaint(ttvUserId);
+  }
+
+  if (badgeId) {
+    setUserBadge(ttvUserId, badgeId);
+  } else {
+    removeUserBadge(ttvUserId);
+  }
+
+  syncUserCosmeticsCacheForTwitchUser(ttvUserId);
+};
+
+export const applyEntitlementDeleteEvent = (data: {
+  ttvUserId: string | null;
+}): void => {
+  if (!data.ttvUserId) {
+    return;
+  }
+
+  removeUserPaint(data.ttvUserId);
+  removeUserBadge(data.ttvUserId);
+  syncUserCosmeticsCacheForTwitchUser(data.ttvUserId);
+  logger.stvWs.info(`Removed entitlements for user: ${data.ttvUserId}`);
+};
+
+export const clearEntitlementUserLinkState = (): void => {
+  twitchIdsBySevenTvUserId.clear();
+  sevenTvUserIdByTwitchId.clear();
 };

--- a/src/store/chat/actions/cosmeticsBridge.ts
+++ b/src/store/chat/actions/cosmeticsBridge.ts
@@ -119,19 +119,6 @@ export const applyCosmeticCreateEvent = (
   }
 };
 
-function bindEmoteSetStyleCosmetics(
-  ttvUserId: string,
-  paintId: string | null,
-  badgeId: string | null,
-): void {
-  if (paintId) {
-    setUserPaint(ttvUserId, paintId);
-  }
-  if (badgeId) {
-    setUserBadge(ttvUserId, badgeId);
-  }
-}
-
 /**
  * Bind an entitlement to its Twitch user. Paint and badge definitions are
  * expected from `cosmetic.create` WebSocket events.
@@ -156,7 +143,12 @@ export const applyEntitlementCreateEvent = (data: {
   }
 
   if (kind === 'EMOTE_SET' && ttvUserId) {
-    bindEmoteSetStyleCosmetics(ttvUserId, data.paintId, data.badgeId);
+    if (data.paintId) {
+      setUserPaint(ttvUserId, data.paintId);
+    }
+    if (data.badgeId) {
+      setUserBadge(ttvUserId, data.badgeId);
+    }
   }
 
   if (kind === 'PAINT') {
@@ -223,8 +215,6 @@ export const applyEntitlementUpdateEvent = (data: {
     return;
   }
 
-  // Null means "not present in this update", not "unequip". Removals come
-  // through entitlement.delete / entitlement.reset.
   if (paintId) {
     setUserPaint(ttvUserId, paintId);
   }

--- a/src/store/chat/actions/cosmeticsBridge.ts
+++ b/src/store/chat/actions/cosmeticsBridge.ts
@@ -223,19 +223,19 @@ export const applyEntitlementUpdateEvent = (data: {
     return;
   }
 
+  // Null means "not present in this update", not "unequip". Removals come
+  // through entitlement.delete / entitlement.reset.
   if (paintId) {
     setUserPaint(ttvUserId, paintId);
-  } else {
-    removeUserPaint(ttvUserId);
   }
 
   if (badgeId) {
     setUserBadge(ttvUserId, badgeId);
-  } else {
-    removeUserBadge(ttvUserId);
   }
 
-  syncUserCosmeticsCacheForTwitchUser(ttvUserId);
+  if (paintId || badgeId) {
+    syncUserCosmeticsCacheForTwitchUser(ttvUserId);
+  }
 };
 
 export const applyEntitlementDeleteEvent = (data: {

--- a/src/store/chat/actions/cosmeticsBridge.ts
+++ b/src/store/chat/actions/cosmeticsBridge.ts
@@ -157,6 +157,7 @@ export const applyEntitlementResetEvent = (sevenTvUserId: string): void => {
     removeUserPaint(twitchUserId);
     removeUserBadge(twitchUserId);
     syncCachedUserCosmeticsFromStore(sevenTvUserId, twitchUserId);
+    sevenTvUserIdByTwitchId.delete(twitchUserId);
   });
   twitchIdsBySevenTvUserId.delete(sevenTvUserId);
   logger.stvWs.info(`Reset entitlements for 7TV user: ${sevenTvUserId}`);

--- a/src/store/chat/observables/chatStore.ts
+++ b/src/store/chat/observables/chatStore.ts
@@ -71,6 +71,21 @@ export interface ChatStoreState {
       { value: SanitisedBadgeSet[]; expiresAt: number }
     >;
   };
+  /**
+   * Session-scoped 7TV identity/entitlement lookup tables used by the
+   * cosmetics WebSocket bridge. Kept on the store (rather than as
+   * module-level Maps) so their lifecycle sits with the rest of the chat
+   * session state and clears with it. `Object.keys` iteration order gives
+   * FIFO for the entitlement id cap.
+   */
+  sevenTvUserLinks: {
+    twitchIdsBySevenTvUserId: Record<string, string[]>;
+    sevenTvUserIdByTwitchId: Record<string, string>;
+    twitchIdByEntitlementId: Record<
+      string,
+      { kind: 'BADGE' | 'PAINT' | 'EMOTE_SET'; twitchUserId: string }
+    >;
+  };
 }
 
 export const limitChannelCaches = (
@@ -126,6 +141,11 @@ const initialChatStoreState: ChatStoreState = {
   sharedChatBadgeCaches: {
     sourceBadges: {},
     channelBadges: {},
+  },
+  sevenTvUserLinks: {
+    twitchIdsBySevenTvUserId: {},
+    sevenTvUserIdByTwitchId: {},
+    twitchIdByEntitlementId: {},
   },
 };
 

--- a/src/store/chat/observables/chatStore.ts
+++ b/src/store/chat/observables/chatStore.ts
@@ -44,6 +44,11 @@ export interface ChatStoreState {
   messages: AnyChatMessageType[];
   mentionLoginRevision: number;
   cosmeticsCacheVersion: number;
+  /**
+   * Incremented when per-user cosmetic bindings or badge definitions change so
+   * chat messages can re-resolve badges without reloading channel emote data.
+   */
+  cosmeticBindingsVersion: number;
   paints: Record<string, PaintData>;
   userPaintIds: Record<string, string>;
   badges: Record<string, SanitisedBadgeSet>;
@@ -108,6 +113,7 @@ const initialChatStoreState: ChatStoreState = {
   messages: [],
   mentionLoginRevision: 0,
   cosmeticsCacheVersion: 0,
+  cosmeticBindingsVersion: 0,
   paints: {},
   userPaintIds: {},
   badges: {},

--- a/src/store/chat/observables/cosmeticsPersistence.ts
+++ b/src/store/chat/observables/cosmeticsPersistence.ts
@@ -4,7 +4,7 @@ import type { PaintData, SanitisedBadgeSet } from '../types/constants';
 
 const COSMETICS_SNAPSHOT_KEY = 'sevenTvCosmeticsSnapshot_v1';
 const COSMETICS_NAMESPACE = 'seven_tv_cache';
-const SNAPSHOT_TTL_MS = 24 * 60 * 60 * 1000;
+const SNAPSHOT_TTL_MS = 2 * 60 * 60 * 1000;
 const MAX_PERSISTED_PAINTS = 750;
 const MAX_PERSISTED_BADGES = 750;
 const MAX_PERSISTED_ENTITLEMENTS = 500;

--- a/src/store/chat/react/selectors.ts
+++ b/src/store/chat/react/selectors.ts
@@ -151,3 +151,5 @@ export const useChannelEmoteData = (channelId: string | null) => {
 };
 
 export const usePaints = () => useSelector(chatStore$.paints);
+export const useCosmeticBindingsVersion = () =>
+  useSelector(chatStore$.cosmeticBindingsVersion);

--- a/src/types/seventv/cosmetics.ts
+++ b/src/types/seventv/cosmetics.ts
@@ -361,6 +361,10 @@ export interface EntitlementDeleteCallbackData {
   ttvUserId: string | null;
 }
 
+export interface EntitlementResetCallbackData {
+  sevenTvUserId: string;
+}
+
 export interface SevenTvEventMap {
   // Cosmetics
   'cosmetic.create': CosmeticCreate;
@@ -390,6 +394,7 @@ export interface SevenTvEventMap {
   'entitlement.create': EntitlementCreate;
   'entitlement.update': ChangeMap<EntitlementCreate>;
   'entitlement.delete': { id: string };
+  'entitlement.reset': { id: string };
   'entitlement.*':
     EntitlementCreate | ChangeMap<EntitlementCreate> | { id: string };
 }

--- a/src/utils/chat/__tests__/findBadges.test.ts
+++ b/src/utils/chat/__tests__/findBadges.test.ts
@@ -251,5 +251,87 @@ describe('findBadges', () => {
 
       expect(result).toEqual<SanitisedBadgeSet[]>([channelBadge]);
     });
+
+    test('falls back to global subscriber badges when the channel tier has no url', () => {
+      const channelSubscriberBadge = {
+        id: '12',
+        url: '',
+        type: 'Twitch Subscriber Badge',
+        title: 'Broken Channel Sub',
+        set: 'subscriber',
+      } as const;
+
+      const globalSubscriberBadge = {
+        id: 'subscriber_12',
+        url: 'https://example.com/global-sub.png',
+        type: 'Twitch Global Badge',
+        title: '12-Month Subscriber',
+        set: 'subscriber',
+      } as const;
+
+      const userstate: UserStateTags = {
+        'badges-raw': 'subscriber/12',
+        badges: {
+          subscriber: '12',
+        },
+        'user-id': '123456789',
+        username: 'testuser',
+        'display-name': 'TestUser',
+        color: '#FF0000',
+        mod: 'false',
+        subscriber: 'false',
+        turbo: 'false',
+        'user-type': '',
+        'reply-parent-display-name': '',
+        'reply-parent-msg-body': '',
+        'reply-parent-msg-id': '',
+        'reply-parent-user-login': '',
+      };
+
+      const result = findBadges({
+        twitchGlobalBadges: [globalSubscriberBadge],
+        chatterinoBadges: [],
+        chatUsers: [],
+        ffzChannelBadges: [],
+        ffzGlobalBadges: [],
+        twitchChannelBadges: [channelSubscriberBadge],
+        userstate,
+      });
+
+      expect(result).toEqual<SanitisedBadgeSet[]>([globalSubscriberBadge]);
+    });
+
+    test('omits twitch badges when neither channel nor global urls resolve', () => {
+      const userstate: UserStateTags = {
+        'badges-raw': 'subscriber/12',
+        badges: {
+          subscriber: '12',
+        },
+        'user-id': '123456789',
+        username: 'testuser',
+        'display-name': 'TestUser',
+        color: '#FF0000',
+        mod: 'false',
+        subscriber: 'false',
+        turbo: 'false',
+        'user-type': '',
+        'reply-parent-display-name': '',
+        'reply-parent-msg-body': '',
+        'reply-parent-msg-id': '',
+        'reply-parent-user-login': '',
+      };
+
+      const result = findBadges({
+        twitchGlobalBadges: [],
+        chatterinoBadges: [],
+        chatUsers: [],
+        ffzChannelBadges: [],
+        ffzGlobalBadges: [],
+        twitchChannelBadges: [],
+        userstate,
+      });
+
+      expect(result).toEqual<SanitisedBadgeSet[]>([]);
+    });
   });
 });

--- a/src/utils/chat/__tests__/findBadges.test.ts
+++ b/src/utils/chat/__tests__/findBadges.test.ts
@@ -98,21 +98,21 @@ describe('findBadges', () => {
     );
 
     test('uses source badges for shared chat messages', () => {
-      const sourceSubscriberBadge = {
+      const sourceSubscriberBadge: SanitisedBadgeSet = {
         id: '3',
         url: 'https://example.com/source-sub.png',
         type: 'Twitch Subscriber Badge',
         title: 'Source 3-Month Subscriber',
         set: 'subscriber',
-      } as const;
+      };
 
-      const targetSubscriberBadge = {
+      const targetSubscriberBadge: SanitisedBadgeSet = {
         id: '1',
         url: 'https://example.com/target-sub.png',
         type: 'Twitch Subscriber Badge',
         title: 'Target Subscriber',
         set: 'subscriber',
-      } as const;
+      };
 
       const userstate: UserStateTags = {
         'badges-raw': 'subscriber/1',
@@ -149,21 +149,21 @@ describe('findBadges', () => {
     });
 
     test('uses source badges when the source room is the current room', () => {
-      const sourceSubscriberBadge = {
+      const sourceSubscriberBadge: SanitisedBadgeSet = {
         id: '3',
         url: 'https://example.com/source-sub.png',
         type: 'Twitch Subscriber Badge',
         title: 'Source 3-Month Subscriber',
         set: 'subscriber',
-      } as const;
+      };
 
-      const targetSubscriberBadge = {
+      const targetSubscriberBadge: SanitisedBadgeSet = {
         id: '1',
         url: 'https://example.com/target-sub.png',
         type: 'Twitch Subscriber Badge',
         title: 'Target Subscriber',
         set: 'subscriber',
-      } as const;
+      };
 
       const userstate: UserStateTags = {
         'badges-raw': 'subscriber/1',
@@ -200,21 +200,21 @@ describe('findBadges', () => {
     });
 
     test('prefers one channel badge over global fallback for the same raw badge', () => {
-      const channelBadge = {
+      const channelBadge: SanitisedBadgeSet = {
         id: '1000',
         url: 'https://example.com/channel-bits.png',
         type: 'Twitch Bit Badge',
         title: 'Channel Cheer 1000',
         set: 'bits',
-      } as const;
+      };
 
-      const globalBadge = {
+      const globalBadge: SanitisedBadgeSet = {
         id: 'bits_1000',
         url: 'https://example.com/global-bits.png',
         type: 'Twitch Global Badge',
         title: 'Global Cheer 1000',
         set: 'bits',
-      } as const;
+      };
 
       const userstate: UserStateTags = {
         'badges-raw': 'bits/1000',
@@ -248,21 +248,21 @@ describe('findBadges', () => {
     });
 
     test('falls back to global subscriber badges when the channel tier has no url', () => {
-      const channelSubscriberBadge = {
+      const channelSubscriberBadge: SanitisedBadgeSet = {
         id: '12',
         url: '',
         type: 'Twitch Subscriber Badge',
         title: 'Broken Channel Sub',
         set: 'subscriber',
-      } as const;
+      };
 
-      const globalSubscriberBadge = {
+      const globalSubscriberBadge: SanitisedBadgeSet = {
         id: 'subscriber_12',
         url: 'https://example.com/global-sub.png',
         type: 'Twitch Global Badge',
         title: '12-Month Subscriber',
         set: 'subscriber',
-      } as const;
+      };
 
       const userstate: UserStateTags = {
         'badges-raw': 'subscriber/12',

--- a/src/utils/chat/__tests__/findBadges.test.ts
+++ b/src/utils/chat/__tests__/findBadges.test.ts
@@ -32,7 +32,6 @@ describe('findBadges', () => {
         const result = findBadges({
           twitchGlobalBadges: twitchSanitisedGlobalBadges,
           chatterinoBadges: [],
-          chatUsers: [],
           ffzChannelBadges: [],
           ffzGlobalBadges: [],
           twitchChannelBadges: [],
@@ -78,7 +77,6 @@ describe('findBadges', () => {
         const result = findBadges({
           twitchGlobalBadges: [],
           chatterinoBadges: [],
-          chatUsers: [],
           ffzChannelBadges: [],
           ffzGlobalBadges: [],
           twitchChannelBadges: twitchSanitisedChannelBadges,
@@ -141,7 +139,6 @@ describe('findBadges', () => {
       const result = findBadges({
         twitchGlobalBadges: [],
         chatterinoBadges: [],
-        chatUsers: [],
         ffzChannelBadges: [],
         ffzGlobalBadges: [],
         twitchChannelBadges: [targetSubscriberBadge, sourceSubscriberBadge],
@@ -193,7 +190,6 @@ describe('findBadges', () => {
       const result = findBadges({
         twitchGlobalBadges: [],
         chatterinoBadges: [],
-        chatUsers: [],
         ffzChannelBadges: [],
         ffzGlobalBadges: [],
         twitchChannelBadges: [targetSubscriberBadge, sourceSubscriberBadge],
@@ -242,7 +238,6 @@ describe('findBadges', () => {
       const result = findBadges({
         twitchGlobalBadges: [globalBadge],
         chatterinoBadges: [],
-        chatUsers: [],
         ffzChannelBadges: [],
         ffzGlobalBadges: [],
         twitchChannelBadges: [channelBadge],
@@ -291,7 +286,6 @@ describe('findBadges', () => {
       const result = findBadges({
         twitchGlobalBadges: [globalSubscriberBadge],
         chatterinoBadges: [],
-        chatUsers: [],
         ffzChannelBadges: [],
         ffzGlobalBadges: [],
         twitchChannelBadges: [channelSubscriberBadge],
@@ -324,7 +318,6 @@ describe('findBadges', () => {
       const result = findBadges({
         twitchGlobalBadges: [],
         chatterinoBadges: [],
-        chatUsers: [],
         ffzChannelBadges: [],
         ffzGlobalBadges: [],
         twitchChannelBadges: [],

--- a/src/utils/chat/__tests__/findBadges.test.ts
+++ b/src/utils/chat/__tests__/findBadges.test.ts
@@ -1,120 +1,80 @@
 import { twitchSanitisedChannelBadges } from '@app/services/__fixtures__/badges/twitch/twitchSanitisedChannelBadges.fixture';
 import { twitchSanitisedGlobalBadges } from '@app/services/__fixtures__/badges/twitch/twitchSanitisedGlobalBadges.fixture';
-import { UserStateTags } from '@app/types/chat/irc-tags/userstate';
+import { createUserStateTags } from '@app/types/chat/irc-tags/__fixtures__/userStateTags.fixture';
 import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
 
 import { findBadges } from '../findBadges';
 
+const emptyBadgeSources = {
+  chatterinoBadges: [] as SanitisedBadgeSet[],
+  ffzChannelBadges: [] as SanitisedBadgeSet[],
+  ffzGlobalBadges: [] as SanitisedBadgeSet[],
+};
+
 describe('findBadges', () => {
   describe('twitch', () => {
+    const sourceSubscriberBadge: SanitisedBadgeSet = {
+      id: '3',
+      url: 'https://example.com/source-sub.png',
+      type: 'Twitch Subscriber Badge',
+      title: 'Source 3-Month Subscriber',
+      set: 'subscriber',
+    };
+
+    const targetSubscriberBadge: SanitisedBadgeSet = {
+      id: '1',
+      url: 'https://example.com/target-sub.png',
+      type: 'Twitch Subscriber Badge',
+      title: 'Target Subscriber',
+      set: 'subscriber',
+    };
+
     test.each(twitchSanitisedGlobalBadges)(
       'Should find global badge %s',
       badge => {
-        const userstate: UserStateTags = {
+        const userstate = createUserStateTags({
           'badges-raw': `${badge.set}/${badge.id.split('_').pop()}`,
           badges: {
             [badge.set]: badge.id.split('_').pop(),
           },
           'user-id': '123456789',
-          username: 'testuser',
-          'display-name': 'TestUser',
-          color: '#FF0000',
-          mod: 'false',
-          subscriber: 'false',
-          turbo: 'false',
-          'user-type': '',
-          'reply-parent-display-name': '',
-          'reply-parent-msg-body': '',
-          'reply-parent-msg-id': '',
-          'reply-parent-user-login': '',
-        };
+        });
 
         const result = findBadges({
+          ...emptyBadgeSources,
           twitchGlobalBadges: twitchSanitisedGlobalBadges,
-          chatterinoBadges: [],
-          ffzChannelBadges: [],
-          ffzGlobalBadges: [],
           twitchChannelBadges: [],
           userstate,
         });
 
-        expect(result).toEqual<SanitisedBadgeSet[]>([
-          {
-            id: badge.id,
-            title: badge.title,
-            url: badge.url,
-            type: badge.type,
-            set: badge.set,
-            color: badge.color,
-            owner_username: badge.owner_username,
-          },
-        ]);
+        expect(result).toEqual<SanitisedBadgeSet[]>([badge]);
       },
     );
 
     test.each(twitchSanitisedChannelBadges)(
       'should find channel badge %s',
       badge => {
-        const userstate: UserStateTags = {
+        const userstate = createUserStateTags({
           'badges-raw': `${badge.set}/${badge.id.split('_').pop()}`,
           badges: {
             [badge.set]: badge.id.split('_').pop(),
           },
           'user-id': '123456789',
-          username: 'testuser',
-          'display-name': 'TestUser',
-          color: '#FF0000',
-          mod: 'false',
-          subscriber: 'false',
-          turbo: 'false',
-          'user-type': '',
-          'reply-parent-display-name': '',
-          'reply-parent-msg-body': '',
-          'reply-parent-msg-id': '',
-          'reply-parent-user-login': '',
-        };
+        });
 
         const result = findBadges({
+          ...emptyBadgeSources,
           twitchGlobalBadges: [],
-          chatterinoBadges: [],
-          ffzChannelBadges: [],
-          ffzGlobalBadges: [],
           twitchChannelBadges: twitchSanitisedChannelBadges,
           userstate,
         });
 
-        expect(result).toEqual<SanitisedBadgeSet[]>([
-          {
-            id: badge.id,
-            title: badge.title,
-            url: badge.url,
-            type: badge.type,
-            set: badge.set,
-            color: badge.color,
-            owner_username: badge.owner_username,
-          },
-        ]);
+        expect(result).toEqual<SanitisedBadgeSet[]>([badge]);
       },
     );
 
     test('uses source badges for shared chat messages', () => {
-      const sourceSubscriberBadge: SanitisedBadgeSet = {
-        id: '3',
-        url: 'https://example.com/source-sub.png',
-        type: 'Twitch Subscriber Badge',
-        title: 'Source 3-Month Subscriber',
-        set: 'subscriber',
-      };
-
-      const targetSubscriberBadge: SanitisedBadgeSet = {
-        id: '1',
-        url: 'https://example.com/target-sub.png',
-        type: 'Twitch Subscriber Badge',
-        title: 'Target Subscriber',
-        set: 'subscriber',
-      };
-
-      const userstate: UserStateTags = {
+      const userstate = createUserStateTags({
         'badges-raw': 'subscriber/1',
         'room-id': 'target-room',
         'source-room-id': 'source-room',
@@ -123,24 +83,11 @@ describe('findBadges', () => {
           subscriber: '1',
         },
         'user-id': '123456789',
-        username: 'testuser',
-        'display-name': 'TestUser',
-        color: '#FF0000',
-        mod: 'false',
-        subscriber: 'false',
-        turbo: 'false',
-        'user-type': '',
-        'reply-parent-display-name': '',
-        'reply-parent-msg-body': '',
-        'reply-parent-msg-id': '',
-        'reply-parent-user-login': '',
-      };
+      });
 
       const result = findBadges({
+        ...emptyBadgeSources,
         twitchGlobalBadges: [],
-        chatterinoBadges: [],
-        ffzChannelBadges: [],
-        ffzGlobalBadges: [],
         twitchChannelBadges: [targetSubscriberBadge, sourceSubscriberBadge],
         userstate,
       });
@@ -149,23 +96,7 @@ describe('findBadges', () => {
     });
 
     test('uses source badges when the source room is the current room', () => {
-      const sourceSubscriberBadge: SanitisedBadgeSet = {
-        id: '3',
-        url: 'https://example.com/source-sub.png',
-        type: 'Twitch Subscriber Badge',
-        title: 'Source 3-Month Subscriber',
-        set: 'subscriber',
-      };
-
-      const targetSubscriberBadge: SanitisedBadgeSet = {
-        id: '1',
-        url: 'https://example.com/target-sub.png',
-        type: 'Twitch Subscriber Badge',
-        title: 'Target Subscriber',
-        set: 'subscriber',
-      };
-
-      const userstate: UserStateTags = {
+      const userstate = createUserStateTags({
         'badges-raw': 'subscriber/1',
         'room-id': 'source-room',
         'source-room-id': 'source-room',
@@ -174,24 +105,11 @@ describe('findBadges', () => {
           subscriber: '1',
         },
         'user-id': '123456789',
-        username: 'testuser',
-        'display-name': 'TestUser',
-        color: '#FF0000',
-        mod: 'false',
-        subscriber: 'false',
-        turbo: 'false',
-        'user-type': '',
-        'reply-parent-display-name': '',
-        'reply-parent-msg-body': '',
-        'reply-parent-msg-id': '',
-        'reply-parent-user-login': '',
-      };
+      });
 
       const result = findBadges({
+        ...emptyBadgeSources,
         twitchGlobalBadges: [],
-        chatterinoBadges: [],
-        ffzChannelBadges: [],
-        ffzGlobalBadges: [],
         twitchChannelBadges: [targetSubscriberBadge, sourceSubscriberBadge],
         userstate,
       });
@@ -216,30 +134,17 @@ describe('findBadges', () => {
         set: 'bits',
       };
 
-      const userstate: UserStateTags = {
+      const userstate = createUserStateTags({
         'badges-raw': 'bits/1000',
         badges: {
           bits: '1000',
         },
         'user-id': '123456789',
-        username: 'testuser',
-        'display-name': 'TestUser',
-        color: '#FF0000',
-        mod: 'false',
-        subscriber: 'false',
-        turbo: 'false',
-        'user-type': '',
-        'reply-parent-display-name': '',
-        'reply-parent-msg-body': '',
-        'reply-parent-msg-id': '',
-        'reply-parent-user-login': '',
-      };
+      });
 
       const result = findBadges({
+        ...emptyBadgeSources,
         twitchGlobalBadges: [globalBadge],
-        chatterinoBadges: [],
-        ffzChannelBadges: [],
-        ffzGlobalBadges: [],
         twitchChannelBadges: [channelBadge],
         userstate,
       });
@@ -264,30 +169,17 @@ describe('findBadges', () => {
         set: 'subscriber',
       };
 
-      const userstate: UserStateTags = {
+      const userstate = createUserStateTags({
         'badges-raw': 'subscriber/12',
         badges: {
           subscriber: '12',
         },
         'user-id': '123456789',
-        username: 'testuser',
-        'display-name': 'TestUser',
-        color: '#FF0000',
-        mod: 'false',
-        subscriber: 'false',
-        turbo: 'false',
-        'user-type': '',
-        'reply-parent-display-name': '',
-        'reply-parent-msg-body': '',
-        'reply-parent-msg-id': '',
-        'reply-parent-user-login': '',
-      };
+      });
 
       const result = findBadges({
+        ...emptyBadgeSources,
         twitchGlobalBadges: [globalSubscriberBadge],
-        chatterinoBadges: [],
-        ffzChannelBadges: [],
-        ffzGlobalBadges: [],
         twitchChannelBadges: [channelSubscriberBadge],
         userstate,
       });
@@ -296,30 +188,17 @@ describe('findBadges', () => {
     });
 
     test('omits twitch badges when neither channel nor global urls resolve', () => {
-      const userstate: UserStateTags = {
+      const userstate = createUserStateTags({
         'badges-raw': 'subscriber/12',
         badges: {
           subscriber: '12',
         },
         'user-id': '123456789',
-        username: 'testuser',
-        'display-name': 'TestUser',
-        color: '#FF0000',
-        mod: 'false',
-        subscriber: 'false',
-        turbo: 'false',
-        'user-type': '',
-        'reply-parent-display-name': '',
-        'reply-parent-msg-body': '',
-        'reply-parent-msg-id': '',
-        'reply-parent-user-login': '',
-      };
+      });
 
       const result = findBadges({
+        ...emptyBadgeSources,
         twitchGlobalBadges: [],
-        chatterinoBadges: [],
-        ffzChannelBadges: [],
-        ffzGlobalBadges: [],
         twitchChannelBadges: [],
         userstate,
       });

--- a/src/utils/chat/findBadges.ts
+++ b/src/utils/chat/findBadges.ts
@@ -1,6 +1,5 @@
 import { normalizeSevenTvBadge } from '@app/components/Chat/util/normalizeSevenTvCosmetics';
 import { getUserBadge } from '@app/store/chat/actions/cosmetics';
-import type { ChatUser } from '@app/store/chat/types/constants';
 import { UserStateTags } from '@app/types/chat/irc-tags/userstate';
 import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
 
@@ -10,7 +9,6 @@ interface FindBadgesParams {
   twitchGlobalBadges: SanitisedBadgeSet[];
   ffzGlobalBadges: SanitisedBadgeSet[];
   ffzChannelBadges: SanitisedBadgeSet[];
-  chatUsers: ChatUser[];
   chatterinoBadges: SanitisedBadgeSet[];
 }
 
@@ -172,7 +170,6 @@ export function findBadges({
   twitchChannelBadges,
   twitchGlobalBadges,
   ffzGlobalBadges,
-  chatUsers,
   chatterinoBadges,
 }: FindBadgesParams): SanitisedBadgeSet[] {
   const badges: SanitisedBadgeSet[] = [];
@@ -224,18 +221,6 @@ export function findBadges({
       owner_username: b.owner_username,
     });
   });
-
-  const stvUser = chatUsers.find(u => u.name === `@${userstate.username}`);
-
-  if (stvUser && stvUser.cosmetics?.badge_id) {
-    const stvBadge = stvUser.cosmetics.badges.find(
-      b => b.id === stvUser.cosmetics?.badge_id,
-    );
-
-    if (stvBadge) {
-      addBadgeIfMissing(badges, stvBadge);
-    }
-  }
 
   if (userstate['user-id']) {
     const storeBadge = getUserBadge(userstate['user-id']);

--- a/src/utils/chat/findBadges.ts
+++ b/src/utils/chat/findBadges.ts
@@ -41,19 +41,24 @@ const addBadge = (
   badge: SanitisedBadgeSet,
   fallbackType: SanitisedBadgeSet['type'],
 ): void => {
-  if (hasBadge(badges, badge)) {
+  const normalizedBadge = normalizeSevenTvBadge(badge);
+  if (!normalizedBadge.url?.trim()) {
+    return;
+  }
+
+  if (hasBadge(badges, normalizedBadge)) {
     return;
   }
 
   badges.push({
-    title: badge.title,
-    url: badge.url,
-    type: badge.type || fallbackType,
-    set: badge.set || '',
-    id: badge.id,
-    color: badge.color,
-    owner_username: badge.owner_username,
-    ...(badge.provider ? { provider: badge.provider } : {}),
+    title: normalizedBadge.title,
+    url: normalizedBadge.url,
+    type: normalizedBadge.type || fallbackType,
+    set: normalizedBadge.set || '',
+    id: normalizedBadge.id,
+    color: normalizedBadge.color,
+    owner_username: normalizedBadge.owner_username,
+    ...(normalizedBadge.provider ? { provider: normalizedBadge.provider } : {}),
   });
 };
 
@@ -187,7 +192,7 @@ export function findBadges({
         version,
       );
 
-      if (channelBadge) {
+      if (channelBadge?.url?.trim()) {
         addBadge(badges, channelBadge, 'Twitch Channel Badge');
         return;
       }
@@ -198,7 +203,7 @@ export function findBadges({
         version,
       );
 
-      if (globalBadge) {
+      if (globalBadge?.url?.trim()) {
         addBadge(badges, globalBadge, 'Twitch Global Badge');
       }
     });

--- a/src/utils/seventv/__tests__/seventvWsInterpreter.test.ts
+++ b/src/utils/seventv/__tests__/seventvWsInterpreter.test.ts
@@ -722,6 +722,28 @@ describe('interpretSeventvWsMessage', () => {
     });
   });
 
+  describe('entitlement.reset', () => {
+    test('returns applyEntitlementReset with the 7TV user id', () => {
+      const event: SevenTvEventData<'entitlement.reset'> = {
+        type: 'entitlement.reset',
+        body: { id: 'stv-user-1' },
+      };
+
+      const decisions = interpretSeventvWsMessage(
+        createDispatchMessage(event),
+        createContext(),
+      );
+
+      expect(decisions).toEqual<SeventvWsDecision[]>([
+        {
+          type: 'applyEntitlementReset',
+          sevenTvUserId: 'stv-user-1',
+        },
+        { type: 'notifyEvent', eventType: 'entitlement.reset', data: event },
+      ]);
+    });
+  });
+
   describe('dispatch validation', () => {
     test('ignores a dispatch with a null payload and does not notify', () => {
       const decisions = interpretSeventvWsMessage(

--- a/src/utils/seventv/seventvWsInterpreter.ts
+++ b/src/utils/seventv/seventvWsInterpreter.ts
@@ -35,7 +35,8 @@ export type HandledSevenTvEventType =
   | 'cosmetic.delete'
   | 'entitlement.create'
   | 'entitlement.update'
-  | 'entitlement.delete';
+  | 'entitlement.delete'
+  | 'entitlement.reset';
 
 export type SeventvWsDecision =
   | {
@@ -81,6 +82,7 @@ export type SeventvWsDecision =
       badgeId: string | null;
     }
   | { type: 'applyEntitlementDelete'; entitlementId: string; ttvUserId: null }
+  | { type: 'applyEntitlementReset'; sevenTvUserId: string }
   | {
       type: 'applyEmoteSetSwitch';
       oldSetId: string | null;
@@ -443,6 +445,23 @@ function interpretEntitlementDelete(
   }
 }
 
+function interpretEntitlementReset(
+  data: SevenTvEventData<'entitlement.reset'>,
+): SeventvWsDecision {
+  try {
+    return {
+      type: 'applyEntitlementReset',
+      sevenTvUserId: data.body.id,
+    };
+  } catch (error) {
+    return {
+      type: 'eventInterpretationFailed',
+      eventType: 'entitlement.reset',
+      error,
+    };
+  }
+}
+
 /**
  * A `user.update` for the channel owner carries the active emote set switch
  * as a nested change: `updated[key=connections].value[key=emote_set]` with
@@ -533,6 +552,11 @@ function interpretDispatchEvent(
     case 'entitlement.delete':
       return interpretEntitlementDelete(
         data as SevenTvEventData<'entitlement.delete'>,
+      );
+
+    case 'entitlement.reset':
+      return interpretEntitlementReset(
+        data as SevenTvEventData<'entitlement.reset'>,
       );
 
     case 'user.update':


### PR DESCRIPTION
## Summary

Fixes 7TV badge/cosmetics loading edge cases and adds a scroll indicator to the emote picker.

Does not include painted username rendering — that is on `@luke-h1/feat/native-painted-username-module`.

- **Cache clear** — bumps `cosmeticsCacheVersion`, clears global resource cache, and refetches cosmetics via `useChatEmoteLoader`
- **Badge shimmer** — `getUserBadge` only returns badges with a non-empty CDN URL; `findBadges` no longer injects badges from the legacy `chatUsers` path
- **Live updates** — `cosmeticBindingsVersion` on `chatStore$` is included in `Chat.tsx`'s `reprocessKey` so visible messages pick up binding/URL changes without a channel reload
- **GQL cosmetics cache** — `syncCachedUserCosmeticsFromStore` keeps per-user cache aligned after WS entitlement create/update/delete/reset; 2h positive TTL, 30m negative TTL
- **`entitlement.reset`** — clears paint/badge bindings for all Twitch accounts linked to the affected 7TV user
- **Provider failures** — separate system messages for cached vs uncached provider failures; catch-all when the full channel resource load throws
- **Emote sheet** — `indicatorStyle="white"` on the emote grid `LegendList`
- **Entitlement delete** — only clears the binding for the deleted entitlement kind (paint vs badge)

## Test plan

```bash
bun run test -- --testPathPattern="useChatCosmetics|useChatEmoteLoader|useChatSevenTvCallbacks|cosmetics|cosmeticsBridge|channelLoad|channelResources|findBadges|sevenTvBridge|seventvWsInterpreter"
```

- [x] Clear app cache → reopen channel → emotes/badges reload (or failure message if nothing cached)
- [ ] Users without 7TV badge entitlement show no badge shimmer
- [x] WS badge/entitlement change updates existing messages without channel reload
- [x] Emote picker shows scroll indicator on long lists