### PR TITLE
fix(chat): stabilize emote rail press handlers

### DIFF
--- a/src/components/Chat/components/ChatComposer/components/EmoteSuggestions.ios.tsx
+++ b/src/components/Chat/components/ChatComposer/components/EmoteSuggestions.ios.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import {
@@ -19,25 +19,19 @@ interface EmoteSuggestionsProps {
   handleEmotePress: (set: SanitisedEmote) => void;
 }
 
-function createRenderEmoteSuggestionItem(
-  onPress: (emote: SanitisedEmote) => void,
-) {
-  return function RenderEmoteSuggestionItem({
-    item,
-  }: LegendListRenderItemProps<SanitisedEmote>) {
-    return <EmoteSuggestionTile item={item} onPress={onPress} />;
-  };
-}
-
-function EmoteSuggestionTile({
+const EmoteSuggestionTile = memo(function EmoteSuggestionTile({
   item,
   onPress,
 }: {
   item: SanitisedEmote;
   onPress: (emote: SanitisedEmote) => void;
 }) {
+  const handlePress = useCallback(() => {
+    onPress(item);
+  }, [item, onPress]);
+
   return (
-    <Button onPress={() => onPress(item)} style={styles.suggestionItem}>
+    <Button onPress={handlePress} style={styles.suggestionItem}>
       <View style={styles.emoteTile}>
         <Image
           contentFit='contain'
@@ -49,14 +43,16 @@ function EmoteSuggestionTile({
       </View>
     </Button>
   );
-}
+});
 
 export const EmoteSuggestions = memo(function EmoteSuggestions({
   emotes,
   handleEmotePress,
 }: EmoteSuggestionsProps) {
-  const renderItem = useMemo(
-    () => createRenderEmoteSuggestionItem(handleEmotePress),
+  const renderItem = useCallback(
+    ({ item }: LegendListRenderItemProps<SanitisedEmote>) => (
+      <EmoteSuggestionTile item={item} onPress={handleEmotePress} />
+    ),
     [handleEmotePress],
   );
 

--- a/src/components/Chat/components/ChatComposer/components/EmoteSuggestions.tsx
+++ b/src/components/Chat/components/ChatComposer/components/EmoteSuggestions.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
@@ -25,25 +25,19 @@ interface EmoteSuggestionsProps {
   handleEmotePress: (set: SanitisedEmote) => void;
 }
 
-function createRenderEmoteSuggestionItem(
-  onPress: (emote: SanitisedEmote) => void,
-) {
-  return function RenderEmoteSuggestionItem({
-    item,
-  }: LegendListRenderItemProps<SanitisedEmote>) {
-    return <EmoteSuggestionItem item={item} onPress={onPress} />;
-  };
-}
-
-function EmoteSuggestionItem({
+const EmoteSuggestionItem = memo(function EmoteSuggestionItem({
   item,
   onPress,
 }: {
   item: SanitisedEmote;
   onPress: (emote: SanitisedEmote) => void;
 }) {
+  const handlePress = useCallback(() => {
+    onPress(item);
+  }, [item, onPress]);
+
   return (
-    <Button style={styles.suggestionItem} onPress={() => onPress(item)}>
+    <Button style={styles.suggestionItem} onPress={handlePress}>
       <Image
         source={item.url}
         cacheVariant='emote'
@@ -60,15 +54,18 @@ function EmoteSuggestionItem({
       </View>
     </Button>
   );
-}
+});
 
 export const EmoteSuggestions = memo(function EmoteSuggestions({
   emotes,
   handleEmotePress,
 }: EmoteSuggestionsProps) {
   const { t } = useTranslation('chat');
-  const renderItem = useMemo(
-    () => createRenderEmoteSuggestionItem(handleEmotePress),
+
+  const renderItem = useCallback(
+    ({ item }: LegendListRenderItemProps<SanitisedEmote>) => (
+      <EmoteSuggestionItem item={item} onPress={handleEmotePress} />
+    ),
     [handleEmotePress],
   );
 


### PR DESCRIPTION
## Summary

Fixes issue where emote rail buttons were unresponsive to press events.

The root cause was the factory pattern used for creating render items combined with frequent re-renders causing stale or unstable press handlers.

## Changes

- Refactored `EmoteSuggestions` to use direct `useCallback` instead of factory pattern
- Memoized `EmoteSuggestionItem` and `EmoteSuggestionTile` components  
- Added `useCallback` to `handlePress` to prevent inline function recreations
- Applied fix consistently to both default and iOS-specific variants

## Test Plan

- [x] TypeScript compiles without errors
- [x] Pre-commit hooks pass (ESLint, Prettier, ast-grep)
- [ ] Manual testing: Open chat composer, type `:` to trigger emote rail, verify emotes are pressable and insert correctly

## Related

Closes issue where clicking emote in emote rail doesn't autofill.