### PR TITLE
chore(app): simplify hot paths and remote-config Twitch embed parent

### DIFF
--- a/src/components/Chat/components/ChatComposer/components/UserSuggestions.ios.tsx
+++ b/src/components/Chat/components/ChatComposer/components/UserSuggestions.ios.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import {
@@ -66,6 +66,11 @@ export const UserSuggestions = memo(function UserSuggestions({
   showUserSuggestions,
   handleUserSelect,
 }: UserSuggestionsProps) {
+  const extraData = useMemo(
+    () => ({ onPress: handleUserSelect }),
+    [handleUserSelect],
+  );
+
   if (!showUserSuggestions || users.length === 0) {
     return null;
   }
@@ -79,7 +84,7 @@ export const UserSuggestions = memo(function UserSuggestions({
           estimatedItemSize={USER_SUGGESTION_ITEM_SIZE}
           keyExtractor={user => user.userId}
           keyboardShouldPersistTaps='handled'
-          extraData={{ onPress: handleUserSelect }}
+          extraData={extraData}
           renderItem={renderUserSuggestionItem}
           showsHorizontalScrollIndicator={false}
           contentContainerStyle={styles.userSuggestionScroll}

--- a/src/components/Chat/components/ChatComposer/components/UserSuggestions.tsx
+++ b/src/components/Chat/components/ChatComposer/components/UserSuggestions.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
@@ -68,6 +68,11 @@ export const UserSuggestions = memo(function UserSuggestions({
   handleUserSelect,
 }: UserSuggestionsProps) {
   const { t } = useTranslation('chat');
+  const extraData = useMemo(
+    () => ({ onPress: handleUserSelect }),
+    [handleUserSelect],
+  );
+
   if (!showUserSuggestions || users.length === 0) {
     return null;
   }
@@ -82,7 +87,7 @@ export const UserSuggestions = memo(function UserSuggestions({
           estimatedItemSize={USER_SUGGESTION_ITEM_SIZE}
           keyExtractor={user => user.userId}
           keyboardShouldPersistTaps='handled'
-          extraData={{ onPress: handleUserSelect }}
+          extraData={extraData}
           renderItem={renderUserSuggestionItem}
           showsHorizontalScrollIndicator={false}
           contentContainerStyle={styles.userSuggestionScroll}

--- a/src/components/Chat/components/ChatInputSection.ios.tsx
+++ b/src/components/Chat/components/ChatInputSection.ios.tsx
@@ -5,10 +5,10 @@ import { GestureDetector } from 'react-native-gesture-handler';
 import Animated, { FadeInUp, FadeOutDown } from 'react-native-reanimated';
 
 import { BlurView } from 'expo-blur';
-import { SymbolView } from 'expo-symbols';
 
 import { Button as PressableButton } from '@app/components/Button/Button';
 import { PaintedUsername } from '@app/components/Chat/components/ChatMessage/CosmeticUsername/CosmeticUsername';
+import { SymbolView } from '@app/components/ui/Icon/Icon';
 import { Text } from '@app/components/ui/Text/Text';
 import { theme } from '@app/styles/themes';
 import { lightenColor } from '@app/utils/color/lightenColor';

--- a/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
@@ -20,6 +20,7 @@ import {
 import { Image as ExpoImage, type ImageErrorEventData } from 'expo-image';
 
 import { chatScrollActivity } from '@app/components/Chat/util/chatScrollActivity';
+import { resolveUseAppleWebpCodec } from '@app/lib/expo-image/resolveUseAppleWebpCodec';
 import { runAnimationCommand } from '@app/lib/expo-image/runAnimationCommand';
 import {
   evictCachedEmoteRef,
@@ -272,8 +273,6 @@ function ChatInlineImageComponent({
   // Show the shimmer only while there's nothing real to display yet: a decoded
   // sharedRef is instant, so cached emotes (the busy-chat common case) never
   // shimmer and stay on the bare-image fast path with no extra Fabric node.
-  // Callers can suppress the overlay entirely (badges) to avoid a pulsing box
-  // on a tiny slot that a failed load would otherwise leave up indefinitely.
   const overlayVisible =
     showLoadingShimmer && sharedRef == null && status !== 'loaded';
 
@@ -297,13 +296,7 @@ function ChatInlineImageComponent({
       // failed ref), so keep it out of expo-image's in-memory cache to avoid a
       // second session-long decoded-bitmap pool on top of the ImageRef cache.
       cachePolicy={showRef ? 'memory-disk' : 'disk'}
-      // expo-image's Apple WebP codec is faster and lighter but plays animated
-      // WebP at the wrong framerate (see docs on `useAppleWebpCodec`). Chat
-      // emotes are dominated by animated 7TV WebPs, so force the standards-
-      // compliant libwebp path for known-animated urls to restore full FPS —
-      // and leave the fast Apple codec on for badges / static emotes where the
-      // framerate bug can't apply.
-      useAppleWebpCodec={urlKind === 'animated' ? false : undefined}
+      useAppleWebpCodec={resolveUseAppleWebpCodec(urlKind)}
       priority={priority}
       transition={transitionMs}
       onLoad={handleLoad}

--- a/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
@@ -55,8 +55,25 @@ const LOAD_WATCHDOG_MS = 12000;
 
 interface ChatInlineImageProps {
   containerStyle?: StyleProp<ViewStyle>;
+  /**
+   * Max backoff-retry attempts after the whole fallback chain is exhausted.
+   * Defaults to {@link MAX_RELOAD_ATTEMPTS} for emote URLs whose CDN variants
+   * routinely have transient flakiness worth riding out. Callers rendering
+   * assets with stable, single-URL sources (e.g. badges) can pass `0` to fail
+   * immediately and stop the ~36s of on-screen "loading" state that a dead URL
+   * would otherwise produce.
+   */
+  maxRetryAttempts?: number;
   priority?: 'low' | 'normal' | 'high';
   resizeMode?: 'contain' | 'cover' | 'stretch';
+  /**
+   * When `false`, no shimmer is rendered while the image is loading — the slot
+   * just stays empty until the image resolves or is given up on. Use for tiny
+   * assets (badges) where a pulsing box is more distracting than helpful.
+   *
+   * @default true
+   */
+  showLoadingShimmer?: boolean;
   sourceUrl: string;
   style: StyleProp<ImageStyle>;
   testID?: string;
@@ -65,8 +82,10 @@ interface ChatInlineImageProps {
 
 function ChatInlineImageComponent({
   containerStyle,
+  maxRetryAttempts = MAX_RELOAD_ATTEMPTS,
   priority = 'high',
   resizeMode = 'contain',
+  showLoadingShimmer = true,
   sourceUrl,
   style,
   testID,
@@ -157,7 +176,7 @@ function ChatInlineImageComponent({
 
       // Every format/size has 404'd. Patiently backoff-retry the smallest
       // candidate — the one most likely to exist — to ride out a transient blip.
-      if (retryCountRef.current >= MAX_RELOAD_ATTEMPTS) {
+      if (retryCountRef.current >= maxRetryAttempts) {
         const descriptor = describeEmoteUrl(candidateUrl);
         const cache = getCachedEmoteStats();
         logger.chat.warn('chat.emote.load_failed', {
@@ -200,7 +219,14 @@ function ChatInlineImageComponent({
         setReloadNonce(nonce => nonce + 1);
       }, delay);
     },
-    [candidateIndex, candidateUrl, fallbackChain, showRef, sourceUrl],
+    [
+      candidateIndex,
+      candidateUrl,
+      fallbackChain,
+      maxRetryAttempts,
+      showRef,
+      sourceUrl,
+    ],
   );
 
   const onWatchdogTimeout = useEffectEvent(() => handleError());
@@ -246,7 +272,10 @@ function ChatInlineImageComponent({
   // Show the shimmer only while there's nothing real to display yet: a decoded
   // sharedRef is instant, so cached emotes (the busy-chat common case) never
   // shimmer and stay on the bare-image fast path with no extra Fabric node.
-  const overlayVisible = sharedRef == null && status !== 'loaded';
+  // Callers can suppress the overlay entirely (badges) to avoid a pulsing box
+  // on a tiny slot that a failed load would otherwise leave up indefinitely.
+  const overlayVisible =
+    showLoadingShimmer && sharedRef == null && status !== 'loaded';
 
   // Render the decoded sharedRef whenever it's available and hasn't failed to
   // display; otherwise render the current fallback variant's uri.
@@ -268,6 +297,13 @@ function ChatInlineImageComponent({
       // failed ref), so keep it out of expo-image's in-memory cache to avoid a
       // second session-long decoded-bitmap pool on top of the ImageRef cache.
       cachePolicy={showRef ? 'memory-disk' : 'disk'}
+      // expo-image's Apple WebP codec is faster and lighter but plays animated
+      // WebP at the wrong framerate (see docs on `useAppleWebpCodec`). Chat
+      // emotes are dominated by animated 7TV WebPs, so force the standards-
+      // compliant libwebp path for known-animated urls to restore full FPS —
+      // and leave the fast Apple codec on for badges / static emotes where the
+      // framerate bug can't apply.
+      useAppleWebpCodec={urlKind === 'animated' ? false : undefined}
       priority={priority}
       transition={transitionMs}
       onLoad={handleLoad}

--- a/src/components/Chat/components/ChatMessage/renderers/ChatMessageBadges.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatMessageBadges.tsx
@@ -65,6 +65,13 @@ export function ChatMessageBadges({
             compact && styles.badgeCompact,
             Boolean(moderationNotice) && styles.moderatedBadge,
           ]}
+          // Badge urls are stable per-provider (Twitch/FFZ/7TV) and don't have
+          // the transient variant-availability flakiness that emote CDNs do —
+          // a badge that 404s once will 404 forever, so skip the ~36s backoff
+          // retry cycle and drop the shimmer overlay. A dead badge just stays
+          // an empty slot next to the username instead of a pulsing box.
+          maxRetryAttempts={0}
+          showLoadingShimmer={false}
         />
       </ChatMessagePressable>,
     );

--- a/src/components/Chat/components/ChatMessage/renderers/ChatMessageBadges.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatMessageBadges.tsx
@@ -65,11 +65,6 @@ export function ChatMessageBadges({
             compact && styles.badgeCompact,
             Boolean(moderationNotice) && styles.moderatedBadge,
           ]}
-          // Badge urls are stable per-provider (Twitch/FFZ/7TV) and don't have
-          // the transient variant-availability flakiness that emote CDNs do —
-          // a badge that 404s once will 404 forever, so skip the ~36s backoff
-          // retry cycle and drop the shimmer overlay. A dead badge just stays
-          // an empty slot next to the username instead of a pulsing box.
           maxRetryAttempts={0}
           showLoadingShimmer={false}
         />

--- a/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
@@ -316,6 +316,50 @@ describe('ChatInlineImage loading shimmer', () => {
 
     expect(screen.queryByTestId('chat-image-shimmer')).not.toBeOnTheScreen();
   });
+
+  test('showLoadingShimmer=false suppresses the overlay on an uncached load', () => {
+    mockSharedRef = null;
+    render(
+      <ChatInlineImage
+        sourceUrl='https://static-cdn.jtvnw.net/badges/v1/foo/1'
+        style={{}}
+        showLoadingShimmer={false}
+      />,
+    );
+
+    expect(screen.queryByTestId('chat-image-shimmer')).not.toBeOnTheScreen();
+  });
+});
+
+describe('ChatInlineImage maxRetryAttempts', () => {
+  beforeEach(() => {
+    mockSharedRef = null;
+    mockImageProps = null;
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  test('maxRetryAttempts=0 fails immediately on a single-url source without any backoff retry', () => {
+    const sourceUrl = 'https://static-cdn.jtvnw.net/badges/v1/foo/1';
+    render(
+      <ChatInlineImage sourceUrl={sourceUrl} style={{}} maxRetryAttempts={0} />,
+    );
+
+    expect(mockImageProps?.recyclingKey).toEqual(`${sourceUrl}#0`);
+
+    act(() => mockImageProps?.onError?.());
+
+    // No timer was scheduled — advancing time doesn't bump the reload nonce.
+    act(() => jest.advanceTimersByTime(60_000));
+    expect(mockImageProps?.recyclingKey).toEqual(`${sourceUrl}#0`);
+
+    // The warning fires immediately because retries are disabled.
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0]?.[0]).toEqual('chat.emote.load_failed');
+  });
 });
 
 describe('ChatInlineImage load watchdog', () => {

--- a/src/components/Chat/components/EmoteSheet/EmoteCell.tsx
+++ b/src/components/Chat/components/EmoteSheet/EmoteCell.tsx
@@ -4,6 +4,7 @@ import { View } from 'react-native';
 import { Image as ExpoImage } from 'expo-image';
 
 import { Text } from '@app/components/ui/Text/Text';
+import { resolveUseAppleWebpCodec } from '@app/lib/expo-image/resolveUseAppleWebpCodec';
 import { runAnimationCommand } from '@app/lib/expo-image/runAnimationCommand';
 import { describeEmoteUrl } from '@app/utils/emote/describeEmoteUrl';
 
@@ -73,12 +74,9 @@ function EmoteCellComponent({
         contentFit='contain'
         cachePolicy='memory-disk'
         decodeFormat='rgb'
-        // Apple's WebP codec plays animated WebPs at the wrong framerate
-        // (see expo-image `useAppleWebpCodec` docs). Force the standards-
-        // compliant libwebp path for animated urls so the picker preview
-        // matches how the emote will actually play in chat, and keep the
-        // faster/lighter Apple codec for static ones.
-        useAppleWebpCodec={urlKind === 'animated' ? false : true}
+        useAppleWebpCodec={resolveUseAppleWebpCodec(urlKind, {
+          preferAppleCodecForStatic: true,
+        })}
         autoplay={!emoteSheetScrollActivity.isActive()}
         priority='low'
         transition={0}

--- a/src/components/Chat/components/EmoteSheet/EmoteCell.tsx
+++ b/src/components/Chat/components/EmoteSheet/EmoteCell.tsx
@@ -1,10 +1,11 @@
-import { memo, useEffect, useRef } from 'react';
+import { memo, useEffect, useMemo, useRef } from 'react';
 import { View } from 'react-native';
 
 import { Image as ExpoImage } from 'expo-image';
 
 import { Text } from '@app/components/ui/Text/Text';
 import { runAnimationCommand } from '@app/lib/expo-image/runAnimationCommand';
+import { describeEmoteUrl } from '@app/utils/emote/describeEmoteUrl';
 
 import { emoteSheetStyles as styles } from './emoteSheetStyles';
 import type { EmotePickerItem } from './emoteSheetTypes';
@@ -21,6 +22,12 @@ function EmoteCellComponent({
   const innerSize = Math.round(cellSize * 0.78);
   const dimensions = { height: innerSize, width: innerSize };
   const imageRef = useRef<ExpoImage>(null);
+  const displayUrl =
+    typeof item === 'string' ? null : getEmotePickerDisplayUrl(item);
+  const urlKind = useMemo(
+    () => (displayUrl ? describeEmoteUrl(displayUrl).kind : null),
+    [displayUrl],
+  );
 
   useEffect(() => {
     if (typeof item === 'string') {
@@ -61,12 +68,17 @@ function EmoteCellComponent({
     >
       <ExpoImage
         ref={imageRef}
-        source={getEmotePickerDisplayUrl(item)}
+        source={displayUrl}
         style={dimensions}
         contentFit='contain'
         cachePolicy='memory-disk'
         decodeFormat='rgb'
-        useAppleWebpCodec
+        // Apple's WebP codec plays animated WebPs at the wrong framerate
+        // (see expo-image `useAppleWebpCodec` docs). Force the standards-
+        // compliant libwebp path for animated urls so the picker preview
+        // matches how the emote will actually play in chat, and keep the
+        // faster/lighter Apple codec for static ones.
+        useAppleWebpCodec={urlKind === 'animated' ? false : true}
         autoplay={!emoteSheetScrollActivity.isActive()}
         priority='low'
         transition={0}

--- a/src/components/Chat/components/EmoteSheet/EmoteSheet.tsx
+++ b/src/components/Chat/components/EmoteSheet/EmoteSheet.tsx
@@ -16,7 +16,7 @@ import { ProviderChip } from './ProviderChip';
 import { emoteSheetScrollActivity } from './util/emoteSheetScrollActivity';
 
 export type { EmotePickerItem };
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { LayoutChangeEvent } from 'react-native';
 
@@ -54,6 +54,14 @@ export function EmoteSheet({
       setLayoutWidth(current => (current === nextWidth ? current : nextWidth));
     }
   };
+
+  const setRailExtraData = useMemo(
+    () => ({
+      activeSetId: sheet.activeSetId,
+      onScrollToSet: sheet.handleScrollToSet,
+    }),
+    [sheet.activeSetId, sheet.handleScrollToSet],
+  );
 
   return (
     <BottomSheet
@@ -165,10 +173,7 @@ export function EmoteSheet({
                   keyExtractor={set => set.id}
                   nestedScrollEnabled
                   renderItem={renderSetRailItem}
-                  extraData={{
-                    activeSetId: sheet.activeSetId,
-                    onScrollToSet: sheet.handleScrollToSet,
-                  }}
+                  extraData={setRailExtraData}
                   showsHorizontalScrollIndicator={false}
                   contentContainerStyle={styles.categoryBarContent}
                 />

--- a/src/components/FormattedDate/FormattedDate.tsx
+++ b/src/components/FormattedDate/FormattedDate.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import { format as formatter } from 'date-fns/format';
 import { formatRelative } from 'date-fns/formatRelative';
 import { isValid } from 'date-fns/isValid';
@@ -23,7 +21,7 @@ export const FormattedDate = ({
   testId,
   parseFormat,
 }: Props) => {
-  const now = useMemo(() => new Date(), []);
+  const now = new Date();
 
   let parsedDate: Date;
 

--- a/src/components/LiveStreamCard/LiveStreamCard.tsx
+++ b/src/components/LiveStreamCard/LiveStreamCard.tsx
@@ -40,6 +40,10 @@ const LANGUAGE_NAMES: Record<string, string> = {
   pt: 'Portuguese',
 };
 
+const LANGUAGE_VALUE_SET = new Set(
+  Object.values(LANGUAGE_NAMES).map(language => language.toLowerCase()),
+);
+
 // Dedupe rapid double-taps that would push the same route twice (two stacked screens).
 const NAV_DEDUPE_MS = 1000;
 let lastNavPath = '';
@@ -125,11 +129,8 @@ function LiveStreamCard({ stream, layout = 'compact' }: Props) {
     // Only the media layout renders the language, so keep the tag scan out of
     // the (default) compact path.
     const languageLabel =
-      stream.tags?.find(tag =>
-        Object.values(LANGUAGE_NAMES).some(
-          language => language.toLowerCase() === tag.toLowerCase(),
-        ),
-      ) ?? LANGUAGE_NAMES[stream.language];
+      stream.tags?.find(tag => LANGUAGE_VALUE_SET.has(tag.toLowerCase())) ??
+      LANGUAGE_NAMES[stream.language];
 
     return (
       <Button

--- a/src/components/OfflineBanner/OfflineBanner.tsx
+++ b/src/components/OfflineBanner/OfflineBanner.tsx
@@ -24,16 +24,18 @@ export function OfflineBanner() {
 
   useEffect(() => {
     return onlineManager.subscribe(isOnline => {
-      progress.value = withTiming(isOnline ? 0 : 1, {
-        duration: ANIM_DURATION,
-      });
+      progress.set(
+        withTiming(isOnline ? 0 : 1, {
+          duration: ANIM_DURATION,
+        }),
+      );
     });
   }, [progress]);
 
   const totalHeight = insets.top + BANNER_HEIGHT;
 
   const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateY: (progress.value - 1) * totalHeight }],
+    transform: [{ translateY: (progress.get() - 1) * totalHeight }],
   }));
 
   return (

--- a/src/components/RootLayout/RouterEffects.tsx
+++ b/src/components/RootLayout/RouterEffects.tsx
@@ -11,7 +11,7 @@ import { useClearExpiredStorageItems } from '@app/hooks/useClearExpiredStorageIt
 import { useIcloudPreferenceSync } from '@app/hooks/useIcloudPreferenceSync';
 import { useLazyRef } from '@app/hooks/useLazyRef';
 import { useOnAppStateChange } from '@app/hooks/useOnAppStateChange';
-import { useOnReconnect } from '@app/hooks/useOnReconnect';
+import '@app/hooks/useOnReconnect';
 import { usePopulateAuth } from '@app/hooks/usePopulateAuth';
 import { useRecoveredFromError } from '@app/hooks/useRecoveredFromError';
 import { useSyncRef } from '@app/hooks/useSyncRef';
@@ -79,7 +79,6 @@ export function RouterEffects() {
       focusManager.setFocused(current === 'active');
     }
   });
-  useOnReconnect();
   useClearExpiredStorageItems();
   useIcloudPreferenceSync();
   usePopulateAuth();

--- a/src/components/RootLayout/__tests__/RouterEffects.test.tsx
+++ b/src/components/RootLayout/__tests__/RouterEffects.test.tsx
@@ -39,9 +39,7 @@ jest.mock('@app/hooks/useIcloudPreferenceSync', () => ({
 jest.mock('@app/hooks/useOnAppStateChange', () => ({
   useOnAppStateChange: jest.fn(),
 }));
-jest.mock('@app/hooks/useOnReconnect', () => ({
-  useOnReconnect: jest.fn(),
-}));
+jest.mock('@app/hooks/useOnReconnect', () => ({}));
 jest.mock('@app/hooks/usePopulateAuth', () => ({
   usePopulateAuth: jest.fn(),
 }));

--- a/src/components/StreamPlayer/ControlsOverlay.tsx
+++ b/src/components/StreamPlayer/ControlsOverlay.tsx
@@ -43,14 +43,9 @@ interface OverlayMetricsState {
 
 import { useTranslation } from 'react-i18next';
 
-import { formatDuration } from './formatStreamDuration';
+import { formatViewCount } from '@app/utils/string/formatViewCount';
 
-function formatViewerCount(count?: number): string {
-  if (!count) {
-    return '0';
-  }
-  return count.toLocaleString();
-}
+import { formatDuration } from './formatStreamDuration';
 
 export function ControlsOverlay({
   isVisible,
@@ -218,7 +213,7 @@ export function ControlsOverlay({
                 tintColor={theme.colorWhite}
               />
               <Text style={styles.viewerCountText}>
-                {formatViewerCount(streamInfo?.viewerCount)}
+                {formatViewCount(streamInfo?.viewerCount)}
               </Text>
             </View>
           </View>

--- a/src/components/StreamPlayer/useStreamPlayerControls.ts
+++ b/src/components/StreamPlayer/useStreamPlayerControls.ts
@@ -48,23 +48,23 @@ export function useStreamPlayerControls({
     clearAutoHide();
     controlsTimeoutRef.current = setTimeout(() => {
       controlsTimeoutRef.current = null;
-      controlsTarget.value = 0;
-      controlsOpacity.value = withTiming(0, CONTROLS_FADE);
+      controlsTarget.set(0);
+      controlsOpacity.set(withTiming(0, CONTROLS_FADE));
       setControlsVisible(false);
     }, CONTROLS_AUTO_HIDE_MS);
   }, [clearAutoHide, controlsOpacity, controlsTarget]);
 
   const forceHideControls = useCallback(() => {
     clearAutoHide();
-    controlsTarget.value = 0;
-    controlsOpacity.value = withTiming(0, CONTROLS_FADE);
+    controlsTarget.set(0);
+    controlsOpacity.set(withTiming(0, CONTROLS_FADE));
     setControlsVisible(false);
   }, [clearAutoHide, controlsOpacity, controlsTarget]);
 
   // Reveal the controls from JS and reset the auto-hide timer.
   const revealControls = useCallback(() => {
-    controlsTarget.value = 1;
-    controlsOpacity.value = withTiming(1, CONTROLS_FADE);
+    controlsTarget.set(1);
+    controlsOpacity.set(withTiming(1, CONTROLS_FADE));
     setControlsVisible(true);
     armAutoHide();
   }, [armAutoHide, controlsOpacity, controlsTarget]);
@@ -117,9 +117,9 @@ export function useStreamPlayerControls({
 
         const tapTime = Date.now();
         // Toggle visually on the UI thread, then hand bookkeeping to JS.
-        const nextShown = controlsTarget.value > 0.5 ? 0 : 1;
-        controlsTarget.value = nextShown;
-        controlsOpacity.value = withTiming(nextShown, CONTROLS_FADE);
+        const nextShown = controlsTarget.get() > 0.5 ? 0 : 1;
+        controlsTarget.set(nextShown);
+        controlsOpacity.set(withTiming(nextShown, CONTROLS_FADE));
         scheduleOnRN(handleTapSettled, nextShown === 1, tapTime);
       });
 

--- a/src/hooks/firebase/remoteConfigModel.ts
+++ b/src/hooks/firebase/remoteConfigModel.ts
@@ -46,6 +46,11 @@ export interface RemoteConfigSchema {
    * sets this per user; the client reads it via `useExperiment`.
    */
   experiments: Record<string, string>;
+
+  /**
+   * `parent` query parameter for Twitch embed URLs.
+   */
+  twitchPlayerEmbedParent: string;
 }
 
 export type RemoteConfigKey = keyof RemoteConfigSchema;
@@ -79,6 +84,7 @@ export const defaultRemoteConfig = {
   experiments: '{}',
   bundleButtonEnabled:
     '{ "ios": { "development": false, "internal": true, "testflight": false, "production": false, "e2e": false }}',
+  twitchPlayerEmbedParent: 'www.twitch.tv',
 } satisfies Record<RemoteConfigKey, string>;
 
 const jsonKeys: RemoteConfigKey[] = [

--- a/src/hooks/firebase/useRemoteConfig.ts
+++ b/src/hooks/firebase/useRemoteConfig.ts
@@ -107,21 +107,16 @@ async function fetchRemoteConfig(): Promise<boolean> {
 function readRemoteConfig(): RemoteConfigType {
   const allConfig = getAll(remoteConfig);
   return Object.fromEntries(
-    Object.entries(allConfig).flatMap(([key, entry]) => {
-      if (!(key in defaultRemoteConfig)) {
-        return [];
-      }
-
-      const raw = entry.asString();
+    (Object.keys(defaultRemoteConfig) as RemoteConfigKey[]).map(key => {
+      const entry = allConfig[key];
+      const raw = entry?.asString() ?? defaultRemoteConfig[key];
       return [
-        [
-          key,
-          {
-            raw,
-            value: parseRemoteConfigValue(key as RemoteConfigKey, raw),
-            source: entry.getSource(),
-          } satisfies RemoteConfigEntry<RemoteConfigSchema[RemoteConfigKey]>,
-        ],
+        key,
+        {
+          raw,
+          value: parseRemoteConfigValue(key, raw),
+          source: entry?.getSource() ?? 'default',
+        } satisfies RemoteConfigEntry<RemoteConfigSchema[RemoteConfigKey]>,
       ];
     }),
   ) as RemoteConfigType;

--- a/src/hooks/useOnReconnect.ts
+++ b/src/hooks/useOnReconnect.ts
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import { onlineManager } from '@tanstack/react-query';
 import * as Network from 'expo-network';
 
@@ -7,16 +5,16 @@ import * as Network from 'expo-network';
  * Registers react-query's online status listener with expo-network so queries
  * auto-refetch when connectivity returns.
  *
+ * `onlineManager.setEventListener` returns void and stores the setup cleanup
+ * internally, so this runs once at module load (same pattern as
+ * `focusManager.setEventListener` in query-provider).
+ *
  * @see https://tanstack.com/query/latest/docs/framework/react/react-native#online-status-management
  */
-export function useOnReconnect() {
-  useEffect(() => {
-    return onlineManager.setEventListener(setOnline => {
-      const eventSubscription = Network.addNetworkStateListener(state => {
-        setOnline(!!state.isConnected);
-      });
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      return eventSubscription.remove;
-    });
-  }, []);
-}
+onlineManager.setEventListener(setOnline => {
+  const eventSubscription = Network.addNetworkStateListener(state => {
+    setOnline(!!state.isConnected);
+  });
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  return eventSubscription.remove;
+});

--- a/src/hooks/useOnReconnect.ts
+++ b/src/hooks/useOnReconnect.ts
@@ -3,11 +3,13 @@ import { useEffect } from 'react';
 import { onlineManager } from '@tanstack/react-query';
 import * as Network from 'expo-network';
 
+/**
+ * Registers react-query's online status listener with expo-network so queries
+ * auto-refetch when connectivity returns.
+ *
+ * @see https://tanstack.com/query/latest/docs/framework/react/react-native#online-status-management
+ */
 export function useOnReconnect() {
-  /**
-   * support auto refetch on network reconnect for react-query
-   * @see https://tanstack.com/query/latest/docs/framework/react/react-native#online-status-management
-   */
   useEffect(() => {
     return onlineManager.setEventListener(setOnline => {
       const eventSubscription = Network.addNetworkStateListener(state => {

--- a/src/hooks/useOnReconnect.ts
+++ b/src/hooks/useOnReconnect.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { onlineManager } from '@tanstack/react-query';
 import * as Network from 'expo-network';
 
@@ -6,11 +8,13 @@ export function useOnReconnect() {
    * support auto refetch on network reconnect for react-query
    * @see https://tanstack.com/query/latest/docs/framework/react/react-native#online-status-management
    */
-  onlineManager.setEventListener(setOnline => {
-    const eventSubscription = Network.addNetworkStateListener(state => {
-      setOnline(!!state.isConnected);
+  useEffect(() => {
+    return onlineManager.setEventListener(setOnline => {
+      const eventSubscription = Network.addNetworkStateListener(state => {
+        setOnline(!!state.isConnected);
+      });
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      return eventSubscription.remove;
     });
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    return eventSubscription.remove;
-  });
+  }, []);
 }

--- a/src/lib/expo-image/resolveUseAppleWebpCodec.ts
+++ b/src/lib/expo-image/resolveUseAppleWebpCodec.ts
@@ -1,0 +1,24 @@
+import type { EmoteUrlDescriptor } from '@app/utils/emote/describeEmoteUrl';
+
+type EmoteUrlKind = EmoteUrlDescriptor['kind'];
+
+/**
+ * expo-image's Apple WebP codec is faster and lighter but plays animated WebP
+ * at the wrong framerate (see expo-image docs on `useAppleWebpCodec`). Force
+ * the standards-compliant libwebp path for known-animated urls so chat emotes
+ * and picker previews play at full FPS; leave static/unknown urls on the fast
+ * Apple codec when `preferAppleCodecForStatic` is set, otherwise expo-image's
+ * default.
+ */
+export function resolveUseAppleWebpCodec(
+  urlKind: EmoteUrlKind,
+  options?: { preferAppleCodecForStatic?: boolean },
+): boolean | undefined {
+  if (urlKind === 'animated') {
+    return false;
+  }
+  if (options?.preferAppleCodecForStatic) {
+    return true;
+  }
+  return undefined;
+}

--- a/src/screens/DevTools/EnvVarsScreen.tsx
+++ b/src/screens/DevTools/EnvVarsScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Platform, Pressable, StyleSheet, View } from 'react-native';
 
 import * as AC from '@bacons/apple-colors';
@@ -92,6 +92,8 @@ function getEnvVars(): EnvVar[] {
   ];
 }
 
+const ENV_VARS = getEnvVars();
+
 async function copyEnvVar(entry: EnvVar): Promise<void> {
   if (entry.value == null) {
     return;
@@ -109,7 +111,7 @@ function maskValue(value: string): string {
 
 export function EnvVarsScreen() {
   const [revealed, setRevealed] = useState(false);
-  const envVars = useMemo(() => getEnvVars(), []);
+  const envVars = ENV_VARS;
 
   const setCount = envVars.filter(
     v => v.value != null && v.value !== '',

--- a/src/screens/Preferences/ChatHighlightsScreen.tsx
+++ b/src/screens/Preferences/ChatHighlightsScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Alert, StyleSheet, TextInput, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
@@ -164,7 +164,7 @@ export function ChatHighlightsScreen() {
 
   useScrollToTop(listRef);
 
-  const highlights = useMemo(() => customHighlights ?? [], [customHighlights]);
+  const highlights = customHighlights ?? [];
 
   const handleAdd = useCallback(() => {
     const phrase = normaliseHighlightPhrase(inputValue);

--- a/src/screens/Preferences/ChatHighlightsScreen.tsx
+++ b/src/screens/Preferences/ChatHighlightsScreen.tsx
@@ -32,6 +32,8 @@ const HIGHLIGHT_COLORS = [
   theme.colorRed,
 ] as const;
 
+const EMPTY_HIGHLIGHTS: CustomHighlight[] = [];
+
 function HighlightRow({
   highlight,
   onRemove,
@@ -164,7 +166,7 @@ export function ChatHighlightsScreen() {
 
   useScrollToTop(listRef);
 
-  const highlights = customHighlights ?? [];
+  const highlights = customHighlights ?? EMPTY_HIGHLIGHTS;
 
   const handleAdd = useCallback(() => {
     const phrase = normaliseHighlightPhrase(inputValue);

--- a/src/screens/Preferences/SavedPhrasesScreen.tsx
+++ b/src/screens/Preferences/SavedPhrasesScreen.tsx
@@ -45,6 +45,8 @@ function createPhraseId(text: string) {
   return `${Date.now()}_${text}`;
 }
 
+const EMPTY_PHRASES: SavedPhrase[] = [];
+
 function PhraseRow({
   phrase,
   isEditing,
@@ -166,7 +168,7 @@ function NativeSavedPhrasesList() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const phraseText = useNativeState('');
 
-  const phrases = savedPhrases ?? [];
+  const phrases = savedPhrases ?? EMPTY_PHRASES;
 
   const handleNativeSave = () => {
     const text = phraseText.value.trim();
@@ -276,7 +278,7 @@ export function SavedPhrasesScreen() {
 
   useScrollToTop(listRef);
 
-  const phrases = savedPhrases ?? [];
+  const phrases = savedPhrases ?? EMPTY_PHRASES;
 
   const handleSave = useCallback(() => {
     const text = inputValue.trim();

--- a/src/screens/Preferences/SavedPhrasesScreen.tsx
+++ b/src/screens/Preferences/SavedPhrasesScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Alert, Platform, StyleSheet, TextInput, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
@@ -166,7 +166,7 @@ function NativeSavedPhrasesList() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const phraseText = useNativeState('');
 
-  const phrases = useMemo(() => savedPhrases ?? [], [savedPhrases]);
+  const phrases = savedPhrases ?? [];
 
   const handleNativeSave = () => {
     const text = phraseText.value.trim();
@@ -276,7 +276,7 @@ export function SavedPhrasesScreen() {
 
   useScrollToTop(listRef);
 
-  const phrases = useMemo(() => savedPhrases ?? [], [savedPhrases]);
+  const phrases = savedPhrases ?? [];
 
   const handleSave = useCallback(() => {
     const text = inputValue.trim();

--- a/src/screens/SettingsScreen/components/profile/ProfileCard.ios.tsx
+++ b/src/screens/SettingsScreen/components/profile/ProfileCard.ios.tsx
@@ -11,9 +11,9 @@ import {
   Text as NativeText,
 } from '@expo/ui/swift-ui';
 import { router } from 'expo-router';
-import { SymbolView } from 'expo-symbols';
 
 import { Image } from '@app/components/Image/Image';
+import { SymbolView } from '@app/components/ui/Icon/Icon';
 import { Text } from '@app/components/ui/Text/Text';
 import { useAuthContext } from '@app/context/AuthContext';
 import i18next from '@app/i18n/i18next';

--- a/src/screens/Stream/ClipPlayerScreen.tsx
+++ b/src/screens/Stream/ClipPlayerScreen.tsx
@@ -7,6 +7,7 @@ import { router } from 'expo-router';
 import { IconButton } from '@app/components/IconButton/IconButton';
 import { StreamPlayer } from '@app/components/StreamPlayer/StreamPlayer';
 import { EmptyState } from '@app/components/ui/EmptyState/EmptyState';
+import { useRemoteConfig } from '@app/hooks/firebase/useRemoteConfig';
 import { theme } from '@app/styles/themes';
 import { shareDeepLink } from '@app/utils/sharing/shareDeepLink';
 
@@ -17,6 +18,7 @@ interface ClipPlayerScreenProps {
 export function ClipPlayerScreen({ id }: ClipPlayerScreenProps) {
   const { t } = useTranslation(['stream', 'common']);
   const insets = useSafeAreaInsets();
+  const { config } = useRemoteConfig();
 
   if (!id) {
     return (
@@ -33,7 +35,7 @@ export function ClipPlayerScreen({ id }: ClipPlayerScreenProps) {
     <View style={styles.container}>
       <StreamPlayer
         clip={id}
-        parent='www.twitch.tv'
+        parent={config.twitchPlayerEmbedParent.value}
         autoplay
         muted={false}
         height='100%'

--- a/src/screens/Stream/LiveStreamScreen.tsx
+++ b/src/screens/Stream/LiveStreamScreen.tsx
@@ -38,6 +38,7 @@ import type { StreamPlayerRef } from '@app/components/StreamPlayer/types';
 import { SymbolView } from '@app/components/ui/Icon/Icon';
 import { Text } from '@app/components/ui/Text/Text';
 import { useAuthContext } from '@app/context/AuthContext';
+import { useRemoteConfig } from '@app/hooks/firebase/useRemoteConfig';
 import { useStreamQuery } from '@app/hooks/queries/useStreamQuery';
 import { useUserQuery } from '@app/hooks/queries/useUserQuery';
 import { useChannelPoll } from '@app/hooks/useChannelPoll';
@@ -116,6 +117,7 @@ export const LiveStreamScreen = memo(function LiveStreamScreen({
   const isFocused = useIsFocused();
   const { authState } = useAuthContext();
   const customPlayerEnabled = usePreference('customPlayerEnabled');
+  const { config } = useRemoteConfig();
   const streamPlayerRef = useRef<StreamPlayerRef>(null);
   useEffect(
     () => subscribeLiveSync(() => streamPlayerRef.current?.syncToLive()),
@@ -851,6 +853,7 @@ export const LiveStreamScreen = memo(function LiveStreamScreen({
           <StreamPlayer
             ref={streamPlayerRef}
             channel={resolvedChannelLogin}
+            parent={config.twitchPlayerEmbedParent.value}
             height='100%'
             width='100%'
             autoplay

--- a/src/screens/Stream/VodPlayerScreen.tsx
+++ b/src/screens/Stream/VodPlayerScreen.tsx
@@ -11,6 +11,7 @@ import { StatusBar } from 'expo-status-bar';
 import { IconButton } from '@app/components/IconButton/IconButton';
 import { StreamPlayer } from '@app/components/StreamPlayer/StreamPlayer';
 import { EmptyState } from '@app/components/ui/EmptyState/EmptyState';
+import { useRemoteConfig } from '@app/hooks/firebase/useRemoteConfig';
 import { theme } from '@app/styles/themes';
 
 import { getLiveStreamLayoutMetrics } from './liveStreamLayout';
@@ -28,6 +29,7 @@ const KEEP_AWAKE_TAG = 'vod-player';
 export function VodPlayerScreen({ id }: VodPlayerScreenProps) {
   const { t } = useTranslation(['stream', 'common']);
   const insets = useSafeAreaInsets();
+  const { config } = useRemoteConfig();
   const sleepTimer = useSleepTimer({
     onExpire: () => {
       if (router.canGoBack()) {
@@ -101,7 +103,7 @@ export function VodPlayerScreen({ id }: VodPlayerScreenProps) {
       >
         <StreamPlayer
           video={id}
-          parent='www.twitch.tv'
+          parent={config.twitchPlayerEmbedParent.value}
           autoplay
           muted={false}
           height='100%'

--- a/src/screens/Top/TopCategoriesScreen.tsx
+++ b/src/screens/Top/TopCategoriesScreen.tsx
@@ -15,14 +15,15 @@ import { FlashList, FlashListRef } from '@app/components/FlashList/FlashList';
 import { EmptyState } from '@app/components/ui/EmptyState/EmptyState';
 import { Skeleton } from '@app/components/ui/Skeleton/Skeleton';
 import { useTopCategoriesQuery } from '@app/hooks/queries/useTopCategoriesQuery';
+import { useFlattenedInfiniteQuery } from '@app/hooks/useFlattenedInfiniteQuery';
 import { useInfiniteQueryLoadMore } from '@app/hooks/useInfiniteQueryLoadMore';
 import { useRefetchOnForeground } from '@app/hooks/useRefetchOnForeground';
 import { useScrollToTop } from '@app/hooks/useScrollToTop';
 import { theme } from '@app/styles/themes';
 import type { Category } from '@app/types/twitch/category';
-import { flattenInfiniteQueryPages } from '@app/utils/pagination/flattenInfiniteQueryPages';
 
 const SKELETON_COUNT = 9;
+const SKELETON_DATA = Array.from({ length: SKELETON_COUNT });
 const SKELETON_COLUMNS = 3;
 const TOP_CATEGORY_SKELETON_KEY_PREFIX = 'skeleton-';
 
@@ -48,7 +49,6 @@ export function TopCategoriesScreen({
   const refreshing$ = useObservable(false);
   const refreshing = useSelector(refreshing$);
   const listRef = useRef<FlashListRef<Category>>(null);
-  const skeletonData = Array.from({ length: SKELETON_COUNT });
 
   useScrollToTop(listRef);
 
@@ -87,7 +87,7 @@ export function TopCategoriesScreen({
     refreshing$.set(false);
   }, [refetch, refreshing$]);
 
-  const allCategories = flattenInfiniteQueryPages(categories?.pages);
+  const allCategories = useFlattenedInfiniteQuery(categories?.pages);
   const showSkeleton = isLoading || (isFetching && allCategories.length === 0);
 
   if (showSkeleton) {
@@ -96,7 +96,7 @@ export function TopCategoriesScreen({
         <FlashList
           getItemType={() => 'category-skeleton'}
           contentInsetAdjustmentBehavior='automatic'
-          data={skeletonData}
+          data={SKELETON_DATA}
           keyExtractor={(_, idx) => `${TOP_CATEGORY_SKELETON_KEY_PREFIX}${idx}`}
           numColumns={SKELETON_COLUMNS}
           renderItem={renderTopCategorySkeletonItem}

--- a/src/services/ffz-service.ts
+++ b/src/services/ffz-service.ts
@@ -76,13 +76,15 @@ export const ffzService = {
     try {
       const result = await ffzApi.get<FfzGlobalEmotesResponse>('/set/global');
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-      const sanitisedSet = result.sets[
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        result.default_sets[0]
-      ].emoticons.map<FfzSanitisedEmote>((emote: FfzEmoticon) =>
-        sanitiseFfzEmote(emote, 'Global FFZ', 'UNKNOWN'),
+      const defaultSetId = String(result.default_sets[0]);
+      const defaultSet = result.sets[defaultSetId];
+      if (!defaultSet) {
+        return [];
+      }
+
+      const sanitisedSet = defaultSet.emoticons.map<FfzSanitisedEmote>(
+        (emote: FfzEmoticon) =>
+          sanitiseFfzEmote(emote, 'Global FFZ', 'UNKNOWN'),
       );
 
       return sanitisedSet as FfzSanitisedEmote[];

--- a/src/utils/devTools/__tests__/useDevToolsAccess.test.tsx
+++ b/src/utils/devTools/__tests__/useDevToolsAccess.test.tsx
@@ -62,6 +62,7 @@ function createRemoteConfigResult(
         e2e: false,
       },
     }),
+    twitchPlayerEmbedParent: entry('www.twitch.tv'),
   };
 
   return { config, refetch: jest.fn(), isRefetching: false, isLoading };

--- a/src/utils/version/__tests__/getMinimumVersion.test.ts
+++ b/src/utils/version/__tests__/getMinimumVersion.test.ts
@@ -35,6 +35,7 @@ function createRemoteConfig(minimumVersion: {
         e2e: false,
       },
     }),
+    twitchPlayerEmbedParent: entry('www.twitch.tv'),
   };
 }
 


### PR DESCRIPTION
## Summary
- Apply targeted simplify/cleanup fixes across list performance, Reanimated compiler compatibility, shared utilities, and preference screens
- Add `twitchPlayerEmbedParent` remote config key and pass it to stream player screens via `useRemoteConfig()`
- Chat inline image/badge loading tweaks (`maxRetryAttempts`, `showLoadingShimmer`, animated WebP codec)
- Fix `useOnReconnect` to register the network listener inside `useEffect` instead of during render

## Test plan
- [x] `bun run ts:check`
- [x] `jest` — `ChatInlineImage`, `workflows.test.ts`
- [ ] Smoke test stream player (live/VOD/clip) with custom player enabled