### PR TITLE
fix(chat): correct 7TV emote sizing and shrink the animated-emote decode storm

### DIFF
--- a/src/Providers/CachedEmotesProvider/__tests__/cache-service.test.ts
+++ b/src/Providers/CachedEmotesProvider/__tests__/cache-service.test.ts
@@ -10,6 +10,7 @@ import { Image, type ImageRef } from 'expo-image';
 import {
   clearCachedEmoteRefs,
   ensureCachedEmoteRef,
+  getCachedEmoteAspectRatio,
   getCachedEmoteByteEstimate,
   getCachedEmoteRef,
   getCachedEmoteStats,
@@ -50,6 +51,44 @@ describe('cache-service', () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(getCachedEmoteRef(url)).toBeNull();
+  });
+
+  test('records the decoded emote aspect ratio so the renderer can size a dimensionless emote', async () => {
+    const url = 'https://cdn.7tv.app/emote/wide/4x.webp';
+    loadAsync.mockResolvedValueOnce({
+      width: 96,
+      height: 32,
+    } as unknown as ImageRef);
+
+    expect(getCachedEmoteAspectRatio(url)).toBeNull();
+
+    await warmCachedEmoteRefs([url]);
+
+    expect(getCachedEmoteAspectRatio(url)).toBe(3);
+  });
+
+  test('does not record an aspect ratio when the decoded ref has no dimensions', async () => {
+    const url = 'https://cdn.7tv.app/emote/nodims/1x.avif';
+    loadAsync.mockResolvedValueOnce({} as ImageRef);
+
+    await warmCachedEmoteRefs([url]);
+
+    expect(getCachedEmoteAspectRatio(url)).toBeNull();
+  });
+
+  test('drops the recorded aspect ratio when the emote is evicted', async () => {
+    const url = 'https://cdn.7tv.app/emote/evictme/4x.webp';
+    loadAsync.mockResolvedValueOnce({
+      width: 64,
+      height: 32,
+    } as unknown as ImageRef);
+
+    await warmCachedEmoteRefs([url]);
+    expect(getCachedEmoteAspectRatio(url)).toBe(2);
+
+    releaseChannelEmoteRefs();
+
+    expect(getCachedEmoteAspectRatio(url)).toBeNull();
   });
 
   test('subscribers that have unsubscribed are not notified on clear', () => {

--- a/src/Providers/CachedEmotesProvider/cache-service.ts
+++ b/src/Providers/CachedEmotesProvider/cache-service.ts
@@ -67,6 +67,13 @@ const ANIMATED_BYTE_FACTOR = 8;
 
 const refs = new Map<string, ImageRef>();
 const refBytes = new Map<string, number>();
+/**
+ * Intrinsic aspect ratio (logical width / height) captured off each decoded ref,
+ * so the renderer can size emotes whose provider doesn't advertise dimensions.
+ * Warm-decoded channel emotes usually have this before they first render, so the
+ * common case corrects with no visible layout shift.
+ */
+const refAspect = new Map<string, number>();
 let totalBytes = 0;
 const pinned = new Set<string>();
 /**
@@ -98,6 +105,7 @@ function dropRefBytes(url: string): void {
     totalBytes -= cost;
     refBytes.delete(url);
   }
+  refAspect.delete(url);
 }
 
 const pendingReleases: { url: string; ref: ImageRef }[] = [];
@@ -244,6 +252,15 @@ export function getCachedEmoteRef(url: string): ImageRef | null {
 }
 
 /**
+ * Intrinsic aspect ratio (width / height) of the decoded emote, or `null` if it
+ * hasn't been decoded yet. Used to correct the layout box for emotes whose
+ * provider doesn't advertise dimensions (Twitch, BTTV).
+ */
+export function getCachedEmoteAspectRatio(url: string): number | null {
+  return refAspect.get(url) ?? null;
+}
+
+/**
  * Re-inserts the entry at the end of the Map so eviction (which scans insertion
  * order) drops the least-recently-rendered ref, not the oldest-decoded one.
  * Kept out of getCachedEmoteRef so the useSyncExternalStore snapshot stays pure.
@@ -306,6 +323,12 @@ async function runDecode(
     refs.set(url, ref);
     refBytes.set(url, cost);
     totalBytes += cost;
+    // Reading width/height off the ref is a JSI hop, but it's a one-off right
+    // after the (far costlier) decode, and lets a dimensionless emote render at
+    // its true aspect ratio instead of a 1:1 box.
+    if (ref.width > 0 && ref.height > 0) {
+      refAspect.set(url, ref.width / ref.height);
+    }
     if (pin) {
       pinned.add(url);
     }
@@ -393,6 +416,7 @@ export function clearCachedEmoteRefs(): void {
   }
   refs.clear();
   refBytes.clear();
+  refAspect.clear();
   totalBytes = 0;
   inflight.clear();
   pinned.clear();

--- a/src/Providers/CachedEmotesProvider/useCachedEmote.ts
+++ b/src/Providers/CachedEmotesProvider/useCachedEmote.ts
@@ -7,6 +7,7 @@ import type { ImageRef } from 'expo-image';
 import {
   EMOTE_DECODE_MAX_PX,
   ensureCachedEmoteRef,
+  getCachedEmoteAspectRatio,
   getCachedEmoteRef,
   subscribeCachedEmoteRef,
   touchCachedEmoteRef,
@@ -43,4 +44,24 @@ export function useCachedEmote(
     }
   }, [url, maxPx, ref]);
   return ref;
+}
+
+/**
+ * Subscribes to the intrinsic aspect ratio (width / height) of the decoded emote
+ * for `url`, returning `null` until it decodes. Only pass a url for emotes whose
+ * provider doesn't advertise dimensions (Twitch, BTTV, and 7TV encodes that
+ * arrive without size metadata); pass `null` when reliable dimensions are
+ * already known so the hook stays inert. This piggybacks on the decode kicked
+ * off by {@link useCachedEmote}, so it never triggers a decode of its own.
+ */
+export function useCachedEmoteAspectRatio(url: string | null): number | null {
+  const subscribe = useCallback(
+    (cb: () => void) => (url ? subscribeCachedEmoteRef(url, cb) : () => {}),
+    [url],
+  );
+  return useSyncExternalStore(
+    subscribe,
+    () => (url ? getCachedEmoteAspectRatio(url) : null),
+    () => null,
+  );
 }

--- a/src/Providers/CachedEmotesProvider/useCachedEmotes.ts
+++ b/src/Providers/CachedEmotesProvider/useCachedEmotes.ts
@@ -11,8 +11,15 @@ import { releaseChannelEmoteRefs, warmCachedEmoteRefs } from './cache-service';
 export type CachedEmotesLoadingState = 'IDLE' | 'WARMING' | 'WARMED';
 
 const WARM_BATCH_SIZE = 24;
-const WARM_LIMIT = 96;
-const GLOBAL_WARM_LIMIT = 128;
+/**
+ * How many emotes to eagerly decode into the shared ref cache on channel entry.
+ * Decodes are capped at 8 concurrent, so these counts set the warm storm's
+ * *duration*, and while it runs it starves the per-frame decoding of an animated
+ * emote that's on screen (it plays choppy until the storm drains). Warm the
+ * common set; the long tail decodes on-demand. Tune against the Chat Perf harness.
+ */
+const WARM_LIMIT = 64;
+const GLOBAL_WARM_LIMIT = 64;
 
 function collectDisplayUrls(emotes: SanitisedEmote[], limit: number): string[] {
   const urls = new Set<string>();

--- a/src/components/Chat/components/ChatMessage/renderers/EmoteRenderer.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/EmoteRenderer.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { View } from 'react-native';
 
 import { Text } from '@app/components/ui/Text/Text';
+import { useCachedEmoteAspectRatio } from '@app/Providers/CachedEmotesProvider/useCachedEmote';
 import { calculateAspectRatio } from '@app/utils/chat/calculateAspectRatio';
 import { ParsedPart } from '@app/utils/chat/parsedPart';
 import { getDisplayEmoteUrl } from '@app/utils/emote/getDisplayEmoteUrl';
@@ -30,11 +31,6 @@ export const EmoteRenderer = memo(
     shouldOverlayPrevious = false,
     targetSize = 30,
   }: EmoteRendererProps) => {
-    const { height, width } = calculateAspectRatio(
-      part.width || 20,
-      part.height || 20,
-      targetSize,
-    );
     const displayUrl = getDisplayEmoteUrl({
       image_variants: part.image_variants,
       url: part.url,
@@ -42,6 +38,21 @@ export const EmoteRenderer = memo(
       disableAnimations,
       preferredScale: CHAT_INLINE_EMOTE_SCALE,
     });
+
+    // Twitch and BTTV don't advertise emote dimensions, and some 7TV encodes
+    // arrive without size metadata too, so the box would default to 1:1 and a
+    // non-square emote renders letterboxed at the wrong width. When metadata is
+    // missing, size from the decoded emote's true aspect ratio instead — it's
+    // usually already known for warm channel emotes (no visible shift) and lands
+    // via the subscription once the emote decodes otherwise.
+    const measuredRatio = useCachedEmoteAspectRatio(
+      part.width && part.height ? null : displayUrl,
+    );
+
+    const { height, width } =
+      part.width && part.height
+        ? calculateAspectRatio(part.width, part.height, targetSize)
+        : calculateAspectRatio(measuredRatio ?? 1, 1, targetSize);
     // No Pressable: long-press is detected by the row's timer, this just
     // records which emote the touch started on. A busy screen renders
     // hundreds of emotes, so each Pressable's gesture machinery added up.

--- a/src/utils/image/preloadEmotes.ts
+++ b/src/utils/image/preloadEmotes.ts
@@ -115,7 +115,10 @@ export async function preloadGlobalEmotes(emoteData: {
     ...(emoteData.ffzGlobalEmotes || []),
   ];
 
-  await preloadEmotes(allGlobal, 100);
+  // Kept in step with the shared-ref warm limits (useCachedEmotes) so channel
+  // entry doesn't fire two large, overlapping decode storms that together
+  // starve on-screen animated emotes. The long tail warms on-demand instead.
+  await preloadEmotes(allGlobal, 64);
 }
 
 /**
@@ -134,7 +137,9 @@ export async function preloadChannelEmotes(emoteData: {
     ...(emoteData.twitchChannelEmotes || []),
   ];
 
-  await preloadEmotes(allChannel, 50);
+  // Trimmed alongside the shared-ref warm limits to shrink the channel-entry
+  // decode storm that starves on-screen animated emotes (see useCachedEmotes).
+  await preloadEmotes(allChannel, 32);
 }
 
 /**

--- a/src/utils/seventv/__tests__/seventvWsInterpreter.test.ts
+++ b/src/utils/seventv/__tests__/seventvWsInterpreter.test.ts
@@ -228,6 +228,56 @@ describe('interpretSeventvWsMessage', () => {
       ]);
     });
 
+    test('resolves real dimensions from a webp encode when the host ships no avif', () => {
+      const webpOnlyEmote = createSevenTvEmote({
+        id: 'emote-webp',
+        name: 'wideEmote',
+        files: [
+          createSevenTvFile({
+            name: '1x.webp',
+            width: 96,
+            height: 32,
+            format: 'WEBP',
+          }),
+          createSevenTvFile({
+            name: '4x.webp',
+            width: 384,
+            height: 128,
+            frame_count: 30,
+            format: 'WEBP',
+          }),
+        ],
+      });
+      const event = createEmoteSetUpdateEvent({
+        id: 'set-1',
+        pushed: [createPushedChange(webpOnlyEmote)],
+      });
+
+      const decisions = interpretSeventvWsMessage(
+        createDispatchMessage(event),
+        createContext(),
+      );
+
+      const decision = decisions[0];
+      if (decision?.type !== 'applyEmoteUpdate') {
+        throw new Error(`expected applyEmoteUpdate, got ${decision?.type}`);
+      }
+      const added = decision.added[0];
+      // Only the size/url resolution matters here — a webp-only emote must not
+      // collapse to 0x0 (which renders as a 1:1 square at the wrong width).
+      expect({
+        url: added?.url,
+        width: added?.width,
+        height: added?.height,
+        aspect_ratio: added?.aspect_ratio,
+      }).toEqual({
+        url: 'https://cdn.7tv.app/emote/emote-webp/4x.webp',
+        width: 384,
+        height: 128,
+        aspect_ratio: 3,
+      });
+    });
+
     test('ignores updates for a different emote set but still notifies the raw event', () => {
       const event = createEmoteSetUpdateEvent({
         id: 'other-set',

--- a/src/utils/seventv/seventvWsInterpreter.ts
+++ b/src/utils/seventv/seventvWsInterpreter.ts
@@ -9,7 +9,7 @@ import type {
   SevenTvEventType,
   SevenTvWsMessage,
 } from '@app/types/seventv/cosmetics';
-import type { SevenTvEmote } from '@app/types/seventv/emotes';
+import type { SevenTvEmote, SevenTvFile } from '@app/types/seventv/emotes';
 import type { StvUser } from '@app/types/seventv/users';
 
 export const HISTORICAL_EVENT_BUFFER = 10000; // 10 seconds
@@ -126,16 +126,54 @@ export type SeventvWsDecision =
   | { type: 'reconnect' }
   | { type: 'unhandledOp'; op: number };
 
+/**
+ * The EventAPI advertises several encodes per emote. Prefer avif at the largest
+ * scale (best size/quality, and the url form the CDN expects), but fall back to
+ * webp so an emote whose host only ships webp still resolves real dimensions —
+ * otherwise width/height collapse to 0 and a non-square emote renders as a 1:1
+ * square at the wrong width. As a last resort take the widest encode that
+ * carries dimensions so the aspect ratio is at least correct.
+ */
+const SEVEN_TV_FILE_PREFERENCE = [
+  '4x.avif',
+  '3x.avif',
+  '2x.avif',
+  '1x.avif',
+  '4x.webp',
+  '3x.webp',
+  '2x.webp',
+  '1x.webp',
+] as const;
+
+function pickBestSevenTvFile(
+  files: readonly SevenTvFile[],
+): SevenTvFile | undefined {
+  const byName = new Map(files.map(file => [file.name, file]));
+  for (const name of SEVEN_TV_FILE_PREFERENCE) {
+    const match = byName.get(name);
+    if (match) {
+      return match;
+    }
+  }
+  let widest: SevenTvFile | undefined;
+  for (const file of files) {
+    if (
+      file.width > 0 &&
+      file.height > 0 &&
+      (!widest || file.width > widest.width)
+    ) {
+      widest = file;
+    }
+  }
+  return widest;
+}
+
 function toSanitisedSevenTvEmote(
   emote: SevenTvEmote,
   actor: StvUser | undefined,
   now: number,
 ): SanitisedEmote {
-  const bestFile =
-    emote.data.host.files.find(file => file.name === '4x.avif') ||
-    emote.data.host.files.find(file => file.name === '3x.avif') ||
-    emote.data.host.files.find(file => file.name === '2x.avif') ||
-    emote.data.host.files.find(file => file.name === '1x.avif');
+  const bestFile = pickBestSevenTvFile(emote.data.host.files);
 
   return {
     name: emote.name,


### PR DESCRIPTION
## What & why

Two related emote-rendering issues in chat.

### 1. 7TV emotes rendering at the wrong width (`fix`)
7TV emotes added at runtime via the EventAPI (personal / tagged-sub emotes, the #717 path) picked their "best file" by matching **`*.avif` filenames only**. An emote whose payload ships webp/gif encodes got `bestFile = undefined` → `width/height = 0` → the renderer forced it into a **1:1 square box**, so a non-square emote rendered letterboxed at the wrong width.

- **Data source:** `pickBestSevenTvFile` is now format-agnostic (avif → webp → widest encode with real dimensions), so dimensions are correct on first paint.
- **Renderer safety net:** any emote that still arrives without dimensions (Twitch, BTTV, stray 7TV encodes) is now sized from its **true decoded aspect ratio**, recorded on the shared `ImageRef` cache and read via a new `useCachedEmoteAspectRatio` subscription. Warm channel emotes have the ratio before first render, so the common case corrects with no visible layout shift.

### 2. Animated emote choppy for 10-20s, then full FPS (`perf`)
Entering a channel warmed up to **224 `ImageRef` decodes + ~150 preload prefetches** at once. Those native decodes saturate the decode threads for ~10-20s and starve the per-frame decoding of an animated emote that's actually on screen, so it plays choppy until the storm drains.

Decodes are capped at 8 concurrent, so the storm's **duration** scales with the number of URLs warmed. This roughly halves the warmed set (warm limits `96/128 → 64/64`, preload `100/50 → 64/32`). The long tail decodes on-demand, and those decodes preempt warm so they stay fast. Both warming systems are kept intact (preload also covers the static variant animations-disabled users render).

## Testing
- `tsc`, eslint, prettier all clean.
- 97 tests pass, including new regression coverage for the webp-only WS emote (`seventvWsInterpreter.test.ts`) and the aspect-ratio cache API (`cache-service.test.ts`).

## Validation notes
- **#2 wants an on-device pass** via the Chat Perf harness (`ChatPerfScreen`) to confirm the animated-emote ramp shortens; the warm/preload limits are documented as tunable. If halving isn't enough, follow-ups are a separate warm-decode concurrency cap, skip-warming animated emotes, the 200MB memory-trim threshold, and re-evaluating `useAppleWebpCodec` for animated WebP.
- **#1** is worth eyeballing on a real animated 7TV emote you've seen mis-size.

## Not done (investigated)
Evaluated `react-native-nitro-image`: no animated-image playback (dealbreaker for animated emotes), same iOS loader (SDWebImage), and its shared-in-memory-image win is already what expo-image's `ImageRef` cache provides. Recommendation: stay on expo-image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)