### PR TITLE
feat(chat): add HTML/CSS painted username rendering primitives

### DIFF
--- a/__mocks__/@native-html/render.tsx
+++ b/__mocks__/@native-html/render.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+function RenderHTML({
+  renderers,
+  source,
+}: {
+  renderers?: Record<
+    string,
+    React.ComponentType<{
+      tnode: { attributes: Record<string, string> };
+    }>
+  >;
+  source: { html: string };
+}) {
+  if (
+    renderers?.span &&
+    source.html.includes('data-seventv-painted-text="true"')
+  ) {
+    const SpanRenderer = renderers.span;
+    return React.createElement(SpanRenderer, {
+      tnode: { attributes: { 'data-seventv-painted-text': 'true' } },
+    });
+  }
+
+  const text = source.html.replaceAll(/<[^>]+>/g, '');
+  return React.createElement(Text, null, text);
+}
+
+export default RenderHTML;

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@expo/ui": "~57.0.1",
         "@legendapp/list": "3.0.4",
         "@legendapp/state": "^2.1.15",
+        "@native-html/render": "1.0.3",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "12.0.1",
         "@react-native-community/slider": "5.2.0",
@@ -931,6 +932,10 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@jsamr/counter-style": ["@jsamr/counter-style@2.0.2", "", {}, "sha512-2mXudGVtSzVxWEA7B9jZLKjoXUeUFYDDtFrQoC0IFX9/Dszz4t1vZOmafi3JSw/FxD+udMQ+4TAFR8Qs0J3URQ=="],
+
+    "@jsamr/react-native-li": ["@jsamr/react-native-li@2.3.1", "", { "peerDependencies": { "@jsamr/counter-style": "^1.0.0 || ^2.0.0", "react": "*", "react-native": "*" } }, "sha512-Qbo4NEj48SQ4k8FZJHFE2fgZDKTWaUGmVxcIQh3msg5JezLdTMMHuRRDYctfdHI6L0FZGObmEv3haWbIvmol8w=="],
+
     "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
 
     "@kwsites/promise-deferred": ["@kwsites/promise-deferred@1.1.1", "", {}, "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="],
@@ -940,6 +945,12 @@
     "@legendapp/state": ["@legendapp/state@2.1.15", "", { "dependencies": { "use-sync-external-store": "^1.2.0" }, "peerDependencies": { "react": ">=16.8.0" }, "optionalPeers": ["react"] }, "sha512-7/8Rgg7m38eznupr36QJeSkrtbhVxaRtQvRMjdBigSm+HW3ZIFgMtUX1DqZ2hJxbPqqAJamw5s+TLs8dRstUNw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@native-html/css-processor": ["@native-html/css-processor@2.0.1", "", { "dependencies": { "css-to-react-native": "^3.2.0", "csstype": "^3.1.3" }, "peerDependencies": { "@types/react": "*" } }, "sha512-NN0TKGjnu8eSWsKP4EQVIPCb5YoYlCQE9MnZnzN93euu0hkwZ89TBKqEnQ3FJE/hjZ1NFwciPqbenqn6RcgIag=="],
+
+    "@native-html/render": ["@native-html/render@1.0.3", "", { "dependencies": { "@jsamr/counter-style": "^2.0.2", "@jsamr/react-native-li": "^2.3.1", "@native-html/transient-render-engine": "12.0.1", "@types/ramda": "^0.31.1", "@types/urijs": "^1.19.25", "prop-types": "^15.8.1", "ramda": "^0.32.0", "stringify-entities": "^4.0.4", "urijs": "^1.19.11" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-C6nThaZf+rOcNpZHqbZoSrsNU6SUyHFCQqz+0ixGcOEyvypYiA1KowBNc9AkWKiVcoHpISioKbQlrQ7l+rlqEw=="],
+
+    "@native-html/transient-render-engine": ["@native-html/transient-render-engine@12.0.1", "", { "dependencies": { "@native-html/css-processor": "2.0.1", "csstype": "^3.1.3", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "htmlparser2": "^10.0.0", "ramda": "^0.32.0" }, "peerDependencies": { "react-native": "*" } }, "sha512-DiaVMJbW75k08aWJXYTftg/JULaEFUv3+GF/9xW3Cb12+S0vmwbu1+c33wKBc7TomZABD9hEYk9Y7kyQp6BgOg=="],
 
     "@nicolo-ribaudo/eslint-scope-5-internals": ["@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1", "", { "dependencies": { "eslint-scope": "5.1.1" } }, "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg=="],
 
@@ -1407,6 +1418,8 @@
 
     "@types/node": ["@types/node@24.1.0", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w=="],
 
+    "@types/ramda": ["@types/ramda@0.31.1", "", { "dependencies": { "types-ramda": "^0.31.0" } }, "sha512-Vt6sFXnuRpzaEj+yeutA0q3bcAsK7wdPuASIzR9LXqL4gJPyFw8im9qchlbp4ltuf3kDEIRmPJTD/Fkg60dn7g=="],
+
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
     "@types/react-test-renderer": ["@types/react-test-renderer@19.1.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ=="],
@@ -1416,6 +1429,8 @@
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
 
     "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
+
+    "@types/urijs": ["@types/urijs@1.19.26", "", {}, "sha512-wkXrVzX5yoqLnndOwFsieJA7oKM8cNkOKJtf/3vVGSUFkWDKZvFHpIl9Pvqb/T9UsawBBFMTTD8xu7sK5MWuvg=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -1695,6 +1710,8 @@
 
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
+    "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001800", "", {}, "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA=="],
 
     "canvaskit-wasm": ["canvaskit-wasm@0.41.0", "", { "dependencies": { "@webgpu/types": "0.1.21" } }, "sha512-cnbL02NFB3yOYMF/MtxViZHgD1vh55Pvy+zR8q4JuFvyCPejZP3eClkt2GuZ0S7jOmGMCJXaHBasbMChbR9JZg=="],
@@ -1712,6 +1729,10 @@
     "change-case-all": ["change-case-all@1.0.15", "", { "dependencies": { "change-case": "^4.1.2", "is-lower-case": "^2.0.2", "is-upper-case": "^2.0.2", "lower-case": "^2.0.2", "lower-case-first": "^2.0.2", "sponge-case": "^1.0.1", "swap-case": "^2.0.2", "title-case": "^3.0.3", "upper-case": "^2.0.2", "upper-case-first": "^2.0.2" } }, "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ=="],
 
     "char-regex": ["char-regex@2.0.2", "", {}, "sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "chardet": ["chardet@0.7.0", "", {}, "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="],
 
@@ -1811,9 +1832,13 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-color-keywords": ["css-color-keywords@1.0.0", "", {}, "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="],
+
     "css-in-js-utils": ["css-in-js-utils@3.1.0", "", { "dependencies": { "hyphenate-style-name": "^1.0.3" } }, "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-to-react-native": ["css-to-react-native@3.2.0", "", { "dependencies": { "camelize": "^1.0.0", "css-color-keywords": "^1.0.0", "postcss-value-parser": "^4.0.2" } }, "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
@@ -1955,7 +1980,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.24.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -2360,6 +2385,8 @@
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "html-parse-stringify": ["html-parse-stringify@3.0.1", "", { "dependencies": { "void-elements": "3.1.0" } }, "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -3049,6 +3076,8 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "ramda": ["ramda@0.32.0", "", {}, "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ=="],
+
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@2.5.3", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
@@ -3377,6 +3406,8 @@
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -3483,6 +3514,8 @@
 
     "ts-regex-builder": ["ts-regex-builder@1.8.2", "", {}, "sha512-Y8HovHFheDKm/jgLIWSO8o81xA/I9O5AGc3/vNG1sVSskatOifr3SQzAsatBXGLjL3nYhQif1MpwQRS5GF8ADg=="],
 
+    "ts-toolbelt": ["ts-toolbelt@9.6.0", "", {}, "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="],
+
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -3512,6 +3545,8 @@
     "typed-array-length": ["typed-array-length@1.0.8", "", { "dependencies": { "call-bind": "^1.0.9", "for-each": "^0.3.5", "gopd": "^1.2.0", "is-typed-array": "^1.1.15", "possible-typed-array-names": "^1.1.0", "reflect.getprototypeof": "^1.0.10" } }, "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g=="],
 
     "typed-function": ["typed-function@4.2.2", "", {}, "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A=="],
+
+    "types-ramda": ["types-ramda@0.31.0", "", { "dependencies": { "ts-toolbelt": "^9.6.0" } }, "sha512-vaoC35CRC3xvL8Z6HkshDbi6KWM1ezK0LHN0YyxXWUn9HKzBNg/T3xSGlJZjCYspnOD3jE7bcizsp0bUXZDxnQ=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
@@ -3550,6 +3585,8 @@
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "uri-template-matcher": ["uri-template-matcher@1.1.2", "", {}, "sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ=="],
+
+    "urijs": ["urijs@1.19.11", "", {}, "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="],
 
     "url-parse": ["url-parse@1.5.10", "", { "dependencies": { "querystringify": "^2.1.1", "requires-port": "^1.0.0" } }, "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ=="],
 
@@ -4174,6 +4211,8 @@
     "oxlint-plugin-react-doctor/oxc-parser": ["oxc-parser@0.132.0", "", { "dependencies": { "@oxc-project/types": "^0.132.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.132.0", "@oxc-parser/binding-android-arm64": "0.132.0", "@oxc-parser/binding-darwin-arm64": "0.132.0", "@oxc-parser/binding-darwin-x64": "0.132.0", "@oxc-parser/binding-freebsd-x64": "0.132.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.132.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.132.0", "@oxc-parser/binding-linux-arm64-gnu": "0.132.0", "@oxc-parser/binding-linux-arm64-musl": "0.132.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.132.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.132.0", "@oxc-parser/binding-linux-riscv64-musl": "0.132.0", "@oxc-parser/binding-linux-s390x-gnu": "0.132.0", "@oxc-parser/binding-linux-x64-gnu": "0.132.0", "@oxc-parser/binding-linux-x64-musl": "0.132.0", "@oxc-parser/binding-openharmony-arm64": "0.132.0", "@oxc-parser/binding-wasm32-wasi": "0.132.0", "@oxc-parser/binding-win32-arm64-msvc": "0.132.0", "@oxc-parser/binding-win32-ia32-msvc": "0.132.0", "@oxc-parser/binding-win32-x64-msvc": "0.132.0" } }, "sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg=="],
 
     "parse-bmfont-xml/xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ const jestConfig = {
   moduleNameMapper: {
     '^@app/(.*)$': '<rootDir>/src/$1',
     '^@modules/(.*)$': '<rootDir>/modules/$1',
+    '^@native-html/render$': '<rootDir>/__mocks__/@native-html/render.tsx',
     '\\.otf$': '<rootDir>/__mocks__/fileMock.js',
     '^@bacons/apple-colors$': '<rootDir>/__mocks__/@bacons/apple-colors.ts',
     '^react-native-legal$': '<rootDir>/__mocks__/react-native-legal.ts',

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@expo/ui": "~57.0.1",
     "@legendapp/list": "3.0.4",
     "@legendapp/state": "^2.1.15",
+    "@native-html/render": "1.0.3",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "12.0.1",
     "@react-native-community/slider": "5.2.0",

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/CosmeticUsername.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/CosmeticUsername.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { type StyleProp, StyleSheet, TextStyle, View } from 'react-native';
+import { Platform, type StyleProp, StyleSheet, TextStyle } from 'react-native';
 
 import { useSelector } from '@legendapp/state/react';
 
@@ -11,20 +11,11 @@ import type { PaintData } from '@app/types/seventv/cosmetics';
 import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
 
 import { chatLineMetrics } from '../RichChatMessage.styles';
-import { PaintedUsernameDropShadowLayer } from './PaintedUsernameDropShadowLayer';
-import { PaintedUsernameMaskedFill } from './PaintedUsernameMaskedFill';
+import { PaintedUsernameHtml } from './PaintedUsernameHtml';
 import {
   DEFAULT_PAINT_DROP_SHADOW_MODE,
-  getPaintDropShadows,
   type PaintDropShadowMode,
-  paintShadowKey,
 } from './util/paintLayer';
-import {
-  buildPaintUsernameTextStyle,
-  getPaintTextShadows,
-  getPaintTextStroke,
-  paintStrokeToShadow,
-} from './util/paintTextStyle';
 
 interface PaintedUsernameProps {
   username: string;
@@ -51,47 +42,14 @@ function PaintedUsernameWithPaint({
   sevenTvPaintDropShadows,
   usernameTextStyle,
 }: PaintedUsernameWithPaintProps) {
-  const dropShadowMode = sevenTvPaintDropShadows;
-  const paintTextStyle = buildPaintUsernameTextStyle(paint);
-  const dropShadows = getPaintDropShadows(paint, dropShadowMode);
-  const textShadows = getPaintTextShadows(paint);
-  const stroke = getPaintTextStroke(paint);
-
-  const maskTextStyle = [
-    styles.maskText,
-    usernameTextStyle,
-    paintTextStyle,
-  ] as StyleProp<TextStyle>;
-
-  // Layer order mirrors the extension's CSS compositing: drop-shadow filter
-  // furthest back, then text-shadows, then the stroke, then the painted fill.
-  const underlayShadows = [
-    ...dropShadows.map(shadow => ({ shadow, source: 'drop' })),
-    ...textShadows.map(shadow => ({ shadow, source: 'text' })),
-    ...(stroke
-      ? [{ shadow: paintStrokeToShadow(stroke), source: 'stroke' }]
-      : []),
-  ];
-
   return (
-    <View style={styles.paintedWrapper}>
-      {underlayShadows.map(({ shadow, source }, index) => (
-        <PaintedUsernameDropShadowLayer
-          // Static, never-reordered list; index disambiguates identical shadows.
-          // eslint-disable-next-line react-doctor/no-array-index-as-key
-          key={`${source}-${index}-${paintShadowKey(shadow)}`}
-          displayUsername={displayUsername}
-          maskTextStyle={maskTextStyle}
-          shadow={shadow}
-        />
-      ))}
-      <PaintedUsernameMaskedFill
-        displayUsername={displayUsername}
-        fallbackColor={fallbackColor}
-        paint={paint}
-        maskTextStyle={maskTextStyle}
-      />
-    </View>
+    <PaintedUsernameHtml
+      displayUsername={displayUsername}
+      fallbackColor={fallbackColor}
+      paint={paint}
+      sevenTvPaintDropShadows={sevenTvPaintDropShadows}
+      usernameTextStyle={usernameTextStyle}
+    />
   );
 }
 
@@ -132,16 +90,10 @@ function PaintedUsernameComponent({
     );
   }
 
-  const solidFallback =
-    paint.color === null ? fallbackColor : sevenTvColorToCss(paint.color);
+  if (Platform.OS !== 'web' && isScrolling) {
+    const solidFallback =
+      paint.color === null ? fallbackColor : sevenTvColorToCss(paint.color);
 
-  // During an active fling, render the username in its dominant solid colour
-  // and skip the per-row MaskedView offscreen pass + gradient/SVG/image fill
-  // layers; the full painted fill returns when the list settles (~150ms),
-  // mirroring how animated emotes pause decode during scroll. This sheds the
-  // offscreen render passes at the moment the Core Animation render encoder is
-  // most pressured (FOAM-TV-MOBILE-BJ render-commit OOM).
-  if (isScrolling) {
     return (
       <Text
         style={[
@@ -158,7 +110,7 @@ function PaintedUsernameComponent({
   return (
     <PaintedUsernameWithPaint
       displayUsername={displayUsername}
-      fallbackColor={solidFallback}
+      fallbackColor={fallbackColor}
       paint={paint}
       sevenTvPaintDropShadows={sevenTvPaintDropShadows}
       usernameTextStyle={usernameTextStyle}
@@ -167,15 +119,6 @@ function PaintedUsernameComponent({
 }
 
 const styles = StyleSheet.create({
-  maskText: {
-    ...chatLineMetrics.comfortable,
-    color: 'black',
-    fontWeight: 'bold',
-  },
-  paintedWrapper: {
-    alignSelf: 'flex-start',
-    position: 'relative',
-  },
   plainUsername: {
     ...chatLineMetrics.comfortable,
     fontWeight: 'bold',

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameHtml.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameHtml.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from 'react';
 import { Platform, StyleSheet, useWindowDimensions } from 'react-native';
 
-import RenderHTML, { type CustomTextualRenderer } from '@native-html/render';
+import RenderHTML, {
+  type CustomTextualRenderer,
+  type MixedStyleDeclaration,
+} from '@native-html/render';
 
 import type { PaintData } from '@app/types/seventv/cosmetics';
 
@@ -75,26 +78,27 @@ export function PaintedUsernameHtml({
     [displayUsername, inlineCss, paint.id],
   );
 
-  const flatMetrics = StyleSheet.flatten(usernameMetricsStyle) ?? {};
+  const tagsStyles = useMemo((): Record<string, MixedStyleDeclaration> => {
+    const { overflow: _overflow, ...flatMetrics } =
+      StyleSheet.flatten(usernameMetricsStyle) ?? {};
 
-  const tagsStyles = useMemo(
-    () =>
-      Platform.OS === 'web'
-        ? {
-            span: {
-              ...flatMetrics,
-              ...buildPaintCssTextStyle(
-                paint,
-                fallbackColor,
-                sevenTvPaintDropShadows,
-              ),
-            },
-          }
-        : {
-            span: flatMetrics,
-          },
-    [fallbackColor, flatMetrics, paint, sevenTvPaintDropShadows],
-  );
+    if (Platform.OS === 'web') {
+      return {
+        span: {
+          ...flatMetrics,
+          ...buildPaintCssTextStyle(
+            paint,
+            fallbackColor,
+            sevenTvPaintDropShadows,
+          ),
+        } as MixedStyleDeclaration,
+      };
+    }
+
+    return {
+      span: flatMetrics as MixedStyleDeclaration,
+    };
+  }, [fallbackColor, paint, sevenTvPaintDropShadows, usernameMetricsStyle]);
 
   const renderers = useMemo(
     () =>

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameHtml.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameHtml.tsx
@@ -1,5 +1,11 @@
 import { useMemo } from 'react';
-import { Platform, StyleSheet, useWindowDimensions } from 'react-native';
+import {
+  Platform,
+  StyleSheet,
+  useWindowDimensions,
+  type StyleProp,
+  type TextStyle,
+} from 'react-native';
 
 import RenderHTML, {
   type CustomTextualRenderer,
@@ -8,11 +14,9 @@ import RenderHTML, {
 
 import type { PaintData } from '@app/types/seventv/cosmetics';
 
+import { chatLineMetrics } from '../RichChatMessage.styles';
 import { PaintedUsernameNativeLayers } from './PaintedUsernameNativeLayers';
-import {
-  type PaintedUsernameRenderContextValue,
-  PaintedUsernameRenderProvider,
-} from './PaintedUsernameRenderContext';
+import { PaintedUsernameRenderProvider } from './PaintedUsernameRenderContext';
 import {
   buildPaintCssInlineStyle,
   buildPaintCssTextStyle,
@@ -43,9 +47,8 @@ interface PaintedUsernameHtmlProps {
   displayUsername: string;
   fallbackColor: string;
   paint: PaintData;
-  renderContext: PaintedUsernameRenderContextValue;
   sevenTvPaintDropShadows: PaintDropShadowMode;
-  usernameMetricsStyle: PaintedUsernameRenderContextValue['usernameTextStyle'];
+  usernameTextStyle?: StyleProp<TextStyle>;
 }
 
 /**
@@ -60,11 +63,30 @@ export function PaintedUsernameHtml({
   displayUsername,
   fallbackColor,
   paint,
-  renderContext,
   sevenTvPaintDropShadows,
-  usernameMetricsStyle,
+  usernameTextStyle,
 }: PaintedUsernameHtmlProps) {
   const { width } = useWindowDimensions();
+  const renderContext = useMemo(
+    () => ({
+      displayUsername,
+      fallbackColor,
+      paint,
+      sevenTvPaintDropShadows,
+      usernameTextStyle,
+    }),
+    [
+      displayUsername,
+      fallbackColor,
+      paint,
+      sevenTvPaintDropShadows,
+      usernameTextStyle,
+    ],
+  );
+  const usernameMetricsStyle = useMemo(
+    () => [styles.maskText, usernameTextStyle] as StyleProp<TextStyle>,
+    [usernameTextStyle],
+  );
   const inlineCss = buildPaintCssInlineStyle(
     paint,
     fallbackColor,
@@ -73,7 +95,7 @@ export function PaintedUsernameHtml({
 
   const source = useMemo(
     () => ({
-      html: `<span class="seventv-painted-content seventv-paint" data-seventv-paint-id="${paint.id}" data-seventv-painted-text="true" style="${inlineCss}">${escapeHtml(displayUsername)}</span>`,
+      html: `<span class="seventv-painted-content seventv-paint" data-seventv-paint-id="${escapeHtml(paint.id)}" data-seventv-painted-text="true" style="${inlineCss}">${escapeHtml(displayUsername)}</span>`,
     }),
     [displayUsername, inlineCss, paint.id],
   );
@@ -122,3 +144,11 @@ export function PaintedUsernameHtml({
     </PaintedUsernameRenderProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  maskText: {
+    ...chatLineMetrics.comfortable,
+    color: 'black',
+    fontWeight: 'bold',
+  },
+});

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameHtml.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameHtml.tsx
@@ -1,0 +1,120 @@
+import { useMemo } from 'react';
+import { Platform, StyleSheet, useWindowDimensions } from 'react-native';
+
+import RenderHTML, { type CustomTextualRenderer } from '@native-html/render';
+
+import type { PaintData } from '@app/types/seventv/cosmetics';
+
+import { PaintedUsernameNativeLayers } from './PaintedUsernameNativeLayers';
+import {
+  type PaintedUsernameRenderContextValue,
+  PaintedUsernameRenderProvider,
+} from './PaintedUsernameRenderContext';
+import {
+  buildPaintCssInlineStyle,
+  buildPaintCssTextStyle,
+} from './util/buildPaintCssStyle';
+import type { PaintDropShadowMode } from './util/paintLayer';
+
+function escapeHtml(text: string): string {
+  return text
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+const PaintedSpanRenderer: CustomTextualRenderer = ({
+  TDefaultRenderer,
+  tnode,
+  ...props
+}) => {
+  if (tnode.attributes['data-seventv-painted-text'] !== 'true') {
+    return <TDefaultRenderer tnode={tnode} {...props} />;
+  }
+
+  return <PaintedUsernameNativeLayers />;
+};
+
+interface PaintedUsernameHtmlProps {
+  displayUsername: string;
+  fallbackColor: string;
+  paint: PaintData;
+  renderContext: PaintedUsernameRenderContextValue;
+  sevenTvPaintDropShadows: PaintDropShadowMode;
+  usernameMetricsStyle: PaintedUsernameRenderContextValue['usernameTextStyle'];
+}
+
+/**
+ * Renders a 7TV paint via @native-html/render using extension-style CSS.
+ *
+ * Web applies `background-clip: text`, `filter: drop-shadow()`, and
+ * `-webkit-text-stroke` from {@link buildPaintCssTextStyle}. Native falls back
+ * to layered MaskedView rendering because those CSS properties are not
+ * supported by the native HTML engine on iOS and Android.
+ */
+export function PaintedUsernameHtml({
+  displayUsername,
+  fallbackColor,
+  paint,
+  renderContext,
+  sevenTvPaintDropShadows,
+  usernameMetricsStyle,
+}: PaintedUsernameHtmlProps) {
+  const { width } = useWindowDimensions();
+  const inlineCss = buildPaintCssInlineStyle(
+    paint,
+    fallbackColor,
+    sevenTvPaintDropShadows,
+  );
+
+  const source = useMemo(
+    () => ({
+      html: `<span class="seventv-painted-content seventv-paint" data-seventv-paint-id="${paint.id}" data-seventv-painted-text="true" style="${inlineCss}">${escapeHtml(displayUsername)}</span>`,
+    }),
+    [displayUsername, inlineCss, paint.id],
+  );
+
+  const flatMetrics = StyleSheet.flatten(usernameMetricsStyle) ?? {};
+
+  const tagsStyles = useMemo(
+    () =>
+      Platform.OS === 'web'
+        ? {
+            span: {
+              ...flatMetrics,
+              ...buildPaintCssTextStyle(
+                paint,
+                fallbackColor,
+                sevenTvPaintDropShadows,
+              ),
+            },
+          }
+        : {
+            span: flatMetrics,
+          },
+    [fallbackColor, flatMetrics, paint, sevenTvPaintDropShadows],
+  );
+
+  const renderers = useMemo(
+    () =>
+      Platform.OS === 'web'
+        ? undefined
+        : {
+            span: PaintedSpanRenderer,
+          },
+    [],
+  );
+
+  return (
+    <PaintedUsernameRenderProvider value={renderContext}>
+      <RenderHTML
+        contentWidth={width}
+        defaultTextProps={{ allowFontScaling: false }}
+        renderers={renderers}
+        source={source}
+        tagsStyles={tagsStyles}
+      />
+    </PaintedUsernameRenderProvider>
+  );
+}

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameNativeLayers.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameNativeLayers.tsx
@@ -1,0 +1,92 @@
+import { type StyleProp, StyleSheet, TextStyle, View } from 'react-native';
+
+import { chatLineMetrics } from '../RichChatMessage.styles';
+import { PaintedUsernameDropShadowLayer } from './PaintedUsernameDropShadowLayer';
+import { PaintedUsernameMaskedFill } from './PaintedUsernameMaskedFill';
+import { usePaintedUsernameRenderContext } from './PaintedUsernameRenderContext';
+import { PaintedUsernameStrokeLayer } from './PaintedUsernameStrokeLayer';
+import { getPaintDropShadows, paintShadowKey } from './util/paintLayer';
+import {
+  buildPaintUsernameTextStyle,
+  getPaintTextShadows,
+  getPaintTextStroke,
+  scaleNativeDropShadow,
+} from './util/paintTextStyle';
+
+/**
+ * Native fallback for painted usernames when CSS `filter` / `background-clip`
+ * cannot be applied by @native-html/render on iOS and Android.
+ */
+export function PaintedUsernameNativeLayers() {
+  const context = usePaintedUsernameRenderContext();
+  if (!context) {
+    return null;
+  }
+
+  const {
+    displayUsername,
+    fallbackColor,
+    paint,
+    sevenTvPaintDropShadows,
+    usernameTextStyle,
+  } = context;
+
+  const paintTextStyle = buildPaintUsernameTextStyle(paint);
+  const dropShadows = getPaintDropShadows(paint, sevenTvPaintDropShadows).map(
+    scaleNativeDropShadow,
+  );
+  const textShadows = getPaintTextShadows(paint);
+  const stroke = getPaintTextStroke(paint);
+
+  const maskTextStyle = [
+    styles.maskText,
+    usernameTextStyle,
+    paintTextStyle,
+  ] as StyleProp<TextStyle>;
+
+  const underlayShadows = [
+    ...dropShadows.map(shadow => ({ shadow, source: 'drop' as const })),
+    ...textShadows.map(shadow => ({ shadow, source: 'text' as const })),
+  ];
+
+  return (
+    <View style={styles.paintedWrapper}>
+      {underlayShadows.map(({ shadow, source }, index) => (
+        <PaintedUsernameDropShadowLayer
+          // Static, never-reordered list; index disambiguates identical shadows.
+          // eslint-disable-next-line react-doctor/no-array-index-as-key
+          key={`${source}-${index}-${paintShadowKey(shadow)}`}
+          displayUsername={displayUsername}
+          maskTextStyle={maskTextStyle}
+          shadow={shadow}
+        />
+      ))}
+      <PaintedUsernameMaskedFill
+        displayUsername={displayUsername}
+        fallbackColor={fallbackColor}
+        paint={paint}
+        maskTextStyle={maskTextStyle}
+      />
+      {stroke ? (
+        <PaintedUsernameStrokeLayer
+          displayUsername={displayUsername}
+          maskTextStyle={maskTextStyle}
+          stroke={stroke}
+        />
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  maskText: {
+    ...chatLineMetrics.comfortable,
+    color: 'black',
+    fontWeight: 'bold',
+  },
+  paintedWrapper: {
+    alignSelf: 'flex-start',
+    overflow: 'visible',
+    position: 'relative',
+  },
+});

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameRenderContext.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameRenderContext.tsx
@@ -1,0 +1,35 @@
+import { createContext, useContext } from 'react';
+import type { StyleProp, TextStyle } from 'react-native';
+
+import type { PaintData } from '@app/types/seventv/cosmetics';
+
+import type { PaintDropShadowMode } from './util/paintLayer';
+
+export interface PaintedUsernameRenderContextValue {
+  displayUsername: string;
+  fallbackColor: string;
+  paint: PaintData;
+  sevenTvPaintDropShadows: PaintDropShadowMode;
+  usernameTextStyle?: StyleProp<TextStyle>;
+}
+
+const PaintedUsernameRenderContext =
+  createContext<PaintedUsernameRenderContextValue | null>(null);
+
+export function PaintedUsernameRenderProvider({
+  children,
+  value,
+}: {
+  children: React.ReactNode;
+  value: PaintedUsernameRenderContextValue;
+}) {
+  return (
+    <PaintedUsernameRenderContext.Provider value={value}>
+      {children}
+    </PaintedUsernameRenderContext.Provider>
+  );
+}
+
+export function usePaintedUsernameRenderContext(): PaintedUsernameRenderContextValue | null {
+  return useContext(PaintedUsernameRenderContext);
+}

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameStrokeLayer.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameStrokeLayer.tsx
@@ -1,0 +1,69 @@
+import { type StyleProp, StyleSheet, TextStyle } from 'react-native';
+
+import { Text } from '@app/components/ui/Text/Text';
+import type { PaintTextStroke } from '@app/types/seventv/cosmetics';
+import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
+
+interface PaintedUsernameStrokeLayerProps {
+  displayUsername: string;
+  maskTextStyle: StyleProp<TextStyle>;
+  stroke: PaintTextStroke;
+}
+
+const STROKE_UNIT_OFFSETS = [
+  { width: -1, height: 0 },
+  { width: 1, height: 0 },
+  { width: 0, height: -1 },
+  { width: 0, height: 1 },
+  { width: -1, height: -1 },
+  { width: -1, height: 1 },
+  { width: 1, height: -1 },
+  { width: 1, height: 1 },
+] as const;
+
+/**
+ * Approximates `-webkit-text-stroke` on top of the painted fill by ringing
+ * transparent glyphs with same-position text-shadow copies in the stroke color.
+ */
+export function PaintedUsernameStrokeLayer({
+  displayUsername,
+  maskTextStyle,
+  stroke,
+}: PaintedUsernameStrokeLayerProps) {
+  const strokeColor = sevenTvColorToCss(stroke.color);
+  const radius = Math.max(1, Math.round(stroke.width));
+  const offsets = STROKE_UNIT_OFFSETS.map(offset => ({
+    width: offset.width * radius,
+    height: offset.height * radius,
+  }));
+
+  return (
+    <>
+      {offsets.map(offset => (
+        <Text
+          key={`stroke-${offset.width}-${offset.height}`}
+          pointerEvents='none'
+          style={[
+            styles.strokeText,
+            maskTextStyle,
+            {
+              color: 'transparent',
+              textShadowColor: strokeColor,
+              textShadowOffset: offset,
+              textShadowRadius: 0,
+            },
+          ]}
+        >
+          {displayUsername}
+        </Text>
+      ))}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  strokeText: {
+    position: 'absolute',
+    zIndex: 1,
+  },
+});

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/buildPaintCssStyle.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/buildPaintCssStyle.test.ts
@@ -3,6 +3,7 @@ import type { PaintData } from '@app/types/seventv/cosmetics';
 import {
   buildPaintCssInlineStyle,
   buildPaintCssTextStyle,
+  type PaintCssTextStyle,
 } from '../buildPaintCssStyle';
 
 function rgbaToSevenTvColor(
@@ -73,7 +74,7 @@ const roseGoldPaint: PaintData = {
 
 describe('buildPaintCssTextStyle', () => {
   test('clips gradient backgrounds to text and stacks drop-shadow filters', () => {
-    expect(buildPaintCssTextStyle(roseGoldPaint, '#ffffff', 1)).toEqual({
+    expect(buildPaintCssTextStyle(roseGoldPaint, '#ffffff', 1)).toEqual<PaintCssTextStyle>({
       backgroundClip: 'text',
       WebkitBackgroundClip: 'text',
       WebkitTextFillColor: 'transparent',

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/buildPaintCssStyle.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/buildPaintCssStyle.test.ts
@@ -1,0 +1,113 @@
+import type { PaintData } from '@app/types/seventv/cosmetics';
+
+import {
+  buildPaintCssInlineStyle,
+  buildPaintCssTextStyle,
+} from '../buildPaintCssStyle';
+
+function rgbaToSevenTvColor(
+  r: number,
+  g: number,
+  b: number,
+  a: number,
+): number {
+  // eslint-disable-next-line no-bitwise
+  return ((r << 24) | (g << 16) | (b << 8) | a) >>> 0;
+}
+
+const roseGoldPaint: PaintData = {
+  id: 'rose-gold',
+  name: 'Rose Gold',
+  color: null,
+  function: 'LINEAR_GRADIENT',
+  repeat: false,
+  angle: 0,
+  shape: 'circle',
+  image_url: '',
+  layers: {
+    0: {
+      function: 'LINEAR_GRADIENT',
+      angle: 0,
+      repeat: false,
+      shape: 'circle',
+      image_url: '',
+      canvas_repeat: 'unset',
+      at: null,
+      size: null,
+      stops: {
+        0: { at: 0, color: rgbaToSevenTvColor(255, 97, 129, 255) },
+        1: { at: 0.4, color: rgbaToSevenTvColor(254, 155, 144, 255) },
+        2: { at: 1, color: rgbaToSevenTvColor(255, 117, 147, 255) },
+        length: 3,
+      },
+    },
+    length: 1,
+  },
+  shadows: {
+    0: {
+      color: rgbaToSevenTvColor(254, 118, 148, 255),
+      radius: 0.1,
+      x_offset: 0,
+      y_offset: 0,
+    },
+    1: {
+      color: rgbaToSevenTvColor(255, 77, 115, 255),
+      radius: 4,
+      x_offset: 0,
+      y_offset: 0,
+    },
+    length: 2,
+  },
+  textStyle: {
+    stroke: {
+      color: rgbaToSevenTvColor(255, 255, 255, 255),
+      width: 1,
+    },
+  },
+  stops: {
+    0: { at: 0, color: rgbaToSevenTvColor(255, 97, 129, 255) },
+    1: { at: 1, color: rgbaToSevenTvColor(255, 117, 147, 255) },
+    length: 2,
+  },
+};
+
+describe('buildPaintCssTextStyle', () => {
+  test('clips gradient backgrounds to text and stacks drop-shadow filters', () => {
+    expect(buildPaintCssTextStyle(roseGoldPaint, '#ffffff', 1)).toEqual({
+      backgroundClip: 'text',
+      WebkitBackgroundClip: 'text',
+      WebkitTextFillColor: 'transparent',
+      backgroundColor: 'currentColor',
+      color: 'inherit',
+      fontWeight: '700',
+      backgroundImage:
+        'linear-gradient(0deg, rgba(255, 97, 129, 1.000) 0%, rgba(254, 155, 144, 1.000) 40%, rgba(255, 117, 147, 1.000) 100%)',
+      backgroundPosition: '',
+      backgroundSize: '',
+      backgroundRepeat: 'unset',
+      filter:
+        'drop-shadow(0px 0px 0.1px rgba(254, 118, 148, 1.000)) drop-shadow(0px 0px 4px rgba(255, 77, 115, 1.000))',
+      WebkitTextStrokeWidth: '1px',
+      WebkitTextStrokeColor: 'rgba(255, 255, 255, 1.000)',
+    });
+  });
+
+  test('limits drop-shadow filters when mode is 2', () => {
+    expect(buildPaintCssTextStyle(roseGoldPaint, '#ffffff', 2).filter).toBe(
+      'drop-shadow(0px 0px 0.1px rgba(254, 118, 148, 1.000))',
+    );
+  });
+
+  test('omits drop-shadow filters when mode is 0', () => {
+    const style = buildPaintCssTextStyle(roseGoldPaint, '#ffffff', 0);
+    expect('filter' in style).toBe(false);
+  });
+});
+
+describe('buildPaintCssInlineStyle', () => {
+  test('serializes extension-style paint CSS for inline HTML', () => {
+    expect(buildPaintCssInlineStyle(roseGoldPaint, '#ffffff', 1)).toEqual(
+      'background-clip: text; -webkit-background-clip: text; -webkit-text-fill-color: transparent; font-weight: 700; color: inherit; background-color: currentColor; background-image: linear-gradient(0deg, rgba(255, 97, 129, 1.000) 0%, rgba(254, 155, 144, 1.000) 40%, rgba(255, 117, 147, 1.000) 100%); background-repeat: unset; filter: drop-shadow(0px 0px 0.1px rgba(254, 118, 148, 1.000)) drop-shadow(0px 0px 4px rgba(255, 77, 115, 1.000)); -webkit-text-stroke-width: 1px; -webkit-text-stroke-color: rgba(255, 255, 255, 1.000)',
+    );
+  });
+});

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/buildPaintCssStyle.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/buildPaintCssStyle.test.ts
@@ -74,7 +74,9 @@ const roseGoldPaint: PaintData = {
 
 describe('buildPaintCssTextStyle', () => {
   test('clips gradient backgrounds to text and stacks drop-shadow filters', () => {
-    expect(buildPaintCssTextStyle(roseGoldPaint, '#ffffff', 1)).toEqual<PaintCssTextStyle>({
+    expect(
+      buildPaintCssTextStyle(roseGoldPaint, '#ffffff', 1),
+    ).toEqual<PaintCssTextStyle>({
       backgroundClip: 'text',
       WebkitBackgroundClip: 'text',
       WebkitTextFillColor: 'transparent',

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/paintTextStyle.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/paintTextStyle.test.ts
@@ -1,0 +1,43 @@
+import {
+  NATIVE_DROP_SHADOW_RADIUS_MULTIPLIER,
+  scaleNativeDropShadow,
+} from '../paintTextStyle';
+
+function rgbaToSevenTvColor(
+  r: number,
+  g: number,
+  b: number,
+  a: number,
+): number {
+  // eslint-disable-next-line no-bitwise
+  return ((r << 24) | (g << 16) | (b << 8) | a) >>> 0;
+}
+
+describe('scaleNativeDropShadow', () => {
+  test('multiplies drop-shadow radius to match extension glow on native', () => {
+    expect(
+      scaleNativeDropShadow({
+        color: rgbaToSevenTvColor(255, 0, 0, 255),
+        radius: 2,
+        x_offset: 1,
+        y_offset: -1,
+      }),
+    ).toEqual({
+      color: rgbaToSevenTvColor(255, 0, 0, 255),
+      radius: 2 * NATIVE_DROP_SHADOW_RADIUS_MULTIPLIER,
+      x_offset: 1,
+      y_offset: -1,
+    });
+  });
+
+  test('leaves zero-radius shadows unchanged', () => {
+    const shadow = {
+      color: rgbaToSevenTvColor(255, 0, 0, 255),
+      radius: 0,
+      x_offset: 0,
+      y_offset: 0,
+    };
+
+    expect(scaleNativeDropShadow(shadow)).toEqual(shadow);
+  });
+});

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/buildPaintCssStyle.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/buildPaintCssStyle.ts
@@ -1,0 +1,214 @@
+import type { TextStyle } from 'react-native';
+
+import { indexedCollectionToArray } from '@app/services/ws/util/indexedCollection';
+import type {
+  PaintData,
+  PaintLayerData,
+  PaintShadow,
+} from '@app/types/seventv/cosmetics';
+import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
+
+import {
+  getPaintDropShadows,
+  getPaintLayers,
+  type PaintDropShadowMode,
+} from './paintLayer';
+import {
+  buildPaintUsernameTextStyle,
+  getPaintTextShadows,
+  getPaintTextStroke,
+} from './paintTextStyle';
+
+type PaintCssBackground = {
+  image: string;
+  position: string;
+  size: string;
+  repeat: string;
+};
+
+/**
+ * Mirrors `createGradientFromPaint` in the 7TV extension.
+ */
+function cssGradientFunction(layer: PaintLayerData): string {
+  const stops = indexedCollectionToArray(layer.stops)
+    .slice()
+    .sort((a, b) => a.at - b.at)
+    .map(stop => `${sevenTvColorToCss(stop.color)} ${stop.at * 100}%`);
+
+  if (layer.function === 'URL') {
+    return layer.image_url ? `url("${layer.image_url}")` : 'none';
+  }
+
+  const prefix = layer.repeat ? 'repeating-' : '';
+  if (layer.function === 'RADIAL_GRADIENT') {
+    return `${prefix}radial-gradient(${layer.shape ?? 'circle'}, ${stops.join(', ')})`;
+  }
+
+  return `${prefix}linear-gradient(${layer.angle ?? 0}deg, ${stops.join(', ')})`;
+}
+
+function cssBackgroundForLayer(layer: PaintLayerData): PaintCssBackground {
+  const at = layer.at;
+  const size = layer.size;
+
+  return {
+    image: cssGradientFunction(layer),
+    position: at && at.length === 2 ? `${at[0] * 100}% ${at[1] * 100}%` : '',
+    size:
+      size && size.length === 2 ? `${size[0] * 100}% ${size[1] * 100}%` : '',
+    repeat:
+      layer.canvas_repeat && layer.canvas_repeat !== 'unset'
+        ? layer.canvas_repeat
+        : 'unset',
+  };
+}
+
+/**
+ * Mirrors `createFilterDropshadow` in the 7TV extension.
+ */
+function cssDropShadowFilter(shadow: PaintShadow): string {
+  return `drop-shadow(${shadow.x_offset}px ${shadow.y_offset}px ${shadow.radius}px ${sevenTvColorToCss(shadow.color)})`;
+}
+
+function cssTextShadows(shadows: PaintShadow[]): string | undefined {
+  if (shadows.length === 0) {
+    return undefined;
+  }
+
+  return shadows
+    .map(
+      shadow =>
+        `${shadow.x_offset}px ${shadow.y_offset}px ${shadow.radius}px ${sevenTvColorToCss(shadow.color)}`,
+    )
+    .join(', ');
+}
+
+function buildPaintCssBackgrounds(paint: PaintData): PaintCssBackground[] {
+  return getPaintLayers(paint).map(cssBackgroundForLayer);
+}
+
+/**
+ * Builds the CSS paint styles the 7TV extension applies per paint id
+ * (background-clip text, filter drop-shadows, text stroke, etc.).
+ */
+export function buildPaintCssTextStyle(
+  paint: PaintData,
+  fallbackColor: string,
+  dropShadowMode: PaintDropShadowMode,
+): TextStyle {
+  const backgrounds = buildPaintCssBackgrounds(paint);
+  const paintTextStyle = buildPaintUsernameTextStyle(paint);
+  const textShadows = getPaintTextShadows(paint);
+  const stroke = getPaintTextStroke(paint);
+  const dropShadows = getPaintDropShadows(paint, dropShadowMode);
+  const filter =
+    dropShadows.length > 0
+      ? dropShadows.map(cssDropShadowFilter).join(' ')
+      : undefined;
+
+  // Mirror `.seventv-painted-content` + per-paint rules from the extension:
+  // `background-color: currentcolor` with `color: inherit` when the paint has
+  // no solid color, otherwise an explicit packed RGBA on both properties.
+  const paintCssColor =
+    paint.color !== null ? sevenTvColorToCss(paint.color) : undefined;
+
+  const style: TextStyle = {
+    ...paintTextStyle,
+    backgroundClip: 'text',
+    // @ts-expect-error RN web accepts vendor-prefixed clip properties.
+    WebkitBackgroundClip: 'text',
+    // @ts-expect-error RN web accepts vendor-prefixed fill properties.
+    WebkitTextFillColor: 'transparent',
+    fontWeight: paintTextStyle.fontWeight ?? '700',
+    ...(paintCssColor
+      ? { color: paintCssColor, backgroundColor: paintCssColor }
+      : { color: 'inherit', backgroundColor: 'currentColor' }),
+    ...(backgrounds.length > 0
+      ? {
+          backgroundImage: backgrounds.map(entry => entry.image).join(', '),
+          backgroundPosition: backgrounds
+            .map(entry => entry.position)
+            .join(', '),
+          backgroundSize: backgrounds.map(entry => entry.size).join(', '),
+          backgroundRepeat: backgrounds.map(entry => entry.repeat).join(', '),
+        }
+      : {}),
+    ...(filter ? { filter } : {}),
+    ...(textShadows.length > 0
+      ? { textShadow: cssTextShadows(textShadows) }
+      : {}),
+    ...(stroke
+      ? {
+          // @ts-expect-error RN web maps vendor-prefixed stroke properties.
+          WebkitTextStrokeWidth: `${stroke.width}px`,
+          // @ts-expect-error RN web maps vendor-prefixed stroke properties.
+          WebkitTextStrokeColor: sevenTvColorToCss(stroke.color),
+        }
+      : {}),
+  };
+
+  // `fallbackColor` is only used when the paint has no layer stops; keep the
+  // parameter so callers can pass the username tint without a second lookup.
+  void fallbackColor;
+
+  return style;
+}
+
+/**
+ * Serializes extension-style paint CSS for an inline HTML `style` attribute.
+ */
+export function buildPaintCssInlineStyle(
+  paint: PaintData,
+  fallbackColor: string,
+  dropShadowMode: PaintDropShadowMode,
+): string {
+  const style = buildPaintCssTextStyle(paint, fallbackColor, dropShadowMode);
+  const declarations: string[] = [
+    'background-clip: text',
+    '-webkit-background-clip: text',
+    '-webkit-text-fill-color: transparent',
+    `font-weight: ${style.fontWeight ?? 700}`,
+  ];
+
+  if (style.color) {
+    declarations.push(`color: ${String(style.color)}`);
+  }
+  if (style.backgroundColor) {
+    declarations.push(`background-color: ${String(style.backgroundColor)}`);
+  }
+  if (style.backgroundImage) {
+    declarations.push(`background-image: ${String(style.backgroundImage)}`);
+  }
+  if (style.backgroundPosition) {
+    declarations.push(
+      `background-position: ${String(style.backgroundPosition)}`,
+    );
+  }
+  if (style.backgroundSize) {
+    declarations.push(`background-size: ${String(style.backgroundSize)}`);
+  }
+  if (style.backgroundRepeat) {
+    declarations.push(`background-repeat: ${String(style.backgroundRepeat)}`);
+  }
+  if (style.filter) {
+    declarations.push(`filter: ${String(style.filter)}`);
+  }
+  if (style.textShadow) {
+    declarations.push(`text-shadow: ${String(style.textShadow)}`);
+  }
+  if ('WebkitTextStrokeWidth' in style && style.WebkitTextStrokeWidth) {
+    declarations.push(
+      `-webkit-text-stroke-width: ${String(style.WebkitTextStrokeWidth)}`,
+    );
+  }
+  if ('WebkitTextStrokeColor' in style && style.WebkitTextStrokeColor) {
+    declarations.push(
+      `-webkit-text-stroke-color: ${String(style.WebkitTextStrokeColor)}`,
+    );
+  }
+  if (style.textTransform) {
+    declarations.push(`text-transform: ${String(style.textTransform)}`);
+  }
+
+  return declarations.join('; ');
+}

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/buildPaintCssStyle.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/buildPaintCssStyle.ts
@@ -27,6 +27,23 @@ type PaintCssBackground = {
 };
 
 /**
+ * Web-only paint styles that RN's TextStyle type does not declare.
+ */
+export type PaintCssTextStyle = Omit<TextStyle, 'filter' | 'textShadow'> & {
+  backgroundClip?: string;
+  WebkitBackgroundClip?: string;
+  WebkitTextFillColor?: string;
+  backgroundImage?: string;
+  backgroundPosition?: string;
+  backgroundSize?: string;
+  backgroundRepeat?: string;
+  filter?: string;
+  textShadow?: string;
+  WebkitTextStrokeWidth?: string;
+  WebkitTextStrokeColor?: string;
+};
+
+/**
  * Mirrors `createGradientFromPaint` in the 7TV extension.
  */
 function cssGradientFunction(layer: PaintLayerData): string {
@@ -36,7 +53,7 @@ function cssGradientFunction(layer: PaintLayerData): string {
     .map(stop => `${sevenTvColorToCss(stop.color)} ${stop.at * 100}%`);
 
   if (layer.function === 'URL') {
-    return layer.image_url ? `url("${layer.image_url}")` : 'none';
+    return layer.image_url ? `url('${layer.image_url}')` : 'none';
   }
 
   const prefix = layer.repeat ? 'repeating-' : '';
@@ -95,7 +112,7 @@ export function buildPaintCssTextStyle(
   paint: PaintData,
   fallbackColor: string,
   dropShadowMode: PaintDropShadowMode,
-): TextStyle {
+): PaintCssTextStyle {
   const backgrounds = buildPaintCssBackgrounds(paint);
   const paintTextStyle = buildPaintUsernameTextStyle(paint);
   const textShadows = getPaintTextShadows(paint);
@@ -112,12 +129,10 @@ export function buildPaintCssTextStyle(
   const paintCssColor =
     paint.color !== null ? sevenTvColorToCss(paint.color) : undefined;
 
-  const style: TextStyle = {
+  const style = {
     ...paintTextStyle,
     backgroundClip: 'text',
-    // @ts-expect-error RN web accepts vendor-prefixed clip properties.
     WebkitBackgroundClip: 'text',
-    // @ts-expect-error RN web accepts vendor-prefixed fill properties.
     WebkitTextFillColor: 'transparent',
     fontWeight: paintTextStyle.fontWeight ?? '700',
     ...(paintCssColor
@@ -139,13 +154,11 @@ export function buildPaintCssTextStyle(
       : {}),
     ...(stroke
       ? {
-          // @ts-expect-error RN web maps vendor-prefixed stroke properties.
           WebkitTextStrokeWidth: `${stroke.width}px`,
-          // @ts-expect-error RN web maps vendor-prefixed stroke properties.
           WebkitTextStrokeColor: sevenTvColorToCss(stroke.color),
         }
       : {}),
-  };
+  } as PaintCssTextStyle;
 
   // `fallbackColor` is only used when the paint has no layer stops; keep the
   // parameter so callers can pass the username tint without a second lookup.
@@ -196,12 +209,12 @@ export function buildPaintCssInlineStyle(
   if (style.textShadow) {
     declarations.push(`text-shadow: ${String(style.textShadow)}`);
   }
-  if ('WebkitTextStrokeWidth' in style && style.WebkitTextStrokeWidth) {
+  if (style.WebkitTextStrokeWidth) {
     declarations.push(
       `-webkit-text-stroke-width: ${String(style.WebkitTextStrokeWidth)}`,
     );
   }
-  if ('WebkitTextStrokeColor' in style && style.WebkitTextStrokeColor) {
+  if (style.WebkitTextStrokeColor) {
     declarations.push(
       `-webkit-text-stroke-color: ${String(style.WebkitTextStrokeColor)}`,
     );

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/buildPaintCssStyle.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/buildPaintCssStyle.ts
@@ -110,7 +110,7 @@ function buildPaintCssBackgrounds(paint: PaintData): PaintCssBackground[] {
  */
 export function buildPaintCssTextStyle(
   paint: PaintData,
-  fallbackColor: string,
+  _fallbackColor: string,
   dropShadowMode: PaintDropShadowMode,
 ): PaintCssTextStyle {
   const backgrounds = buildPaintCssBackgrounds(paint);
@@ -159,10 +159,6 @@ export function buildPaintCssTextStyle(
         }
       : {}),
   } as PaintCssTextStyle;
-
-  // `fallbackColor` is only used when the paint has no layer stops; keep the
-  // parameter so callers can pass the username tint without a second lookup.
-  void fallbackColor;
 
   return style;
 }

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer.ts
@@ -223,6 +223,18 @@ function computeLayerGradientConfig(
   let stops = indexedCollectionToArray<PaintStop>(layer.stops)
     .slice()
     .sort((a, b) => a.at - b.at);
+
+  // Qt/CSS hard-edge stops share a position; nudge later stops forward slightly.
+  let lastStop = -1;
+  stops = stops.map(stop => {
+    let at = stop.at;
+    if (at <= lastStop) {
+      at = lastStop + 0.0000001;
+    }
+    lastStop = at;
+    return at === stop.at ? stop : { ...stop, at };
+  });
+
   if (layer.repeat) {
     stops = expandRepeatingStops(stops);
   }

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintTextStyle.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintTextStyle.ts
@@ -19,11 +19,8 @@ const textStyleCache = new WeakMap<PaintData, TextStyle>();
 const textShadowsCache = new WeakMap<PaintData, PaintShadow[]>();
 
 /**
- * Styles that change glyph shape (weight, transform). These must be applied
- * to the mask text, the fill sizer, and every shadow underlay so all layers
- * share identical metrics. Stroke and shadows are rendered as separate
- * underlay layers instead, matching the extension's compositing order
- * (shadow behind stroke behind fill).
+ * Styles that change glyph shape (weight, transform). Applied to every painted
+ * username layer so mask, fill, and shadow copies share identical metrics.
  */
 export function buildPaintUsernameTextStyle(paint: PaintData): TextStyle {
   const cached = textStyleCache.get(paint);
@@ -70,19 +67,6 @@ export function getPaintTextShadows(paint: PaintData): PaintShadow[] {
 export function getPaintTextStroke(paint: PaintData): PaintTextStroke | null {
   const stroke = paint.textStyle?.stroke;
   return stroke?.width ? stroke : null;
-}
-
-/**
- * Approximates -webkit-text-stroke with a same-position glyph copy in the
- * stroke color, blurred outward by the stroke width.
- */
-export function paintStrokeToShadow(stroke: PaintTextStroke): PaintShadow {
-  return {
-    color: stroke.color,
-    radius: stroke.width,
-    x_offset: 0,
-    y_offset: 0,
-  };
 }
 
 export function paintShadowTextColor(shadow: PaintShadow): string {

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintTextStyle.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintTextStyle.ts
@@ -8,10 +8,13 @@ import type {
 } from '@app/types/seventv/cosmetics';
 import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
 
-// Paint-pure derivations, memoised on the paint object so every user wearing a
-// shared paint reuses one computed result (the 7TV extension computes each
-// paint's style once, not per user). WeakMap-keyed so entries drop with the
-// paint; no eviction needed.
+/**
+ * CSS `filter: drop-shadow()` glow reads much larger than RN `textShadowRadius`
+ * at the same numeric radius. Chatterino 7TV uses the same multiplier to match
+ * the browser extension on native Qt filters.
+ */
+export const NATIVE_DROP_SHADOW_RADIUS_MULTIPLIER = 3;
+
 const textStyleCache = new WeakMap<PaintData, TextStyle>();
 const textShadowsCache = new WeakMap<PaintData, PaintShadow[]>();
 
@@ -84,4 +87,19 @@ export function paintStrokeToShadow(stroke: PaintTextStroke): PaintShadow {
 
 export function paintShadowTextColor(shadow: PaintShadow): string {
   return sevenTvColorToCss(shadow.color);
+}
+
+/**
+ * Scales paint drop-shadow radius on native so glow layers match the extension.
+ */
+export function scaleNativeDropShadow(shadow: PaintShadow): PaintShadow {
+  const radius = shadow.radius ?? 0;
+  if (radius <= 0) {
+    return shadow;
+  }
+
+  return {
+    ...shadow,
+    radius: radius * NATIVE_DROP_SHADOW_RADIUS_MULTIPLIER,
+  };
 }

--- a/src/components/Chat/components/ChatMessage/__tests__/CosmeticUsername.test.tsx
+++ b/src/components/Chat/components/ChatMessage/__tests__/CosmeticUsername.test.tsx
@@ -1,7 +1,6 @@
-import { act, render } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import { Image } from 'expo-image';
 
-import { chatScrollActivity } from '@app/components/Chat/util/chatScrollActivity';
 import type { PaintData } from '@app/types/seventv/cosmetics';
 
 import { PaintedUsername } from '../CosmeticUsername/CosmeticUsername';
@@ -546,42 +545,6 @@ describe('PaintedUsername', () => {
       );
 
       expect(getAllByText('NullColor:').length).toBeGreaterThanOrEqual(1);
-    });
-  });
-
-  describe('Scroll-gated flatten', () => {
-    afterEach(() => {
-      act(() => {
-        chatScrollActivity.reset();
-      });
-    });
-
-    const gradientPaint = () =>
-      createPaintData({
-        stops: {
-          0: { at: 0, color: rgbaToSevenTvColor(255, 0, 0, 255) },
-          1: { at: 1, color: rgbaToSevenTvColor(0, 0, 255, 255) },
-          length: 2,
-        },
-      });
-
-    test('renders the painted MaskedView when the list is idle', () => {
-      const { getByTestId } = render(
-        <PaintedUsername username='Idle' paint={gradientPaint()} />,
-      );
-
-      expect(getByTestId('masked-view')).toBeOnTheScreen();
-    });
-
-    test('skips the MaskedView offscreen pass while actively scrolling', () => {
-      chatScrollActivity.poke();
-
-      const { queryByTestId, getAllByText } = render(
-        <PaintedUsername username='Scrolling' paint={gradientPaint()} />,
-      );
-
-      expect(queryByTestId('masked-view')).not.toBeOnTheScreen();
-      expect(getAllByText('Scrolling:').length).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/src/components/Chat/components/ChatMessage/__tests__/__snapshots__/CosmeticUsername.test.tsx.snap
+++ b/src/components/Chat/components/ChatMessage/__tests__/__snapshots__/CosmeticUsername.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`PaintedUsername Snapshots should match snapshot with URL paint (solid c
   style={
     {
       "alignSelf": "flex-start",
+      "overflow": "visible",
       "position": "relative",
     }
   }
@@ -254,6 +255,7 @@ exports[`PaintedUsername Snapshots should match snapshot with linear gradient pa
   style={
     {
       "alignSelf": "flex-start",
+      "overflow": "visible",
       "position": "relative",
     }
   }
@@ -297,7 +299,7 @@ exports[`PaintedUsername Snapshots should match snapshot with linear gradient pa
               "height": 0,
               "width": 0,
             },
-            "textShadowRadius": 0.1,
+            "textShadowRadius": 0.30000000000000004,
             "top": 0,
           },
         ],
@@ -535,6 +537,7 @@ exports[`PaintedUsername Snapshots should match snapshot with long username 1`] 
   style={
     {
       "alignSelf": "flex-start",
+      "overflow": "visible",
       "position": "relative",
     }
   }
@@ -767,6 +770,7 @@ exports[`PaintedUsername Snapshots should match snapshot with multiple shadows 1
   style={
     {
       "alignSelf": "flex-start",
+      "overflow": "visible",
       "position": "relative",
     }
   }
@@ -810,7 +814,7 @@ exports[`PaintedUsername Snapshots should match snapshot with multiple shadows 1
               "height": 0,
               "width": 0,
             },
-            "textShadowRadius": 0.1,
+            "textShadowRadius": 0.30000000000000004,
             "top": 0,
           },
         ],
@@ -859,7 +863,7 @@ exports[`PaintedUsername Snapshots should match snapshot with multiple shadows 1
               "height": 0,
               "width": 0,
             },
-            "textShadowRadius": 1,
+            "textShadowRadius": 3,
             "top": 0,
           },
         ],
@@ -1097,6 +1101,7 @@ exports[`PaintedUsername Snapshots should match snapshot with radial gradient pa
   style={
     {
       "alignSelf": "flex-start",
+      "overflow": "visible",
       "position": "relative",
     }
   }
@@ -1140,7 +1145,7 @@ exports[`PaintedUsername Snapshots should match snapshot with radial gradient pa
               "height": 0,
               "width": 0,
             },
-            "textShadowRadius": 0.1,
+            "textShadowRadius": 0.30000000000000004,
             "top": 0,
           },
         ],


### PR DESCRIPTION
## Summary
- Add extension-style CSS paint builders (`buildPaintCssStyle`) with unit tests
- Add `PaintedUsernameHtml` using `@native-html/render` for web-style paint compositing
- Add native layer fallback components (`PaintedUsernameNativeLayers`, stroke layer, render context) for platforms where CSS `filter` / `background-clip` cannot be applied via RenderHTML

## Test plan
- [x] `bun run test -- src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/buildPaintCssStyle.test.ts`
- [ ] Wire into `CosmeticUsername` in a follow-up PR
- [ ] Verify painted usernames render correctly on iOS, Android, and web