### PR TITLE
fix(chat): keep 7TV personal + tagged sub emotes resolved on reprocess

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -215,6 +215,7 @@ export const Chat = memo(
             messages$={messages$}
             processedMessageIdsRef={processedMessageIdsRef}
             reprocessKey={emoteReprocessKey}
+            userLogin={user?.login}
           />
           <View style={styles.keyboardAvoidingView}>
             <View style={styles.chatContainer}>

--- a/src/components/Chat/components/ChatEmoteReprocessor.tsx
+++ b/src/components/Chat/components/ChatEmoteReprocessor.tsx
@@ -2,6 +2,7 @@ import { memo, RefObject } from 'react';
 
 import { useChannelEmoteData } from '@app/store/chat/react/selectors';
 import type { AnyChatMessageType } from '@app/store/chat/types/constants';
+import { usePreference } from '@app/store/preferenceStore';
 
 import { useEmoteReprocessing } from '../hooks/useEmoteReprocessing';
 
@@ -12,14 +13,17 @@ export const ChatEmoteReprocessor = memo(
     messages$,
     processedMessageIdsRef,
     reprocessKey,
+    userLogin,
   }: {
     channelId: string;
     emoteLoadStatus: string;
     messages$: { peek: () => AnyChatMessageType[] };
     processedMessageIdsRef: RefObject<Set<string>>;
     reprocessKey: string;
+    userLogin?: string | null;
   }) => {
     const channelEmoteData = useChannelEmoteData(channelId);
+    const show7TvEmotes = usePreference('show7TvEmotes');
 
     useEmoteReprocessing({
       channelId,
@@ -28,6 +32,8 @@ export const ChatEmoteReprocessor = memo(
       emoteLoadStatus,
       processedMessageIdsRef,
       reprocessKey,
+      show7TvEmotes,
+      userLogin,
     });
 
     return null;

--- a/src/components/Chat/hooks/__tests__/useEmoteReprocessing.personalEmotes.test.ts
+++ b/src/components/Chat/hooks/__tests__/useEmoteReprocessing.personalEmotes.test.ts
@@ -1,0 +1,182 @@
+import { renderHook } from '@testing-library/react-native';
+
+import type { AnyChatMessageType } from '@app/components/Chat/util/messageHandlers';
+import { resolveMessageEmoteParts } from '@app/components/Chat/util/resolveMessageEmoteParts';
+import {
+  getCurrentEmoteData,
+  getUserPersonalEmotes,
+} from '@app/store/chat/actions/channelLoad';
+import { updateMessages } from '@app/store/chat/actions/messages';
+import { createUserStateTags } from '@app/types/chat/irc-tags/__fixtures__/userStateTags.fixture';
+import type { ParsedPart } from '@app/utils/chat/parsedPart';
+
+import { useEmoteReprocessing } from '../useEmoteReprocessing';
+import {
+  createEmoteData,
+  createSevenTvEmote,
+} from './__fixtures__/useChat.fixture';
+
+// The whole point of this suite is to exercise the real resolver + emote
+// worklet, so neither is mocked - only the store-backed emote sources are.
+jest.mock('@app/store/chat/actions/channelLoad', () => ({
+  getCurrentEmoteData: jest.fn(),
+  getUserPersonalEmotes: jest.fn(() => []),
+}));
+jest.mock('@app/store/chat/actions/messages', () => ({
+  updateMessages: jest.fn(),
+}));
+jest.mock('@app/store/chat/observables/chatStore', () => ({
+  chatStore$: {
+    emojis: {
+      peek: jest.fn(() => []),
+    },
+  },
+}));
+jest.mock('@app/utils/chat/findBadges', () => ({
+  findBadges: jest.fn(() => []),
+}));
+
+const mockGetCurrentEmoteData = jest.mocked(getCurrentEmoteData);
+const mockGetUserPersonalEmotes = jest.mocked(getUserPersonalEmotes);
+const mockUpdateMessages = jest.mocked(updateMessages);
+
+const channelId = 'channel-1';
+
+// A channel emote so the reprocess pass's "does this channel have any emotes?"
+// gate passes; `plaska` itself is only ever reachable via the personal set.
+const channelKappa = createSevenTvEmote({ id: 'kappa', name: 'Kappa' });
+const personalPlaska = createSevenTvEmote({
+  id: 'plaska-id',
+  name: 'plaska',
+  original_name: 'plaska',
+  url: 'https://cdn.example.test/plaska.webp',
+  static_url: 'https://cdn.example.test/plaska.png',
+});
+
+const senderUserstate = createUserStateTags({
+  'display-name': 'chatter',
+  login: 'chatter',
+  username: 'chatter',
+  'user-id': 'sender-1',
+  id: 'm1',
+  color: '#fff',
+});
+
+function createMessage(
+  parts: ParsedPart[],
+  messageId = 'm1',
+): AnyChatMessageType {
+  return {
+    id: messageId,
+    message_id: messageId,
+    message_nonce: 'n1',
+    message: parts,
+    channel: 'test',
+    sender: 'chatter',
+    badges: [],
+    userstate: senderUserstate,
+    parentDisplayName: '',
+    replyDisplayName: '',
+    replyBody: '',
+  };
+}
+
+function renderReprocess(
+  message: AnyChatMessageType,
+  overrides: { show7TvEmotes?: boolean } = {},
+) {
+  const processedMessageIdsRef = { current: new Set<string>() };
+  renderHook(() =>
+    useEmoteReprocessing({
+      channelId,
+      channelEmoteData: {},
+      messages$: { peek: () => [message] },
+      emoteLoadStatus: 'success',
+      processedMessageIdsRef,
+      show7TvEmotes: overrides.show7TvEmotes ?? true,
+      userLogin: 'me',
+    }),
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetCurrentEmoteData.mockReturnValue(
+    createEmoteData({ sevenTvChannelEmotes: [channelKappa] }),
+  );
+  mockGetUserPersonalEmotes.mockReturnValue([personalPlaska]);
+});
+
+/**
+ * Resolves `text` the same way live ingest does, so a test can seed a message
+ * with the parts it would have had when it first arrived.
+ */
+function ingestParts(text: string): ParsedPart[] {
+  return resolveMessageEmoteParts({
+    channelId,
+    emoteData: createEmoteData({ sevenTvChannelEmotes: [channelKappa] }),
+    show7TvEmotes: true,
+    text,
+    userId: 'sender-1',
+    userLogin: 'me',
+    userstate: senderUserstate,
+  });
+}
+
+/**
+ * Reduces parts to the fields these tests assert on so the shape can be
+ * compared with `toEqual` instead of a partial matcher.
+ */
+function partShapes(parts: ParsedPart[]): { type: string; id?: string }[] {
+  return parts.map(part => ({
+    type: part.type,
+    id: 'id' in part ? part.id : undefined,
+  }));
+}
+
+function updatedMessage(): ParsedPart[] {
+  return mockUpdateMessages.mock.calls[0]?.[0]?.[0]?.updates
+    ?.message as ParsedPart[];
+}
+
+describe('useEmoteReprocessing personal 7TV emotes', () => {
+  test('seeds a message where `plaska` resolves to the personal emote', () => {
+    expect(partShapes(ingestParts('plaska'))).toEqual([
+      { type: 'emote', id: 'plaska-id' },
+    ]);
+  });
+
+  test('keeps a resolved personal emote as an emote on reprocess (no text downgrade)', () => {
+    // Message arrived already resolved to the personal emote on ingest.
+    renderReprocess(createMessage(ingestParts('plaska')));
+
+    // The reprocess pass must re-resolve `plaska` via the personal set and leave
+    // the emote untouched - never rewrite it back to a plain "plaska" text part.
+    expect(mockGetUserPersonalEmotes).toHaveBeenCalledWith(
+      'sender-1',
+      channelId,
+    );
+    expect(mockUpdateMessages).not.toHaveBeenCalled();
+  });
+
+  test('upgrades a text-only message to the personal emote once it is available', () => {
+    // Message arrived as text (personal set not loaded yet), then reprocess runs.
+    renderReprocess(createMessage([{ type: 'text', content: 'plaska' }]));
+
+    expect(mockUpdateMessages).toHaveBeenCalledTimes(1);
+    expect(partShapes(updatedMessage())).toEqual([
+      { type: 'emote', id: 'plaska-id' },
+    ]);
+  });
+
+  test('downgrades to text only when 7TV emotes are turned off', () => {
+    // With the toggle off the personal set is intentionally dropped, so the
+    // emote falls back to text - the behaviour the reprocess gate should honour.
+    renderReprocess(createMessage(ingestParts('plaska')), {
+      show7TvEmotes: false,
+    });
+
+    expect(mockUpdateMessages).toHaveBeenCalledTimes(1);
+    expect(updatedMessage()).toEqual([{ type: 'text', content: 'plaska' }]);
+  });
+});

--- a/src/components/Chat/hooks/__tests__/useEmoteReprocessing.personalEmotes.test.ts
+++ b/src/components/Chat/hooks/__tests__/useEmoteReprocessing.personalEmotes.test.ts
@@ -42,8 +42,8 @@ const mockUpdateMessages = jest.mocked(updateMessages);
 
 const channelId = 'channel-1';
 
-// A channel emote so the reprocess pass's "does this channel have any emotes?"
-// gate passes; `plaska` itself is only ever reachable via the personal set.
+// Only used to keep the reprocess gate open in the 7TV-disabled case below;
+// `plaska` itself always resolves via the personal set, never this emote.
 const channelKappa = createSevenTvEmote({ id: 'kappa', name: 'Kappa' });
 const personalPlaska = createSevenTvEmote({
   id: 'plaska-id',
@@ -101,9 +101,9 @@ function renderReprocess(
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockGetCurrentEmoteData.mockReturnValue(
-    createEmoteData({ sevenTvChannelEmotes: [channelKappa] }),
-  );
+  // Empty channel emote data: `plaska` is reachable only via the personal set,
+  // so these tests also prove a personal-emote-only channel still reprocesses.
+  mockGetCurrentEmoteData.mockReturnValue(createEmoteData());
   mockGetUserPersonalEmotes.mockReturnValue([personalPlaska]);
 });
 
@@ -114,7 +114,7 @@ beforeEach(() => {
 function ingestParts(text: string): ParsedPart[] {
   return resolveMessageEmoteParts({
     channelId,
-    emoteData: createEmoteData({ sevenTvChannelEmotes: [channelKappa] }),
+    emoteData: createEmoteData(),
     show7TvEmotes: true,
     text,
     userId: 'sender-1',
@@ -171,7 +171,11 @@ describe('useEmoteReprocessing personal 7TV emotes', () => {
 
   test('downgrades to text only when 7TV emotes are turned off', () => {
     // With the toggle off the personal set is intentionally dropped, so the
-    // emote falls back to text - the behaviour the reprocess gate should honour.
+    // emote falls back to text. A channel emote keeps the reprocess gate open
+    // (7TV off no longer holds it open on its own) so the resolver still runs.
+    mockGetCurrentEmoteData.mockReturnValue(
+      createEmoteData({ sevenTvChannelEmotes: [channelKappa] }),
+    );
     renderReprocess(createMessage(ingestParts('plaska')), {
       show7TvEmotes: false,
     });

--- a/src/components/Chat/hooks/__tests__/useEmoteReprocessing.test.ts
+++ b/src/components/Chat/hooks/__tests__/useEmoteReprocessing.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react-native';
 
 import type { AnyChatMessageType } from '@app/components/Chat/util/messageHandlers';
+import { resolveMessageEmoteParts } from '@app/components/Chat/util/resolveMessageEmoteParts';
 import { getCurrentEmoteData } from '@app/store/chat/actions/channelLoad';
 import { updateMessages } from '@app/store/chat/actions/messages';
 import { chatStore$ } from '@app/store/chat/observables/chatStore';
@@ -28,14 +29,14 @@ jest.mock('@app/store/chat/observables/chatStore', () => ({
   },
 }));
 
-jest.mock('@app/utils/chat/emoteProcessor', () => {
+jest.mock('@app/components/Chat/util/resolveMessageEmoteParts', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports -- Jest mock factory runs before module imports
   const {
     createEmotePart,
   } = require('@app/utils/chat/__tests__/__fixtures__/parsedPart.fixture');
   return {
-    processEmotesWorklet: jest.fn((x: { inputString: string }) => [
-      createEmotePart(x.inputString, { id: 'e1', url: '' }),
+    resolveMessageEmoteParts: jest.fn((x: { text: string }) => [
+      createEmotePart(x.text, { id: 'e1', url: '' }),
     ]),
   };
 });
@@ -46,6 +47,7 @@ jest.mock('@app/utils/chat/findBadges', () => ({
 
 const mockGetCurrentEmoteData = jest.mocked(getCurrentEmoteData);
 const mockUpdateMessages = jest.mocked(updateMessages);
+const mockResolveMessageEmoteParts = jest.mocked(resolveMessageEmoteParts);
 const mockEmojisPeek = jest.mocked(chatStore$.emojis.peek);
 
 function createTextOnlyMessage(
@@ -98,6 +100,9 @@ describe('useEmoteReprocessing', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockEmojisPeek.mockReturnValue([]);
+    mockResolveMessageEmoteParts.mockImplementation((x: { text: string }) => [
+      createEmotePart(x.text, { id: 'e1', url: '' }),
+    ]);
     processedMessageIdsRef.current.clear();
   });
 
@@ -113,6 +118,7 @@ describe('useEmoteReprocessing', () => {
         messages$: { peek },
         emoteLoadStatus: 'loading',
         processedMessageIdsRef,
+        show7TvEmotes: true,
       }),
     );
 
@@ -134,6 +140,7 @@ describe('useEmoteReprocessing', () => {
         messages$: { peek },
         emoteLoadStatus: 'success',
         processedMessageIdsRef,
+        show7TvEmotes: true,
       }),
     );
 
@@ -165,6 +172,7 @@ describe('useEmoteReprocessing', () => {
         messages$: { peek },
         emoteLoadStatus: 'success',
         processedMessageIdsRef,
+        show7TvEmotes: true,
       }),
     );
 
@@ -183,6 +191,7 @@ describe('useEmoteReprocessing', () => {
         messages$: { peek },
         emoteLoadStatus: 'success',
         processedMessageIdsRef,
+        show7TvEmotes: true,
       }),
     );
 
@@ -191,6 +200,36 @@ describe('useEmoteReprocessing', () => {
       expectMessageUpdate('msg-1', 'nonce-1'),
     ]);
     expect(processedMessageIdsRef.current.has('msg-1')).toBe(true);
+  });
+
+  test('forwards the sender scope to the shared resolver', () => {
+    mockGetCurrentEmoteData.mockReturnValue(emoteDataWithEmotes);
+    const msg1 = createTextOnlyMessage('msg-1', 'nonce-1', 'plaska');
+    const peek = jest.fn().mockReturnValue([msg1]);
+
+    renderHook(() =>
+      useEmoteReprocessing({
+        channelId,
+        channelEmoteData: emoteDataWithEmotes,
+        messages$: { peek },
+        emoteLoadStatus: 'success',
+        processedMessageIdsRef,
+        show7TvEmotes: true,
+        userLogin: 'me',
+      }),
+    );
+
+    // The sender's userId, the 7TV toggle and the current login all reach the
+    // resolver so scoped personal / subscriber emotes resolve on reprocess.
+    expect(mockResolveMessageEmoteParts).toHaveBeenCalledWith({
+      channelId,
+      emoteData: emoteDataWithEmotes,
+      show7TvEmotes: true,
+      text: 'plaska',
+      userId: '1',
+      userLogin: 'me',
+      userstate: msg1.userstate,
+    });
   });
 
   test('yields between large reprocessing batches', () => {
@@ -208,6 +247,7 @@ describe('useEmoteReprocessing', () => {
         messages$: { peek },
         emoteLoadStatus: 'success',
         processedMessageIdsRef,
+        show7TvEmotes: true,
       }),
     );
 
@@ -225,9 +265,7 @@ describe('useEmoteReprocessing', () => {
 
   test('skips equivalent reprocessed message parts and badges', () => {
     const existingParts = [createEmotePart('Kappa', { id: 'e1', url: '' })];
-    jest
-      .requireMock('@app/utils/chat/emoteProcessor')
-      .processEmotesWorklet.mockReturnValueOnce(existingParts);
+    mockResolveMessageEmoteParts.mockReturnValueOnce(existingParts);
     mockGetCurrentEmoteData.mockReturnValue(emoteDataWithEmotes);
     const msg1 = {
       ...createTextOnlyMessage('msg-1', 'nonce-1', 'Kappa'),
@@ -242,6 +280,7 @@ describe('useEmoteReprocessing', () => {
         messages$: { peek },
         emoteLoadStatus: 'success',
         processedMessageIdsRef,
+        show7TvEmotes: true,
       }),
     );
 
@@ -268,6 +307,7 @@ describe('useEmoteReprocessing', () => {
         messages$: { peek },
         emoteLoadStatus: 'success',
         processedMessageIdsRef,
+        show7TvEmotes: true,
       }),
     );
 
@@ -275,6 +315,29 @@ describe('useEmoteReprocessing', () => {
     expect(mockUpdateMessages).toHaveBeenCalledWith([
       expectMessageUpdate('msg-1', 'nonce-1'),
     ]);
+  });
+
+  test('skips messages without a userstate', () => {
+    mockGetCurrentEmoteData.mockReturnValue(emoteDataWithEmotes);
+    const noUserstate = {
+      ...createTextOnlyMessage('msg-1', 'nonce-1', 'hello'),
+      userstate: undefined,
+    } as unknown as AnyChatMessageType;
+    const peek = jest.fn().mockReturnValue([noUserstate]);
+
+    renderHook(() =>
+      useEmoteReprocessing({
+        channelId,
+        channelEmoteData: emoteDataWithEmotes,
+        messages$: { peek },
+        emoteLoadStatus: 'success',
+        processedMessageIdsRef,
+        show7TvEmotes: true,
+      }),
+    );
+
+    expect(mockResolveMessageEmoteParts).not.toHaveBeenCalled();
+    expect(mockUpdateMessages).not.toHaveBeenCalled();
   });
 
   test('skips messages already in processedMessageIdsRef', () => {
@@ -290,6 +353,7 @@ describe('useEmoteReprocessing', () => {
         messages$: { peek },
         emoteLoadStatus: 'success',
         processedMessageIdsRef,
+        show7TvEmotes: true,
       }),
     );
 
@@ -315,6 +379,7 @@ describe('useEmoteReprocessing', () => {
         messages$: { peek },
         emoteLoadStatus: 'success',
         processedMessageIdsRef,
+        show7TvEmotes: true,
       }),
     );
 
@@ -348,6 +413,7 @@ describe('useEmoteReprocessing', () => {
           emoteLoadStatus: 'success',
           processedMessageIdsRef,
           reprocessKey,
+          show7TvEmotes: true,
         }),
       {
         initialProps: {
@@ -380,6 +446,7 @@ describe('useEmoteReprocessing', () => {
         messages$: { peek },
         emoteLoadStatus: 'success',
         processedMessageIdsRef,
+        show7TvEmotes: true,
       }),
     );
 

--- a/src/components/Chat/hooks/__tests__/useEmoteReprocessing.test.ts
+++ b/src/components/Chat/hooks/__tests__/useEmoteReprocessing.test.ts
@@ -148,23 +148,43 @@ describe('useEmoteReprocessing', () => {
     expect(mockUpdateMessages).not.toHaveBeenCalled();
   });
 
-  test('does nothing when emote data has no emotes', () => {
-    mockGetCurrentEmoteData.mockReturnValue(
-      createEmoteData({
-        ...emoteDataWithEmotes,
-        sevenTvGlobalEmotes: [],
-        sevenTvChannelEmotes: [],
-        twitchGlobalEmotes: [],
-        twitchChannelEmotes: [],
-        bttvGlobalEmotes: [],
-        bttvChannelEmotes: [],
-        ffzGlobalEmotes: [],
-        ffzChannelEmotes: [],
-      }),
-    );
+  const emptyEmoteData = createEmoteData({
+    sevenTvGlobalEmotes: [],
+    sevenTvChannelEmotes: [],
+    twitchGlobalEmotes: [],
+    twitchChannelEmotes: [],
+    bttvGlobalEmotes: [],
+    bttvChannelEmotes: [],
+    ffzGlobalEmotes: [],
+    ffzChannelEmotes: [],
+  });
+
+  test('does nothing when there are no emotes and 7TV emotes are disabled', () => {
+    mockGetCurrentEmoteData.mockReturnValue(emptyEmoteData);
     const peek = jest
       .fn()
       .mockReturnValue([createTextOnlyMessage('1', 'n1', 'hello')]);
+    renderHook(() =>
+      useEmoteReprocessing({
+        channelId,
+        channelEmoteData: {},
+        messages$: { peek },
+        emoteLoadStatus: 'success',
+        processedMessageIdsRef,
+        show7TvEmotes: false,
+      }),
+    );
+
+    expect(mockUpdateMessages).not.toHaveBeenCalled();
+  });
+
+  test('still reprocesses a personal-emote-only channel when 7TV emotes are enabled', () => {
+    // Personal 7TV emotes live outside the channel emote data, so an empty
+    // channel set must not gate the reprocess pass off when 7TV is enabled.
+    mockGetCurrentEmoteData.mockReturnValue(emptyEmoteData);
+    const peek = jest
+      .fn()
+      .mockReturnValue([createTextOnlyMessage('1', 'n1', 'plaska')]);
     renderHook(() =>
       useEmoteReprocessing({
         channelId,
@@ -176,7 +196,10 @@ describe('useEmoteReprocessing', () => {
       }),
     );
 
-    expect(mockUpdateMessages).not.toHaveBeenCalled();
+    expect(mockResolveMessageEmoteParts).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMessages).toHaveBeenCalledWith([
+      expectMessageUpdate('1', 'n1'),
+    ]);
   });
 
   test('reprocesses text-only unprocessed messages and calls updateMessages', () => {

--- a/src/components/Chat/hooks/useEmoteReprocessing.ts
+++ b/src/components/Chat/hooks/useEmoteReprocessing.ts
@@ -4,11 +4,11 @@ import type { MutableRefObject } from 'react';
 import { getCurrentEmoteData } from '@app/store/chat/actions/channelLoad';
 import { updateMessages } from '@app/store/chat/actions/messages';
 import { chatStore$ } from '@app/store/chat/observables/chatStore';
-import { processEmotesWorklet } from '@app/utils/chat/emoteProcessor';
 import { findBadges } from '@app/utils/chat/findBadges';
 import type { ParsedPart } from '@app/utils/chat/parsedPart';
 
 import type { AnyChatMessageType } from '../util/messageHandlers';
+import { resolveMessageEmoteParts } from '../util/resolveMessageEmoteParts';
 
 const EMOTE_REPROCESS_BATCH_DELAY_MS = 32;
 const EMOTE_REPROCESS_BATCH_SIZE = 6;
@@ -20,6 +20,8 @@ export function useEmoteReprocessing({
   emoteLoadStatus,
   processedMessageIdsRef,
   reprocessKey,
+  show7TvEmotes,
+  userLogin,
 }: {
   channelId: string;
   channelEmoteData: unknown;
@@ -27,6 +29,8 @@ export function useEmoteReprocessing({
   emoteLoadStatus: string;
   processedMessageIdsRef: MutableRefObject<Set<string>>;
   reprocessKey?: string;
+  show7TvEmotes: boolean;
+  userLogin?: string | null;
 }) {
   const previousReprocessKeyRef = useRef(reprocessKey);
 
@@ -69,7 +73,7 @@ export function useEmoteReprocessing({
     let pendingUpdates: Parameters<typeof updateMessages>[0] = [];
 
     const processMessage = (msg?: AnyChatMessageType) => {
-      if (!msg?.message_id || !Array.isArray(msg.message)) {
+      if (!msg?.message_id || !Array.isArray(msg.message) || !msg.userstate) {
         return;
       }
 
@@ -106,18 +110,17 @@ export function useEmoteReprocessing({
         return;
       }
 
-      const replacedMessage = processEmotesWorklet({
-        inputString: textContent.trimEnd(),
+      // Route through the shared resolver (not the worklet directly) so the
+      // sender's 7TV personal emotes and tagged subscriber emotes still resolve;
+      // otherwise an emote resolved on ingest downgrades back to text here.
+      const replacedMessage = resolveMessageEmoteParts({
+        channelId,
+        emoteData,
+        show7TvEmotes,
+        text: textContent.trimEnd(),
+        userId: msg.userstate['user-id'],
+        userLogin,
         userstate: msg.userstate,
-        emojiEmotes: chatStore$.emojis.peek(),
-        sevenTvGlobalEmotes: emoteData.sevenTvGlobalEmotes,
-        sevenTvChannelEmotes: emoteData.sevenTvChannelEmotes,
-        twitchGlobalEmotes: emoteData.twitchGlobalEmotes,
-        twitchChannelEmotes: emoteData.twitchChannelEmotes,
-        ffzChannelEmotes: emoteData.ffzChannelEmotes,
-        ffzGlobalEmotes: emoteData.ffzGlobalEmotes,
-        bttvChannelEmotes: emoteData.bttvChannelEmotes,
-        bttvGlobalEmotes: emoteData.bttvGlobalEmotes,
       });
 
       const replacedBadges = findBadges({
@@ -186,6 +189,8 @@ export function useEmoteReprocessing({
     emoteLoadStatus,
     processedMessageIdsRef,
     reprocessKey,
+    show7TvEmotes,
+    userLogin,
   ]);
 }
 

--- a/src/components/Chat/hooks/useEmoteReprocessing.ts
+++ b/src/components/Chat/hooks/useEmoteReprocessing.ts
@@ -51,6 +51,9 @@ export function useEmoteReprocessing({
     }
 
     const hasEmotes =
+      // Personal 7TV emotes are per-sender, not part of the channel emote data,
+      // so a personal-emote-only channel would otherwise skip reprocessing.
+      show7TvEmotes ||
       chatStore$.emojis.peek().length > 0 ||
       emoteData.sevenTvGlobalEmotes.length > 0 ||
       emoteData.sevenTvChannelEmotes.length > 0 ||


### PR DESCRIPTION
## Problem

A message whose text resolves to a **7TV personal emote** (e.g. `plaska`) - or a Twitch subscriber emote delivered in the IRC `emotes` tag - showed up as plain **text** in chat shortly after arriving, even though it had resolved to the emote on ingest.

### Root cause

`resolveMessageEmoteParts` is the documented single source of truth for turning message text into emote parts, and it scopes two per-sender sets that global/channel lookups don't cover:

- the sender's **7TV personal emotes** (`getUserPersonalEmotes`)
- the message's **tagged Twitch subscriber emotes** (`extractEmotesFromTag`)

Live ingest (`useChatMessageProcessing`) routes through it. The emote **reprocess** pass (`useEmoteReprocessing`) did **not** - it called `processEmotesWorklet` directly with only the global/channel sets. So when reprocessing ran over an already-resolved message, the personal/subscriber emote was no longer in scope and the part was rewritten back to a plain text token. The reprocess pass is batched, so this surfaced as emotes "flipping" to text a beat after they appeared.

## Fix

Route `useEmoteReprocessing` through `resolveMessageEmoteParts` - the resolver both paths are meant to share - threading `show7TvEmotes` (from `usePreference`) and the current `userLogin` so the personal/subscriber scoping matches ingest exactly. Cheermote handling comes along for free via the same resolver.

## Tests

- Reworked the existing `useEmoteReprocessing` unit tests onto the resolver seam (batching, skip, reprocessKey behaviour unchanged).
- New `useEmoteReprocessing.personalEmotes.test.ts` drives the **real** resolver + emote worklet (only the store-backed emote sources are mocked) and asserts:
  - a personal emote resolved on ingest **stays an emote** on reprocess (the regression),
  - a text-only message **upgrades** to the personal emote once it's available,
  - it downgrades to text **only** when 7TV emotes are turned off.
- Verified the regression test **fails** against the pre-fix behaviour (temporarily dropped the scope → `no text downgrade` test went red), then passes with the fix.

`bun run jest src/components/Chat/hooks/__tests__/useEmoteReprocessing` (17 passed), `ts:check`, `eslint`, `prettier` all clean.