### PR TITLE
fix(stream): hardcode Twitch embed parent and detect misconfigured embeds

### DIFF
--- a/src/components/StreamPlayer/StreamPlayer.tsx
+++ b/src/components/StreamPlayer/StreamPlayer.tsx
@@ -24,12 +24,14 @@ import {
   buildTwitchClipPlayerUrl,
   buildTwitchContentGateAcceptScript,
   buildTwitchContentGateWatcherScript,
+  buildTwitchEmbedErrorWatcherScript,
   buildTwitchLatencyTrackerScript,
   buildTwitchLiveSyncScript,
   buildTwitchPipBridgeScript,
   buildTwitchPlayerAudioDefaultScript,
   buildTwitchPlayerQualityDefaultScript,
   buildTwitchPlayerStateScript,
+  resolveTwitchEmbedParent,
 } from './twitchPlayerSource';
 import type { StreamPlayerProps } from './types';
 import { usePlayerBridge } from './usePlayerBridge';
@@ -143,7 +145,12 @@ export const StreamPlayer = memo(function StreamPlayer({
   ref,
 }: StreamPlayerProps) {
   const { config } = useRemoteConfig();
-  const embedParent = config.twitchPlayerEmbedParent.value;
+  // Read the parent from remote config but hold it to the known-good host: a
+  // blank or malformed `parent` makes Twitch render "this embed is
+  // misconfigured" and breaks every stream.
+  const embedParent = resolveTwitchEmbedParent(
+    config.twitchPlayerEmbedParent.value,
+  );
   const webViewRef = useRef<WebView>(null);
   const needsInitRef = useRef(true);
   const authCompletionReloadTimeoutRef = useRef<ReturnType<
@@ -386,6 +393,11 @@ export const StreamPlayer = memo(function StreamPlayer({
    */
   const injectedJavaScript =
     TWITCH_AUTH_HELPER_SCRIPT +
+    '\n' +
+    // Detect Twitch's "this embed is misconfigured" error page (bad parent) on
+    // every player kind so a broken embed reports to Sentry instead of only
+    // timing out.
+    buildTwitchEmbedErrorWatcherScript() +
     '\n' +
     buildTwitchContentGateAcceptScript() +
     '\n' +

--- a/src/components/StreamPlayer/StreamPlayer.tsx
+++ b/src/components/StreamPlayer/StreamPlayer.tsx
@@ -3,7 +3,6 @@ import { InteractionManager, Platform, StyleSheet, View } from 'react-native';
 import type { WebViewMessageEvent } from 'react-native-webview';
 import { WebView } from 'react-native-webview';
 
-import { useRemoteConfig } from '@app/hooks/firebase/useRemoteConfig';
 import { useWatchTimeTracking } from '@app/hooks/useWatchTimeTracking';
 import { usePreference } from '@app/store/preferenceStore';
 import { theme } from '@app/styles/themes';
@@ -31,7 +30,6 @@ import {
   buildTwitchPlayerAudioDefaultScript,
   buildTwitchPlayerQualityDefaultScript,
   buildTwitchPlayerStateScript,
-  resolveTwitchEmbedParent,
 } from './twitchPlayerSource';
 import type { StreamPlayerProps } from './types';
 import { usePlayerBridge } from './usePlayerBridge';
@@ -144,13 +142,10 @@ export const StreamPlayer = memo(function StreamPlayer({
   width,
   ref,
 }: StreamPlayerProps) {
-  const { config } = useRemoteConfig();
-  // Read the parent from remote config but hold it to the known-good host: a
-  // blank or malformed `parent` makes Twitch render "this embed is
+  // Twitch's embed `parent`, hardcoded to Twitch's own domain, which its embed
+  // always accepts. A blank or invalid value makes Twitch render "this embed is
   // misconfigured" and breaks every stream.
-  const embedParent = resolveTwitchEmbedParent(
-    config.twitchPlayerEmbedParent.value,
-  );
+  const embedParent = 'www.twitch.tv';
   const webViewRef = useRef<WebView>(null);
   const needsInitRef = useRef(true);
   const authCompletionReloadTimeoutRef = useRef<ReturnType<

--- a/src/components/StreamPlayer/__tests__/StreamPlayer.test.tsx
+++ b/src/components/StreamPlayer/__tests__/StreamPlayer.test.tsx
@@ -51,19 +51,6 @@ jest.mock('@app/lib/sentry', () => ({
   startInactiveSpan: jest.fn(),
 }));
 
-jest.mock('@app/hooks/firebase/useRemoteConfig', () => ({
-  useRemoteConfig: jest.fn(() => ({
-    config: {
-      twitchPlayerEmbedParent: {
-        value: 'www.twitch.tv',
-      },
-    },
-    refetch: jest.fn(),
-    isRefetching: false,
-    isLoading: false,
-  })),
-}));
-
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({
     bottom: 0,

--- a/src/components/StreamPlayer/__tests__/twitchPlayerSource.test.ts
+++ b/src/components/StreamPlayer/__tests__/twitchPlayerSource.test.ts
@@ -6,12 +6,15 @@ import {
   buildTwitchClipPlayerUrl,
   buildTwitchContentGateAcceptScript,
   buildTwitchContentGateWatcherScript,
+  buildTwitchEmbedErrorWatcherScript,
   buildTwitchLatencyTrackerScript,
   buildTwitchLiveSyncScript,
   buildTwitchOverlayHideScript,
   buildTwitchPlayerAudioDefaultScript,
+  DEFAULT_TWITCH_EMBED_PARENT,
   isAppUrl,
   isTwitchPassportCallbackUrl,
+  resolveTwitchEmbedParent,
 } from '../twitchPlayerSource';
 
 describe('twitchPlayerSource', () => {
@@ -265,6 +268,49 @@ describe('twitchPlayerSource', () => {
       }),
     ).toBe(
       'https://clips.twitch.tv/embed?clip=AnimatedOptimisticWasabiVoteNay&parent=www.twitch.tv&autoplay=true&muted=false&preload=metadata',
+    );
+  });
+
+  test('resolveTwitchEmbedParent reads remote config but holds the parent to www.twitch.tv', () => {
+    // The known-good host is honoured, including URL and casing variants.
+    expect(resolveTwitchEmbedParent('www.twitch.tv')).toBe('www.twitch.tv');
+    expect(resolveTwitchEmbedParent('WWW.Twitch.TV')).toBe('www.twitch.tv');
+    expect(resolveTwitchEmbedParent('https://www.twitch.tv/')).toBe(
+      'www.twitch.tv',
+    );
+
+    // Any other value - the misconfiguration that broke the embed - is coerced
+    // back to the known-good host instead of reaching Twitch as-is.
+    expect(resolveTwitchEmbedParent('foam-app.com')).toBe('www.twitch.tv');
+    expect(resolveTwitchEmbedParent('https://foam-app.com/')).toBe(
+      'www.twitch.tv',
+    );
+    expect(resolveTwitchEmbedParent('')).toBe('www.twitch.tv');
+    expect(resolveTwitchEmbedParent('   ')).toBe('www.twitch.tv');
+    expect(resolveTwitchEmbedParent(undefined)).toBe('www.twitch.tv');
+    expect(resolveTwitchEmbedParent(null)).toBe('www.twitch.tv');
+    expect(resolveTwitchEmbedParent('has spaces')).toBe('www.twitch.tv');
+    expect(resolveTwitchEmbedParent('bad_domain!')).toBe('www.twitch.tv');
+    expect(DEFAULT_TWITCH_EMBED_PARENT).toBe('www.twitch.tv');
+  });
+
+  test('embed-error watcher reports Twitch misconfigured pages with the parent value', () => {
+    const script = buildTwitchEmbedErrorWatcherScript();
+
+    // Detects Twitch's misconfigured-embed error text.
+    expect(script).toContain("text.indexOf('embed is misconfigured') !== -1");
+    // Posts the bridge message the native side maps to a dedicated Sentry issue.
+    expect(script).toContain("type: 'embedMisconfigured'");
+    // Includes the offending parent so the report is actionable.
+    expect(script).toContain(
+      "new URLSearchParams(window.location.search).get('parent')",
+    );
+    // Stops as soon as a real player video appears, so it never scans the
+    // healthy player's large DOM.
+    expect(script).toContain("if (document.querySelector('video'))");
+    // Only the top frame reports, so a subframe can't duplicate the event.
+    expect(script).toContain(
+      'if (window.top !== window.self) { return true; }',
     );
   });
 

--- a/src/components/StreamPlayer/__tests__/twitchPlayerSource.test.ts
+++ b/src/components/StreamPlayer/__tests__/twitchPlayerSource.test.ts
@@ -287,6 +287,10 @@ describe('twitchPlayerSource', () => {
     expect(script).toContain(
       'if (window.top !== window.self) { return true; }',
     );
+    // The poll is only started when the synchronous check has not already
+    // resolved, so a same-tick hit never leaves an unclearable interval.
+    expect(script).toContain('if (!stopped) {');
+    expect(script).toContain('timer = setInterval(check, 1000)');
   });
 
   test('detects app and Twitch passport callback URLs', () => {

--- a/src/components/StreamPlayer/__tests__/twitchPlayerSource.test.ts
+++ b/src/components/StreamPlayer/__tests__/twitchPlayerSource.test.ts
@@ -11,10 +11,8 @@ import {
   buildTwitchLiveSyncScript,
   buildTwitchOverlayHideScript,
   buildTwitchPlayerAudioDefaultScript,
-  DEFAULT_TWITCH_EMBED_PARENT,
   isAppUrl,
   isTwitchPassportCallbackUrl,
-  resolveTwitchEmbedParent,
 } from '../twitchPlayerSource';
 
 describe('twitchPlayerSource', () => {
@@ -269,29 +267,6 @@ describe('twitchPlayerSource', () => {
     ).toBe(
       'https://clips.twitch.tv/embed?clip=AnimatedOptimisticWasabiVoteNay&parent=www.twitch.tv&autoplay=true&muted=false&preload=metadata',
     );
-  });
-
-  test('resolveTwitchEmbedParent reads remote config but holds the parent to www.twitch.tv', () => {
-    // The known-good host is honoured, including URL and casing variants.
-    expect(resolveTwitchEmbedParent('www.twitch.tv')).toBe('www.twitch.tv');
-    expect(resolveTwitchEmbedParent('WWW.Twitch.TV')).toBe('www.twitch.tv');
-    expect(resolveTwitchEmbedParent('https://www.twitch.tv/')).toBe(
-      'www.twitch.tv',
-    );
-
-    // Any other value - the misconfiguration that broke the embed - is coerced
-    // back to the known-good host instead of reaching Twitch as-is.
-    expect(resolveTwitchEmbedParent('foam-app.com')).toBe('www.twitch.tv');
-    expect(resolveTwitchEmbedParent('https://foam-app.com/')).toBe(
-      'www.twitch.tv',
-    );
-    expect(resolveTwitchEmbedParent('')).toBe('www.twitch.tv');
-    expect(resolveTwitchEmbedParent('   ')).toBe('www.twitch.tv');
-    expect(resolveTwitchEmbedParent(undefined)).toBe('www.twitch.tv');
-    expect(resolveTwitchEmbedParent(null)).toBe('www.twitch.tv');
-    expect(resolveTwitchEmbedParent('has spaces')).toBe('www.twitch.tv');
-    expect(resolveTwitchEmbedParent('bad_domain!')).toBe('www.twitch.tv');
-    expect(DEFAULT_TWITCH_EMBED_PARENT).toBe('www.twitch.tv');
   });
 
   test('embed-error watcher reports Twitch misconfigured pages with the parent value', () => {

--- a/src/components/StreamPlayer/playerTelemetry.ts
+++ b/src/components/StreamPlayer/playerTelemetry.ts
@@ -65,6 +65,9 @@ function loadFailureLogMessage(reason: string | undefined, error: unknown) {
   if (reason === 'embed_error' && isPlayerErrorMetadata(error)) {
     return `[StreamPlayer:embed ERROR] ${String(error.message ?? 'Unknown embed error')}`;
   }
+  if (reason === 'embed_misconfigured' && isPlayerErrorMetadata(error)) {
+    return `[StreamPlayer:embed MISCONFIGURED] ${String(error.message ?? 'Whoops, this embed is misconfigured')}`;
+  }
   if (reason === 'load_timeout') {
     return `player failed to load within ${PLAYER_LOAD_TIMEOUT_MS}ms`;
   }

--- a/src/components/StreamPlayer/twitchPlayerSource.ts
+++ b/src/components/StreamPlayer/twitchPlayerSource.ts
@@ -1745,11 +1745,12 @@ export function buildTwitchEmbedErrorWatcherScript(): string {
   if (window.__foamEmbedErrorWatcherInstalled) { return true; }
   window.__foamEmbedErrorWatcherInstalled = true;
 
-  var reported = false;
   var checks = 0;
   var timer = null;
+  var stopped = false;
 
   function stop() {
+    stopped = true;
     if (timer) { clearInterval(timer); timer = null; }
   }
 
@@ -1762,7 +1763,7 @@ export function buildTwitchEmbedErrorWatcherScript(): string {
   }
 
   function check() {
-    if (reported) { return; }
+    if (stopped) { return; }
     checks += 1;
     // A real player <video> means the embed loaded; nothing to watch for.
     if (document.querySelector('video')) {
@@ -1771,7 +1772,6 @@ export function buildTwitchEmbedErrorWatcherScript(): string {
     }
     var text = (document.body && document.body.textContent || '').toLowerCase();
     if (text.indexOf('embed is misconfigured') !== -1) {
-      reported = true;
       stop();
       try {
         window.ReactNativeWebView.postMessage(JSON.stringify({
@@ -1788,8 +1788,12 @@ export function buildTwitchEmbedErrorWatcherScript(): string {
     if (checks >= 15) { stop(); }
   }
 
+  // Poll only if the synchronous check did not already resolve, so a same-tick
+  // hit (error/video/timeout) never leaves an interval running unclearable.
   check();
-  timer = setInterval(check, 1000);
+  if (!stopped) {
+    timer = setInterval(check, 1000);
+  }
   return true;
 })();
 true;`;

--- a/src/components/StreamPlayer/twitchPlayerSource.ts
+++ b/src/components/StreamPlayer/twitchPlayerSource.ts
@@ -1,49 +1,5 @@
 import { PIP_ENABLED } from './pipFeature';
 
-/**
- * Fallback Twitch embed `parent`. Twitch always accepts its own domain, so this
- * keeps the player working even when remote config supplies an empty or invalid
- * value.
- */
-export const DEFAULT_TWITCH_EMBED_PARENT = 'www.twitch.tv';
-
-/**
- * Resolves the Twitch embed `parent`. We read the remote-config value but hold
- * it to the known-good host: Twitch renders "Whoops, this embed is
- * misconfigured" when `parent` is empty or is not an allowed domain, so any
- * value that does not normalise to {@link DEFAULT_TWITCH_EMBED_PARENT} is
- * coerced back to it. This keeps the embed working even if a blank or malformed
- * value is pushed to remote config, while still accepting URL/casing variants
- * of the expected host (e.g. `https://www.twitch.tv/`, `WWW.Twitch.TV`).
- */
-export function resolveTwitchEmbedParent(
-  raw: string | null | undefined,
-): string {
-  if (typeof raw !== 'string') {
-    return DEFAULT_TWITCH_EMBED_PARENT;
-  }
-
-  let host = raw.trim();
-
-  // A full URL (e.g. https://www.twitch.tv/) reduces to its hostname.
-  if (host.includes('://')) {
-    try {
-      host = new URL(host).hostname;
-    } catch {
-      return DEFAULT_TWITCH_EMBED_PARENT;
-    }
-  } else {
-    // Drop any path/port/query a bare value might still carry.
-    host = host.replace(/[/:?].*$/, '');
-  }
-
-  host = host.trim().toLowerCase();
-  // Only the known-good host is accepted; anything else falls back to it.
-  return host === DEFAULT_TWITCH_EMBED_PARENT
-    ? host
-    : DEFAULT_TWITCH_EMBED_PARENT;
-}
-
 // Twitch's player embed expects a VOD start offset as `XhYmZs`, not seconds.
 function formatTwitchTimeParam(totalSeconds: number): string {
   const safeSeconds = Math.max(0, Math.floor(totalSeconds));

--- a/src/components/StreamPlayer/twitchPlayerSource.ts
+++ b/src/components/StreamPlayer/twitchPlayerSource.ts
@@ -1,5 +1,49 @@
 import { PIP_ENABLED } from './pipFeature';
 
+/**
+ * Fallback Twitch embed `parent`. Twitch always accepts its own domain, so this
+ * keeps the player working even when remote config supplies an empty or invalid
+ * value.
+ */
+export const DEFAULT_TWITCH_EMBED_PARENT = 'www.twitch.tv';
+
+/**
+ * Resolves the Twitch embed `parent`. We read the remote-config value but hold
+ * it to the known-good host: Twitch renders "Whoops, this embed is
+ * misconfigured" when `parent` is empty or is not an allowed domain, so any
+ * value that does not normalise to {@link DEFAULT_TWITCH_EMBED_PARENT} is
+ * coerced back to it. This keeps the embed working even if a blank or malformed
+ * value is pushed to remote config, while still accepting URL/casing variants
+ * of the expected host (e.g. `https://www.twitch.tv/`, `WWW.Twitch.TV`).
+ */
+export function resolveTwitchEmbedParent(
+  raw: string | null | undefined,
+): string {
+  if (typeof raw !== 'string') {
+    return DEFAULT_TWITCH_EMBED_PARENT;
+  }
+
+  let host = raw.trim();
+
+  // A full URL (e.g. https://www.twitch.tv/) reduces to its hostname.
+  if (host.includes('://')) {
+    try {
+      host = new URL(host).hostname;
+    } catch {
+      return DEFAULT_TWITCH_EMBED_PARENT;
+    }
+  } else {
+    // Drop any path/port/query a bare value might still carry.
+    host = host.replace(/[/:?].*$/, '');
+  }
+
+  host = host.trim().toLowerCase();
+  // Only the known-good host is accepted; anything else falls back to it.
+  return host === DEFAULT_TWITCH_EMBED_PARENT
+    ? host
+    : DEFAULT_TWITCH_EMBED_PARENT;
+}
+
 // Twitch's player embed expects a VOD start offset as `XhYmZs`, not seconds.
 function formatTwitchTimeParam(totalSeconds: number): string {
   const safeSeconds = Math.max(0, Math.floor(totalSeconds));
@@ -1723,6 +1767,73 @@ export function buildTwitchPlayerStateScript(): string {
     subtree: true
   });
 
+  return true;
+})();
+true;`;
+}
+
+/**
+ * Detects Twitch's "Whoops, this embed is misconfigured" error page and posts
+ * an `embedMisconfigured` bridge message so the native side can surface it to
+ * Sentry with the offending `parent` value. Twitch serves this as a bare error
+ * document (no player `<video>`) when the embed `parent` is empty or is not an
+ * allowed domain; without this watcher the failure only shows up as a generic
+ * load timeout. Polls briefly at load and stops as soon as a real player
+ * `<video>` appears, so the healthy player's large DOM is never scanned.
+ */
+export function buildTwitchEmbedErrorWatcherScript(): string {
+  return `
+(function() {
+  // Only the top frame owns the embed URL; a subframe reporting would duplicate.
+  if (window.top !== window.self) { return true; }
+  if (window.__foamEmbedErrorWatcherInstalled) { return true; }
+  window.__foamEmbedErrorWatcherInstalled = true;
+
+  var reported = false;
+  var checks = 0;
+  var timer = null;
+
+  function stop() {
+    if (timer) { clearInterval(timer); timer = null; }
+  }
+
+  function readParent() {
+    try {
+      return new URLSearchParams(window.location.search).get('parent');
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function check() {
+    if (reported) { return; }
+    checks += 1;
+    // A real player <video> means the embed loaded; nothing to watch for.
+    if (document.querySelector('video')) {
+      stop();
+      return;
+    }
+    var text = (document.body && document.body.textContent || '').toLowerCase();
+    if (text.indexOf('embed is misconfigured') !== -1) {
+      reported = true;
+      stop();
+      try {
+        window.ReactNativeWebView.postMessage(JSON.stringify({
+          type: 'embedMisconfigured',
+          payload: {
+            message: 'Whoops, this embed is misconfigured',
+            parent: readParent()
+          }
+        }));
+      } catch (e) {}
+      return;
+    }
+    // The error appears at load; give up after ~15s so this never lingers.
+    if (checks >= 15) { stop(); }
+  }
+
+  check();
+  timer = setInterval(check, 1000);
   return true;
 })();
 true;`;

--- a/src/components/StreamPlayer/types.ts
+++ b/src/components/StreamPlayer/types.ts
@@ -222,9 +222,8 @@ export interface StreamPlayerProps {
    */
   onWebViewLoaded?: () => void;
   /**
-   * Parent domain for Twitch embed. On native, {@link StreamPlayer} reads
-   * `twitchPlayerEmbedParent` from remote config instead. Web uses this prop
-   * (or the page hostname) when no remote config is available.
+   * Parent domain for the Twitch embed. Used by the web player only; native
+   * hardcodes `www.twitch.tv`, the domain Twitch's embed always accepts.
    */
   parent?: string;
   /**

--- a/src/components/StreamPlayer/types.ts
+++ b/src/components/StreamPlayer/types.ts
@@ -349,4 +349,8 @@ export type PlayerMessage =
   | { type: 'trace'; payload: { step: string; detail?: string } }
   | { type: 'twitchAuthComplete' }
   | { type: 'error'; payload: { message: string } }
+  | {
+      type: 'embedMisconfigured';
+      payload: { message: string; parent: string | null };
+    }
   | { type: 'muteState'; payload: { muted: boolean; volume: number } };

--- a/src/components/StreamPlayer/util/__tests__/playerBridgeInterpreter.test.ts
+++ b/src/components/StreamPlayer/util/__tests__/playerBridgeInterpreter.test.ts
@@ -447,6 +447,100 @@ describe('interpretPlayerMessage', () => {
     });
   });
 
+  describe('embedMisconfigured', () => {
+    test('records a dedicated load failure, metric, log and notify with the bad parent', () => {
+      const embedErrorMetadata = {
+        name: 'twitch_player_error',
+        exceptionName: 'StreamPlayerEmbedMisconfigured',
+        fingerprint: ['stream-player-embed-misconfigured'],
+        channel: 'sodapoppin',
+        embedParent: '',
+        elapsedMs: 2_500,
+        message: 'Whoops, this embed is misconfigured',
+      };
+      expect(
+        interpretPlayerMessage(
+          {
+            type: 'embedMisconfigured',
+            payload: {
+              message: 'Whoops, this embed is misconfigured',
+              parent: '',
+            },
+          },
+          createBridgeContext(),
+        ),
+      ).toEqual<PlayerBridgeAction[]>([
+        {
+          type: 'recordLoadFailed',
+          reason: 'embed_misconfigured',
+          error: embedErrorMetadata,
+        },
+        {
+          type: 'countMetric',
+          name: 'stream.embed_misconfigured',
+          attributes: {
+            channel: 'sodapoppin',
+            embed_parent: '',
+          },
+        },
+        {
+          type: 'log',
+          level: 'warn',
+          message:
+            '[StreamPlayer:embed MISCONFIGURED] Whoops, this embed is misconfigured',
+          args: [embedErrorMetadata],
+        },
+        {
+          type: 'notifyError',
+          message: 'Whoops, this embed is misconfigured',
+        },
+      ]);
+    });
+
+    test('falls back to unknown parent and a generic message when the payload is missing', () => {
+      const embedErrorMetadata = {
+        name: 'twitch_player_error',
+        exceptionName: 'StreamPlayerEmbedMisconfigured',
+        fingerprint: ['stream-player-embed-misconfigured'],
+        channel: 'sodapoppin',
+        embedParent: 'unknown',
+        elapsedMs: 2_500,
+        message: 'Whoops, this embed is misconfigured',
+      };
+      expect(
+        interpretPlayerMessage(
+          JSON.parse('{"type":"embedMisconfigured"}') as PlayerMessage,
+          createBridgeContext(),
+        ),
+      ).toEqual<PlayerBridgeAction[]>([
+        {
+          type: 'recordLoadFailed',
+          reason: 'embed_misconfigured',
+          error: embedErrorMetadata,
+        },
+        {
+          type: 'countMetric',
+          name: 'stream.embed_misconfigured',
+          attributes: {
+            channel: 'sodapoppin',
+            embed_parent: 'unknown',
+          },
+        },
+        {
+          type: 'log',
+          level: 'warn',
+          message:
+            '[StreamPlayer:embed MISCONFIGURED] Whoops, this embed is misconfigured',
+          args: [embedErrorMetadata],
+        },
+        {
+          type: 'notifyError',
+          message: 'Whoops, this embed is misconfigured',
+        },
+      ]);
+    });
+  });
+
   describe('contentGateDetected', () => {
     test('propagates the gate flag', () => {
       expect(

--- a/src/components/StreamPlayer/util/playerBridgeInterpreter.ts
+++ b/src/components/StreamPlayer/util/playerBridgeInterpreter.ts
@@ -241,6 +241,45 @@ export function interpretPlayerMessage(
         },
       ];
     }
+    case 'embedMisconfigured': {
+      const embedParent = message.payload?.parent ?? 'unknown';
+      const embedMessage =
+        message.payload?.message ?? 'Whoops, this embed is misconfigured';
+      const embedErrorMetadata = {
+        name: 'twitch_player_error',
+        exceptionName: 'StreamPlayerEmbedMisconfigured',
+        fingerprint: ['stream-player-embed-misconfigured'],
+        channel: context.channel,
+        embedParent,
+        elapsedMs,
+        message: embedMessage,
+      };
+      return [
+        {
+          type: 'recordLoadFailed',
+          reason: 'embed_misconfigured',
+          error: embedErrorMetadata,
+        },
+        {
+          type: 'countMetric',
+          name: 'stream.embed_misconfigured',
+          attributes: {
+            channel: context.channel ?? 'unknown',
+            embed_parent: embedParent,
+          },
+        },
+        {
+          type: 'log',
+          level: 'warn',
+          message: `[StreamPlayer:embed MISCONFIGURED] ${embedMessage}`,
+          args: [embedErrorMetadata],
+        },
+        {
+          type: 'notifyError',
+          message: embedMessage,
+        },
+      ];
+    }
     case 'contentGateDetected':
       return [
         {

--- a/src/hooks/firebase/remoteConfigModel.ts
+++ b/src/hooks/firebase/remoteConfigModel.ts
@@ -46,11 +46,6 @@ export interface RemoteConfigSchema {
    * sets this per user; the client reads it via `useExperiment`.
    */
   experiments: Record<string, string>;
-
-  /**
-   * `parent` query parameter for Twitch embed URLs.
-   */
-  twitchPlayerEmbedParent: string;
 }
 
 export type RemoteConfigKey = keyof RemoteConfigSchema;
@@ -84,7 +79,6 @@ export const defaultRemoteConfig = {
   experiments: '{}',
   bundleButtonEnabled:
     '{ "ios": { "development": false, "internal": true, "testflight": false, "production": false, "e2e": false }}',
-  twitchPlayerEmbedParent: 'www.twitch.tv',
 } satisfies Record<RemoteConfigKey, string>;
 
 const jsonKeys: RemoteConfigKey[] = [

--- a/src/utils/devTools/__tests__/useDevToolsAccess.test.tsx
+++ b/src/utils/devTools/__tests__/useDevToolsAccess.test.tsx
@@ -62,7 +62,6 @@ function createRemoteConfigResult(
         e2e: false,
       },
     }),
-    twitchPlayerEmbedParent: entry('www.twitch.tv'),
   };
 
   return { config, refetch: jest.fn(), isRefetching: false, isLoading };

--- a/src/utils/version/__tests__/getMinimumVersion.test.ts
+++ b/src/utils/version/__tests__/getMinimumVersion.test.ts
@@ -35,7 +35,6 @@ function createRemoteConfig(minimumVersion: {
         e2e: false,
       },
     }),
-    twitchPlayerEmbedParent: entry('www.twitch.tv'),
   };
 }
 


### PR DESCRIPTION
## Problem

Sentry [#133455974](https://foam-tv.sentry.io/issues/133455974/): Twitch shows **"Whoops, this embed is misconfigured"** in the player.

The embed `parent` param moved to a Firebase Remote Config value (`twitchPlayerEmbedParent`) in #707. Twitch renders that error page whenever `parent` is empty or not an allowed domain, so a blank or malformed remote value broke **every** stream, clip, and VOD - and it was invisible, only surfacing ~9s later as a generic `StreamPlayerLoadTimeout`.

## Fix

**1. Hardcode the parent (prevent).** Since `www.twitch.tv` is the only value we ever want (Twitch always accepts its own domain), routing it through remote config just adds a failure mode. This reverts #707's indirection: `parent` is hardcoded to `www.twitch.tv` in the native `StreamPlayer` and the `twitchPlayerEmbedParent` remote-config field is removed. A bad remote push can no longer take down playback.

**2. Detect it (observe).** `buildTwitchEmbedErrorWatcherScript` is injected into every player kind. It spots Twitch's misconfigured-embed page and posts an `embedMisconfigured` bridge message carrying the offending `parent`. The interpreter maps it to a **dedicated Sentry issue** (`stream-player-embed-misconfigured`, exception `StreamPlayerEmbedMisconfigured`) plus a `stream.embed_misconfigured` metric - distinct and alertable instead of buried under load timeouts. This is defence-in-depth: if the embed ever breaks again (Twitch rule change, expired parent, etc.) it's a one-glance diagnosis.

The watcher is cheap: it polls briefly at load and stops the moment a real `<video>` appears (never scans the healthy player's DOM), and is top-frame-only to avoid duplicate reports.

## Files

- `StreamPlayer.tsx` - hardcode `parent`, inject the watcher
- `twitchPlayerSource.ts` - detection script
- `remoteConfigModel.ts` - remove the `twitchPlayerEmbedParent` field
- `types.ts` - `embedMisconfigured` message type; updated `parent` prop doc
- `playerBridgeInterpreter.ts` - interpret it into Sentry/metric/log actions
- `playerTelemetry.ts` - clear log headline for the new reason
- tests for the watcher script and the interpreter case; fixtures updated for the removed field

## Testing

- `bun run jest src/components/StreamPlayer/` and the two remote-config fixture suites - all green (127 tests)
- `bun run ts:check` - clean
- `eslint` / `prettier` - clean