### PR TITLE
chore(infrastructure): wire Sentry Size Analysis into native builds

### DIFF
--- a/.github/actions/native-build-submit/action.yml
+++ b/.github/actions/native-build-submit/action.yml
@@ -115,6 +115,11 @@ runs:
             echo "Skipping Sentry dSYM upload because SENTRY_AUTH_TOKEN is not set"
           fi
 
+          # shellcheck source=scripts/sentry-upload.sh
+          source ./scripts/sentry-upload.sh
+          size_analysis_path="$(sentry_find_ios_size_analysis_artifact "$ipa_path" "$build_marker")"
+          sentry_upload_size_analysis "$size_analysis_path"
+
           bun run eas submit -p ios --profile "$VARIANT" --non-interactive --path ./build-artifacts/app.ipa
         }
 
@@ -128,6 +133,11 @@ runs:
             EXPO_PUBLIC_SENTRY_RELEASE="${EXPO_PUBLIC_SENTRY_RELEASE}" \
             EXPO_PUBLIC_SENTRY_DIST="${EXPO_PUBLIC_SENTRY_DIST}" \
             bun run eas build --platform android --profile "$VARIANT" --non-interactive --local --output=./build-artifacts/app.aab
+
+          # shellcheck source=scripts/sentry-upload.sh
+          source ./scripts/sentry-upload.sh
+          sentry_upload_size_analysis ./build-artifacts/app.aab
+
           bun run eas submit -p android --profile "$VARIANT" --non-interactive --path ./build-artifacts/app.aab
         }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -66,6 +66,10 @@ build_ios() {
   fi
 
   run_sentry_helper sentry_upload_dsyms "${dsym_search_paths[@]}"
+
+  local size_analysis_path
+  size_analysis_path="$(sentry_find_ios_size_analysis_artifact "$ipa_path" "$build_marker")"
+  run_sentry_helper sentry_upload_size_analysis "$size_analysis_path"
 }
 
 build_android() {
@@ -86,6 +90,8 @@ build_android() {
     echo "Unable to find an Android artifact at $artifact_path"
     exit 1
   fi
+
+  run_sentry_helper sentry_upload_size_analysis "$artifact_path"
 }
 
 case "$platform" in

--- a/scripts/sentry-upload.sh
+++ b/scripts/sentry-upload.sh
@@ -64,6 +64,41 @@ sentry_size_analysis_build_configuration() {
   printf 'Release-%s\n' "$app_variant"
 }
 
+sentry_path_mtime() {
+  local path="$1"
+
+  if stat -f %m "$path" >/dev/null 2>&1; then
+    stat -f %m "$path"
+    return
+  fi
+
+  stat -c %Y "$path" 2>/dev/null || printf '0\n'
+}
+
+sentry_newest_xcarchive() {
+  local newest=""
+  local newest_mtime=0
+  local archive
+
+  for archive in "$@"; do
+    local info_plist="$archive/Info.plist"
+
+    if [ ! -f "$info_plist" ]; then
+      continue
+    fi
+
+    local mtime
+    mtime="$(sentry_path_mtime "$info_plist")"
+
+    if [ "$mtime" -gt "$newest_mtime" ]; then
+      newest_mtime="$mtime"
+      newest="$archive"
+    fi
+  done
+
+  printf '%s\n' "$newest"
+}
+
 sentry_find_ios_size_analysis_artifact() {
   local ipa_path="$1"
   local build_marker="$2"
@@ -83,9 +118,7 @@ sentry_find_ios_size_analysis_artifact() {
     )
 
     if [ "${#archives[@]}" -gt 0 ]; then
-      xcarchive_path="$(
-        printf '%s\0' "${archives[@]}" | xargs -0 ls -td 2>/dev/null | head -1 || true
-      )"
+      xcarchive_path="$(sentry_newest_xcarchive "${archives[@]}")"
     fi
   fi
 

--- a/scripts/sentry-upload.sh
+++ b/scripts/sentry-upload.sh
@@ -71,16 +71,22 @@ sentry_find_ios_size_analysis_artifact() {
   local xcarchive_path=""
 
   if [ -d "$xcode_archive_root" ] && [ -f "$build_marker" ]; then
-    xcarchive_path="$(
+    local -a archives=()
+    while IFS= read -r -d '' archive; do
+      archives+=("$archive")
+    done < <(
       find "$xcode_archive_root" \
         -type d \
         -name '*.xcarchive' \
         -newer "$build_marker" \
-        -print0 2>/dev/null \
-        | xargs -0 --no-run-if-empty ls -td 2>/dev/null \
-        | head -1 \
-        || true
-    )"
+        -print0 2>/dev/null || true
+    )
+
+    if [ "${#archives[@]}" -gt 0 ]; then
+      xcarchive_path="$(
+        printf '%s\0' "${archives[@]}" | xargs -0 ls -td 2>/dev/null | head -1 || true
+      )"
+    fi
   fi
 
   if [ -n "$xcarchive_path" ] && [ "$xcarchive_path" != "." ] && [ -e "$xcarchive_path" ]; then

--- a/scripts/sentry-upload.sh
+++ b/scripts/sentry-upload.sh
@@ -77,13 +77,13 @@ sentry_find_ios_size_analysis_artifact() {
         -name '*.xcarchive' \
         -newer "$build_marker" \
         -print0 2>/dev/null \
-        | xargs -0 ls -td 2>/dev/null \
+        | xargs -0 --no-run-if-empty ls -td 2>/dev/null \
         | head -1 \
         || true
     )"
   fi
 
-  if [ -n "$xcarchive_path" ] && [ -e "$xcarchive_path" ]; then
+  if [ -n "$xcarchive_path" ] && [ "$xcarchive_path" != "." ] && [ -e "$xcarchive_path" ]; then
     printf '%s\n' "$xcarchive_path"
     return
   fi

--- a/scripts/sentry-upload.sh
+++ b/scripts/sentry-upload.sh
@@ -59,6 +59,71 @@ sentry_dist() {
   sentry_dist_for_variant
 }
 
+sentry_size_analysis_build_configuration() {
+  local app_variant="${EXPO_PUBLIC_APP_VARIANT:-${variant:-${VARIANT:-development}}}"
+  printf 'Release-%s\n' "$app_variant"
+}
+
+sentry_find_ios_size_analysis_artifact() {
+  local ipa_path="$1"
+  local build_marker="$2"
+  local xcode_archive_root="${IOS_ARCHIVE_ROOT:-$HOME/Library/Developer/Xcode/Archives}"
+  local xcarchive_path=""
+
+  if [ -d "$xcode_archive_root" ] && [ -f "$build_marker" ]; then
+    xcarchive_path="$(
+      find "$xcode_archive_root" \
+        -type d \
+        -name '*.xcarchive' \
+        -newer "$build_marker" \
+        -print0 2>/dev/null \
+        | xargs -0 ls -td 2>/dev/null \
+        | head -1 \
+        || true
+    )"
+  fi
+
+  if [ -n "$xcarchive_path" ] && [ -e "$xcarchive_path" ]; then
+    printf '%s\n' "$xcarchive_path"
+    return
+  fi
+
+  printf '%s\n' "$ipa_path"
+}
+
+sentry_upload_size_analysis() {
+  local artifact_path="$1"
+
+  if sentry_uploads_disabled; then
+    echo "Skipping Sentry Size Analysis upload because Sentry uploads are disabled"
+    return 0
+  fi
+
+  if ! sentry_has_auth_token; then
+    echo "Skipping Sentry Size Analysis upload because SENTRY_AUTH_TOKEN is not set"
+    return 0
+  fi
+
+  if [ ! -e "$artifact_path" ]; then
+    echo "Skipping Sentry Size Analysis upload because $artifact_path does not exist"
+    return 0
+  fi
+
+  local bin
+  bin="$(sentry_cli_bin)"
+
+  local build_configuration
+  build_configuration="$(sentry_size_analysis_build_configuration)"
+
+  echo "Uploading Sentry Size Analysis build from $artifact_path ($build_configuration)"
+  SENTRY_URL="${SENTRY_URL:-https://sentry.io/}" \
+    SENTRY_LOAD_DOTENV="${SENTRY_LOAD_DOTENV:-0}" \
+    sentry_run_upload "$bin" build upload "$artifact_path" \
+      --org "${SENTRY_ORG:-foam-tv}" \
+      --project "${SENTRY_PROJECT:-foam-tv-mobile}" \
+      --build-configuration "$build_configuration"
+}
+
 sentry_cli_bin() {
   local bin="${SENTRY_CLI_BIN:-./node_modules/.bin/sentry-cli}"
 

--- a/scripts/workflows/sentry-size-analysis-cli.ts
+++ b/scripts/workflows/sentry-size-analysis-cli.ts
@@ -1,0 +1,66 @@
+import { existsSync } from 'node:fs';
+
+import {
+  buildSentrySizeAnalysisUploadArgs,
+  SENTRY_SIZE_ANALYSIS_DEFAULT_ORG,
+  SENTRY_SIZE_ANALYSIS_DEFAULT_PROJECT,
+} from './sentrySizeAnalysis';
+import { getRequiredArg, runTool } from './github-actions';
+
+function upload(args: string[]): void {
+  const artifactPath = getRequiredArg(args, 'path');
+  const variant = getRequiredArg(args, 'variant');
+
+  if (!existsSync(artifactPath)) {
+    throw new Error(`Size Analysis artifact does not exist: ${artifactPath}`);
+  }
+
+  const org = process.env.SENTRY_ORG ?? SENTRY_SIZE_ANALYSIS_DEFAULT_ORG;
+  const project =
+    process.env.SENTRY_PROJECT ?? SENTRY_SIZE_ANALYSIS_DEFAULT_PROJECT;
+  const authToken = process.env.SENTRY_AUTH_TOKEN;
+
+  if (authToken == null || authToken === '') {
+    throw new Error('SENTRY_AUTH_TOKEN is not set');
+  }
+
+  const sentryCli =
+    process.env.SENTRY_CLI_BIN ?? './node_modules/.bin/sentry-cli';
+
+  const uploadArgs = buildSentrySizeAnalysisUploadArgs({
+    artifactPath,
+    variant,
+    org,
+    project,
+  });
+
+  runTool(sentryCli, uploadArgs, {
+    env: {
+      ...process.env,
+      SENTRY_AUTH_TOKEN: authToken,
+      SENTRY_LOAD_DOTENV: '0',
+      SENTRY_URL: process.env.SENTRY_URL ?? 'https://sentry.io/',
+    },
+    stdio: 'inherit',
+  });
+}
+
+function main(): void {
+  const [command, ...args] = process.argv.slice(2);
+
+  switch (command) {
+    case 'upload':
+      upload(args);
+      return;
+    default:
+      throw new Error(`Unknown command: ${command ?? '<missing>'}`);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`::error::${message}`);
+  process.exit(1);
+}

--- a/scripts/workflows/sentrySizeAnalysis.ts
+++ b/scripts/workflows/sentrySizeAnalysis.ts
@@ -1,0 +1,68 @@
+import { sentrySizeAnalysisBuildConfigurationFor } from './variant';
+
+export const SENTRY_SIZE_ANALYSIS_DEFAULT_ORG = 'foam-tv';
+export const SENTRY_SIZE_ANALYSIS_DEFAULT_PROJECT = 'foam-tv-mobile';
+
+export type SentrySizeAnalysisUploadOptions = {
+  artifactPath: string;
+  variant: string;
+  org?: string;
+  project?: string;
+  headSha?: string;
+  baseSha?: string;
+  vcsProvider?: string;
+  headRepoName?: string;
+  baseRepoName?: string;
+  headRef?: string;
+  baseRef?: string;
+  prNumber?: string;
+};
+
+export function buildSentrySizeAnalysisUploadArgs(
+  options: SentrySizeAnalysisUploadOptions,
+): string[] {
+  const org = options.org ?? SENTRY_SIZE_ANALYSIS_DEFAULT_ORG;
+  const project = options.project ?? SENTRY_SIZE_ANALYSIS_DEFAULT_PROJECT;
+  const buildConfiguration = sentrySizeAnalysisBuildConfigurationFor(
+    options.variant,
+  );
+
+  const args = [
+    'build',
+    'upload',
+    options.artifactPath,
+    '--org',
+    org,
+    '--project',
+    project,
+    '--build-configuration',
+    buildConfiguration,
+  ];
+
+  if (options.headSha) {
+    args.push('--head-sha', options.headSha);
+  }
+  if (options.baseSha) {
+    args.push('--base-sha', options.baseSha);
+  }
+  if (options.vcsProvider) {
+    args.push('--vcs-provider', options.vcsProvider);
+  }
+  if (options.headRepoName) {
+    args.push('--head-repo-name', options.headRepoName);
+  }
+  if (options.baseRepoName) {
+    args.push('--base-repo-name', options.baseRepoName);
+  }
+  if (options.headRef) {
+    args.push('--head-ref', options.headRef);
+  }
+  if (options.baseRef) {
+    args.push('--base-ref', options.baseRef);
+  }
+  if (options.prNumber) {
+    args.push('--pr-number', options.prNumber);
+  }
+
+  return args;
+}

--- a/scripts/workflows/variant.ts
+++ b/scripts/workflows/variant.ts
@@ -50,6 +50,17 @@ export function sentryDistFor(variant: string): string {
   return getVariantMeta(variant).sentryDist;
 }
 
+/**
+ * Sentry Size Analysis scopes comparisons to like-for-like builds. EAS release
+ * profiles map 1:1 to our deploy variants, so encode the variant in the
+ * configuration name (Release-production, Release-internal, …).
+ */
+export function sentrySizeAnalysisBuildConfigurationFor(
+  variant: string,
+): string {
+  return `Release-${variant}`;
+}
+
 export function variantLabel(variant: string): string {
   return getVariantMeta(variant).label;
 }

--- a/test/workflows.test.ts
+++ b/test/workflows.test.ts
@@ -47,12 +47,14 @@ import {
   type S3Copier,
   saveEntries,
 } from '../scripts/workflows/s3Cache';
+import { buildSentrySizeAnalysisUploadArgs } from '../scripts/workflows/sentrySizeAnalysis';
 import {
   appendVariant,
   getVariantMeta,
   ignoreTagsPattern,
   isVariant,
   sentryDistFor,
+  sentrySizeAnalysisBuildConfigurationFor,
   variantLabel,
 } from '../scripts/workflows/variant';
 
@@ -796,6 +798,18 @@ describe('variant', () => {
     expect(sentryDistFor('testflight')).toBe('foam-tv-testflight');
   });
 
+  test('maps each deploy variant to a Sentry Size Analysis build configuration', () => {
+    expect(sentrySizeAnalysisBuildConfigurationFor('production')).toEqual(
+      'Release-production',
+    );
+    expect(sentrySizeAnalysisBuildConfigurationFor('internal')).toEqual(
+      'Release-internal',
+    );
+    expect(sentrySizeAnalysisBuildConfigurationFor('testflight')).toEqual(
+      'Release-testflight',
+    );
+  });
+
   test('maps each variant to its release label', () => {
     expect(variantLabel('production')).toBe('Production');
     expect(variantLabel('testflight')).toBe('TestFlight');
@@ -832,6 +846,69 @@ describe('variant', () => {
         '^1\\.2\\.3-(internal|preview)$',
       );
     });
+  });
+});
+
+describe('sentrySizeAnalysis', () => {
+  test('builds sentry-cli upload args with org, project, and variant build configuration', () => {
+    expect(
+      buildSentrySizeAnalysisUploadArgs({
+        artifactPath: './build-artifacts/app.aab',
+        variant: 'production',
+      }),
+    ).toEqual([
+      'build',
+      'upload',
+      './build-artifacts/app.aab',
+      '--org',
+      'foam-tv',
+      '--project',
+      'foam-tv-mobile',
+      '--build-configuration',
+      'Release-production',
+    ]);
+  });
+
+  test('includes optional VCS metadata when provided', () => {
+    expect(
+      buildSentrySizeAnalysisUploadArgs({
+        artifactPath: './build-artifacts/app.ipa',
+        variant: 'internal',
+        org: 'custom-org',
+        project: 'custom-project',
+        headSha: 'abc123',
+        baseSha: 'def456',
+        vcsProvider: 'github',
+        headRepoName: 'org/repo',
+        headRef: 'feature-branch',
+        baseRef: 'main',
+        prNumber: '42',
+      }),
+    ).toEqual([
+      'build',
+      'upload',
+      './build-artifacts/app.ipa',
+      '--org',
+      'custom-org',
+      '--project',
+      'custom-project',
+      '--build-configuration',
+      'Release-internal',
+      '--head-sha',
+      'abc123',
+      '--base-sha',
+      'def456',
+      '--vcs-provider',
+      'github',
+      '--head-repo-name',
+      'org/repo',
+      '--head-ref',
+      'feature-branch',
+      '--base-ref',
+      'main',
+      '--pr-number',
+      '42',
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Upload native build artifacts to Sentry Size Analysis after EAS local builds in CI and local `build:local` flows
- iOS prefers the newest post-build XCArchive when available, otherwise falls back to the IPA; Android uploads the AAB
- Scopes comparisons per deploy variant via `Release-{variant}` build configurations (production, internal, testflight)
- Skips gracefully when `SENTRY_AUTH_TOKEN` is unset, matching existing dSYM upload behavior

## Test plan
- [x] `bun jest test/workflows.test.ts` (65 tests pass)
- [ ] Trigger a native deploy build and confirm uploads appear under Sentry → foam-tv-mobile → Size Analysis
- [ ] Verify iOS upload uses XCArchive when Xcode archives are present after the build
- [ ] Verify Android AAB upload completes for internal/production variants


