### PR TITLE
chat/video sync by default, 7tv username typography, sheet crash fix, webview prewarm

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -180,6 +180,7 @@
   "patchedDependencies": {
     "@legendapp/list@3.0.4": "patches/@legendapp%2Flist@3.0.4.patch",
     "@legendapp/state@2.1.15": "patches/@legendapp%2Fstate@2.1.15.patch",
+    "@swmansion/react-native-bottom-sheet@0.14.1": "patches/@swmansion%2Freact-native-bottom-sheet@0.14.1.patch",
     "expo-modules-jsi@57.0.0": "patches/expo-modules-jsi@57.0.0.patch",
     "expo-image@57.0.0": "patches/expo-image@57.0.0.patch",
     "@sentry/core@10.57.0": "patches/@sentry%2Fcore@10.57.0.patch",

--- a/package.json
+++ b/package.json
@@ -299,7 +299,8 @@
     "@legendapp/list@3.0.4": "patches/@legendapp%2Flist@3.0.4.patch",
     "expo-image@57.0.0": "patches/expo-image@57.0.0.patch",
     "expo-modules-jsi@57.0.0": "patches/expo-modules-jsi@57.0.0.patch",
-    "@sentry/core@10.57.0": "patches/@sentry%2Fcore@10.57.0.patch"
+    "@sentry/core@10.57.0": "patches/@sentry%2Fcore@10.57.0.patch",
+    "@swmansion/react-native-bottom-sheet@0.14.1": "patches/@swmansion%2Freact-native-bottom-sheet@0.14.1.patch"
   },
   "reanimated": {
     "staticFeatureFlags": {

--- a/patches/@swmansion%2Freact-native-bottom-sheet@0.14.1.patch
+++ b/patches/@swmansion%2Freact-native-bottom-sheet@0.14.1.patch
@@ -1,0 +1,46 @@
+diff --git a/node_modules/@swmansion/react-native-bottom-sheet/.bun-tag-3be1e4da2a243613 b/.bun-tag-3be1e4da2a243613
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/ios/BottomSheetComponentView.mm b/ios/BottomSheetComponentView.mm
+index d590ebc38611ee210f6e4b2db589b1008bdcea6e..d5dea6363beb9c29adcfb09ff4b9276df6a99f5d 100644
+--- a/ios/BottomSheetComponentView.mm
++++ b/ios/BottomSheetComponentView.mm
+@@ -6,6 +6,7 @@
+ 
+ #import <React/RCTAssert.h>
+ #import <React/RCTConversions.h>
++#import <React/RCTLog.h>
+ #import <React/RCTFabricComponentsPlugins.h>
+ #import <react/renderer/components/ReactNativeBottomSheetSpec/EventEmitters.h>
+ #import <react/renderer/components/ReactNativeBottomSheetSpec/Props.h>
+@@ -160,7 +161,9 @@ using namespace facebook::react;
+ 
+ - (void)bottomSheetView:(BottomSheetContentView *)view didReportError:(NSString *)message
+ {
+-  RCTFatal([NSError errorWithDomain:RCTErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : message}]);
++  // Non-fatal: detent/content mismatches are transient layout races
++  // (rotation), not programmer errors worth crashing the app for.
++  RCTLogError(@"%@", message);
+ }
+ 
+ - (void)prepareForRecycle
+diff --git a/ios/BottomSheetHostingView.swift b/ios/BottomSheetHostingView.swift
+index 255aebb637ddd7444335f9384d6019f82ae0192e..f1e3958d6da04e9db35f600779935e7356da2596 100644
+--- a/ios/BottomSheetHostingView.swift
++++ b/ios/BottomSheetHostingView.swift
+@@ -644,9 +644,13 @@ public final class BottomSheetHostingView: UIView {
+             lastReportedInvalidDetentMessage = message
+             eventDelegate?.bottomSheetHostingView(self, didReportError: message)
+           }
+-          return nil
++          // Clamp instead of failing: content can lag a frame behind fixed
++          // detents during rotation/layout races, and resolution recovers on
++          // the next measurement pass.
++          height = contentHeight
++        } else {
++          height = spec.value
+         }
+-        height = spec.value
+       case .content:
+         height = contentHeight
+       }

--- a/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
+++ b/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
@@ -396,7 +396,7 @@ const setPreferences = (showRecentMessages = true) => {
     sharedChatEnabled: true,
     enhancedVideoStability: false,
     sevenTvPaintRenderer: 'native',
-    chatDelay: 0,
+    chatDelay: 'off',
     update: jest.fn(),
   } satisfies ReturnType<typeof usePreferences>;
 

--- a/src/components/Chat/components/ChatComposer/components/EmoteSuggestions.ios.tsx
+++ b/src/components/Chat/components/ChatComposer/components/EmoteSuggestions.ios.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import {
@@ -19,25 +19,19 @@ interface EmoteSuggestionsProps {
   handleEmotePress: (set: SanitisedEmote) => void;
 }
 
-function createRenderEmoteSuggestionItem(
-  onPress: (emote: SanitisedEmote) => void,
-) {
-  return function RenderEmoteSuggestionItem({
-    item,
-  }: LegendListRenderItemProps<SanitisedEmote>) {
-    return <EmoteSuggestionTile item={item} onPress={onPress} />;
-  };
-}
-
-function EmoteSuggestionTile({
+const EmoteSuggestionTile = memo(function EmoteSuggestionTile({
   item,
   onPress,
 }: {
   item: SanitisedEmote;
   onPress: (emote: SanitisedEmote) => void;
 }) {
+  const handlePress = useCallback(() => {
+    onPress(item);
+  }, [item, onPress]);
+
   return (
-    <Button onPress={() => onPress(item)} style={styles.suggestionItem}>
+    <Button onPress={handlePress} style={styles.suggestionItem}>
       <View style={styles.emoteTile}>
         <Image
           contentFit='contain'
@@ -49,14 +43,16 @@ function EmoteSuggestionTile({
       </View>
     </Button>
   );
-}
+});
 
 export const EmoteSuggestions = memo(function EmoteSuggestions({
   emotes,
   handleEmotePress,
 }: EmoteSuggestionsProps) {
-  const renderItem = useMemo(
-    () => createRenderEmoteSuggestionItem(handleEmotePress),
+  const renderItem = useCallback(
+    ({ item }: LegendListRenderItemProps<SanitisedEmote>) => (
+      <EmoteSuggestionTile item={item} onPress={handleEmotePress} />
+    ),
     [handleEmotePress],
   );
 

--- a/src/components/Chat/components/ChatComposer/components/EmoteSuggestions.tsx
+++ b/src/components/Chat/components/ChatComposer/components/EmoteSuggestions.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
@@ -25,25 +25,19 @@ interface EmoteSuggestionsProps {
   handleEmotePress: (set: SanitisedEmote) => void;
 }
 
-function createRenderEmoteSuggestionItem(
-  onPress: (emote: SanitisedEmote) => void,
-) {
-  return function RenderEmoteSuggestionItem({
-    item,
-  }: LegendListRenderItemProps<SanitisedEmote>) {
-    return <EmoteSuggestionItem item={item} onPress={onPress} />;
-  };
-}
-
-function EmoteSuggestionItem({
+const EmoteSuggestionItem = memo(function EmoteSuggestionItem({
   item,
   onPress,
 }: {
   item: SanitisedEmote;
   onPress: (emote: SanitisedEmote) => void;
 }) {
+  const handlePress = useCallback(() => {
+    onPress(item);
+  }, [item, onPress]);
+
   return (
-    <Button style={styles.suggestionItem} onPress={() => onPress(item)}>
+    <Button style={styles.suggestionItem} onPress={handlePress}>
       <Image
         source={item.url}
         cacheVariant='emote'
@@ -60,15 +54,18 @@ function EmoteSuggestionItem({
       </View>
     </Button>
   );
-}
+});
 
 export const EmoteSuggestions = memo(function EmoteSuggestions({
   emotes,
   handleEmotePress,
 }: EmoteSuggestionsProps) {
   const { t } = useTranslation('chat');
-  const renderItem = useMemo(
-    () => createRenderEmoteSuggestionItem(handleEmotePress),
+
+  const renderItem = useCallback(
+    ({ item }: LegendListRenderItemProps<SanitisedEmote>) => (
+      <EmoteSuggestionItem item={item} onPress={handleEmotePress} />
+    ),
     [handleEmotePress],
   );
 

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintLayerTiledImage.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintLayerTiledImage.tsx
@@ -1,15 +1,11 @@
 import { StyleSheet } from 'react-native';
 
-import {
-  Canvas,
-  Fill,
-  ImageShader,
-  useAnimatedImageValue,
-} from '@shopify/react-native-skia';
+import { Canvas, Fill, ImageShader } from '@shopify/react-native-skia';
 
 import type { PaintCanvasRepeat } from '@app/types/seventv/cosmetics';
 
 import { paintLayerTileModes } from './util/paintLayer/paintLayerTileModes';
+import { useSharedPaintAnimationFrame } from './util/sharedPaintAnimationFrames';
 
 interface PaintLayerTiledImageProps {
   canvasRepeat: PaintCanvasRepeat;
@@ -18,17 +14,14 @@ interface PaintLayerTiledImageProps {
 
 /**
  * Skia image-shader tiling for CSS `background-repeat` paint layers.
- * Uses `useAnimatedImageValue` so animated tile textures advance on the UI
- * thread the same way stretch image layers do.
+ * Uses the shared per-URL animation clock so animated tile textures advance
+ * on the UI thread in phase with every other row showing the same paint.
  */
 export function PaintLayerTiledImage({
   canvasRepeat,
   imageUrl,
 }: PaintLayerTiledImageProps) {
-  const animatedFrame = useAnimatedImageValue(imageUrl);
-  if (!animatedFrame) {
-    return null;
-  }
+  const animatedFrame = useSharedPaintAnimationFrame(imageUrl);
 
   const { tx, ty } = paintLayerTileModes(canvasRepeat);
 

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameSkia.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameSkia.tsx
@@ -7,7 +7,6 @@ import {
   Image,
   ImageShader,
   Mask,
-  useAnimatedImageValue,
 } from '@shopify/react-native-skia';
 
 import { chatLineMetrics } from '@app/components/Chat/components/ChatMessage/RichChatMessage.styles';
@@ -15,6 +14,7 @@ import { Text } from '@app/components/ui/Text/Text';
 import { theme } from '@app/styles/themes';
 import type { PaintData } from '@app/types/seventv/cosmetics';
 
+import { useSharedPaintAnimationFrame } from './util/sharedPaintAnimationFrames';
 import {
   getPaintBitmaps,
   type PaintBitmaps,
@@ -51,8 +51,9 @@ function paintMaskNode(bitmaps: PaintBitmaps): ReactNode {
 }
 
 /**
- * Overlay frame from `useAnimatedImageValue` — advances on the UI thread for
- * both stretch and tiled URL layers (animated WebP/GIF included).
+ * Overlay frame from the shared per-URL animation clock — advances on the UI
+ * thread for both stretch and tiled URL layers (animated WebP/GIF included),
+ * in phase with every other row using the same paint texture.
  */
 function TiledPaintLayerOverlay({
   url,
@@ -63,11 +64,7 @@ function TiledPaintLayerOverlay({
   tile: NonNullable<PaintImageLayer['tile']>;
   maskNode: ReactNode;
 }) {
-  const animatedFrame = useAnimatedImageValue(url);
-
-  if (!animatedFrame) {
-    return null;
-  }
+  const animatedFrame = useSharedPaintAnimationFrame(url);
 
   return (
     <Mask mode='alpha' mask={maskNode}>
@@ -87,11 +84,7 @@ function StretchPaintLayerOverlay({
   rect: NonNullable<PaintImageLayer['rect']>;
   maskNode: ReactNode;
 }) {
-  const animatedFrame = useAnimatedImageValue(url);
-
-  if (!animatedFrame) {
-    return null;
-  }
+  const animatedFrame = useSharedPaintAnimationFrame(url);
 
   return (
     <Mask mode='alpha' mask={maskNode}>

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/sharedPaintAnimationFrames.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/sharedPaintAnimationFrames.ts
@@ -1,0 +1,134 @@
+import { useEffect, useMemo } from 'react';
+import {
+  makeMutable,
+  type SharedValue,
+  useFrameCallback,
+} from 'react-native-reanimated';
+
+import type { SkAnimatedImage, SkImage } from '@shopify/react-native-skia';
+import { Skia } from '@shopify/react-native-skia';
+
+import { logger } from '@app/utils/logger';
+
+interface SharedPaintAnimationEntry {
+  animatedImage: SharedValue<SkAnimatedImage | null>;
+  frame: SharedValue<SkImage | null>;
+  lastTimestamp: SharedValue<number>;
+  refCount: number;
+  disposeTimer: ReturnType<typeof setTimeout> | null;
+}
+
+const entries = new Map<string, SharedPaintAnimationEntry>();
+
+// Keep a released texture briefly so recycled rows rejoin the running clock in phase.
+const RELEASED_ENTRY_LINGER_MS = 5_000;
+
+const DEFAULT_FRAME_DURATION_MS = 60;
+
+function disposeEntry(url: string, entry: SharedPaintAnimationEntry): void {
+  if (entries.get(url) === entry) {
+    entries.delete(url);
+  }
+  entry.frame.value?.dispose();
+  entry.frame.value = null;
+  entry.animatedImage.value?.dispose();
+  entry.animatedImage.value = null;
+}
+
+function getOrCreateEntry(url: string): SharedPaintAnimationEntry {
+  const existing = entries.get(url);
+  if (existing) {
+    if (existing.disposeTimer) {
+      clearTimeout(existing.disposeTimer);
+      existing.disposeTimer = null;
+    }
+    return existing;
+  }
+
+  const entry: SharedPaintAnimationEntry = {
+    animatedImage: makeMutable<SkAnimatedImage | null>(null),
+    frame: makeMutable<SkImage | null>(null),
+    lastTimestamp: makeMutable(-1),
+    refCount: 0,
+    disposeTimer: null,
+  };
+  entries.set(url, entry);
+
+  Skia.Data.fromURI(url)
+    .then(data => {
+      const image = Skia.AnimatedImage.MakeAnimatedImageFromEncoded(data);
+      if (entries.get(url) !== entry) {
+        image?.dispose();
+        return;
+      }
+      entry.animatedImage.value = image;
+    })
+    .catch((error: unknown) => {
+      logger.chat.warn('Failed to load animated paint texture:', {
+        error,
+        url,
+      });
+    });
+
+  return entry;
+}
+
+function retainEntry(url: string): void {
+  const entry = getOrCreateEntry(url);
+  entry.refCount += 1;
+}
+
+function releaseEntry(url: string): void {
+  const entry = entries.get(url);
+  if (!entry) {
+    return;
+  }
+  entry.refCount = Math.max(0, entry.refCount - 1);
+  if (entry.refCount > 0 || entry.disposeTimer) {
+    return;
+  }
+  entry.disposeTimer = setTimeout(
+    () => disposeEntry(url, entry),
+    RELEASED_ENTRY_LINGER_MS,
+  );
+}
+
+/**
+ * Frame stream for an animated paint texture, shared per URL so every row
+ * using the same paint shows the same frame at the same time (one decode per
+ * display frame instead of one per row). All subscribers run the frame
+ * callback; the first to observe an elapsed frame advances the clock and the
+ * rest see no elapsed time and skip.
+ */
+export function useSharedPaintAnimationFrame(
+  url: string,
+): SharedValue<SkImage | null> {
+  const entry = useMemo(() => getOrCreateEntry(url), [url]);
+
+  useEffect(() => {
+    retainEntry(url);
+    return () => releaseEntry(url);
+  }, [url]);
+
+  const { animatedImage, frame, lastTimestamp } = entry;
+  useFrameCallback(frameInfo => {
+    const image = animatedImage.value;
+    if (image == null) {
+      return;
+    }
+    const duration = image.currentFrameDuration() || DEFAULT_FRAME_DURATION_MS;
+    if (
+      lastTimestamp.value !== -1 &&
+      frameInfo.timestamp - lastTimestamp.value < duration
+    ) {
+      return;
+    }
+    image.decodeNextFrame();
+    const oldFrame = frame.value;
+    frame.value = image.getCurrentFrame();
+    oldFrame?.dispose();
+    lastTimestamp.value = frameInfo.timestamp;
+  });
+
+  return frame;
+}

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/skiaPaintedUsernameRasterizer.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/skiaPaintedUsernameRasterizer.ts
@@ -1,4 +1,4 @@
-import { AppState } from 'react-native';
+import { AppState, Platform } from 'react-native';
 
 import type {
   SkCanvas,
@@ -286,15 +286,24 @@ interface PaintUsernameLayout {
   insetsPx: { left: number; top: number; right: number; bottom: number };
 }
 
+/**
+ * SkParagraph excludes trailing breakable spaces from getLongestLine(), which
+ * would glue the painted name to the message text; NBSP keeps the trailing
+ * gap a plain <Text> username renders.
+ */
+function keepTrailingSpaces(text: string): string {
+  return text.replace(/ +$/, match => '\u00A0'.repeat(match.length));
+}
+
 function paintUsernameText(paint: PaintData, displayUsername: string): string {
   const transform = paint.textStyle?.transform;
   if (transform === 'uppercase') {
-    return displayUsername.toLocaleUpperCase();
+    return keepTrailingSpaces(displayUsername.toLocaleUpperCase());
   }
   if (transform === 'lowercase') {
-    return displayUsername.toLocaleLowerCase();
+    return keepTrailingSpaces(displayUsername.toLocaleLowerCase());
   }
-  return displayUsername;
+  return keepTrailingSpaces(displayUsername);
 }
 
 function buildUsernameParagraph(
@@ -330,12 +339,16 @@ function buildPaintLayout(
 
   /**
    * The extension renders paint weight as `weight * 100`; with no explicit
-   * weight the painted span inherits chat's bold (700). Skia shapes glyphs
-   * from the matching registered face, so a heavier paint reads heavier here.
+   * weight the painted span inherits the chat username as rendered. ui/Text
+   * resolves usernames to the single-face Montserrat_400Regular family, so
+   * iOS draws the 400 face (style fontWeight '700' finds no bold sibling in
+   * that family) while Android synthesizes a faux bold from the same face.
    */
   const fontWeight: FontWeight = paint.textStyle?.weight
     ? ((paint.textStyle.weight * 100) as FontWeight)
-    : FontWeight.Bold;
+    : Platform.OS === 'android'
+      ? FontWeight.Bold
+      : FontWeight.Normal;
   const partial = {
     text: paintUsernameText(paint, displayUsername),
     fontSizePx: fontSize * scale,

--- a/src/components/Chat/hooks/__tests__/useChatMessages.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChatMessages.test.ts
@@ -708,6 +708,41 @@ describe('useChatMessages', () => {
       expect(getLastFlushedMessages().map(m => m.message_id)).toEqual(['1']);
     });
 
+    test('a live message arriving after the delay collapses to zero waits behind held messages', () => {
+      let delayMs = 5000;
+      const { result } = renderHook(() =>
+        useChatMessages({ ...defaultOptions, getChatDelayMs: () => delayMs }),
+      );
+
+      act(() => {
+        result.current.handleNewMessage(createMockMessage('1'));
+      });
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+
+      delayMs = 0;
+      act(() => {
+        result.current.handleNewMessage(createMockMessage('2'));
+      });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(mockAddMessages).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(4500);
+      });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+
+      expect(getLastFlushedMessages().map(m => m.message_id)).toEqual([
+        '1',
+        '2',
+      ]);
+    });
+
     test('reconcile flushes everything held once the delay is turned off', () => {
       let delayMs = 5000;
       const { result } = renderHook(() =>

--- a/src/components/Chat/hooks/useChatMessages.ts
+++ b/src/components/Chat/hooks/useChatMessages.ts
@@ -252,6 +252,17 @@ export const useChatMessages = (options: UseChatMessagesOptions) => {
         Number.isFinite(rawDelayMs) && rawDelayMs > 0 ? rawDelayMs : 0;
 
       if (delayMs <= 0) {
+        // An auto-sync delay can collapse to zero mid-stream; a live message
+        // still can't skip past older ones held in the queue.
+        if (countUnread !== false && delayQueueRef.current.size() > 0) {
+          delayQueueRef.current.enqueue(
+            messageWithCachedColor,
+            Date.now(),
+            true,
+          );
+          scheduleDelayTick();
+          return;
+        }
         ingestMessage(messageWithCachedColor, countUnread);
         return;
       }

--- a/src/components/Chat/hooks/useChatSession.ts
+++ b/src/components/Chat/hooks/useChatSession.ts
@@ -23,6 +23,7 @@ import {
   type ChatRenderPreferences,
   usePreference,
 } from '@app/store/preferenceStore';
+import { videoLatencyDisplay$ } from '@app/store/stream/videoLatency';
 import type { UserInfoResponse } from '@app/types/twitch/user';
 import { findCustomHighlight } from '@app/utils/chat/customHighlights/findCustomHighlight';
 import { replaceEmotesWithText } from '@app/utils/chat/replaceEmotesWithText';
@@ -117,7 +118,7 @@ export function useChatSession({
   });
 
   const getChatDelayMs = useCallback(
-    () => resolveEffectiveChatDelayMs(chatDelay),
+    () => resolveEffectiveChatDelayMs(chatDelay, videoLatencyDisplay$.peek()),
     [chatDelay],
   );
 
@@ -156,6 +157,12 @@ export function useChatSession({
 
   useEffect(() => {
     reconcileChatDelay();
+    if (chatDelay !== 'auto') {
+      return;
+    }
+    // In auto mode the effective delay tracks the measured video latency, so
+    // measurement changes need the same reconcile as a preference change.
+    return videoLatencyDisplay$.onChange(() => reconcileChatDelay());
   }, [chatDelay, reconcileChatDelay]);
 
   const chatMentionHaptics = usePreference('chatMentionHaptics');

--- a/src/components/Chat/util/__tests__/chatDelay.test.ts
+++ b/src/components/Chat/util/__tests__/chatDelay.test.ts
@@ -1,0 +1,39 @@
+import {
+  MAX_AUTO_CHAT_DELAY_MS,
+  resolveEffectiveChatDelayMs,
+} from '../chatDelay';
+
+describe('resolveEffectiveChatDelayMs', () => {
+  test('returns zero when the delay is off', () => {
+    expect(resolveEffectiveChatDelayMs('off', 8)).toBe(0);
+  });
+
+  test('converts a manual delay to milliseconds', () => {
+    expect(resolveEffectiveChatDelayMs(5, 8)).toBe(5000);
+  });
+
+  test('clamps negative and non-finite manual delays to zero', () => {
+    expect(resolveEffectiveChatDelayMs(-3, null)).toBe(0);
+    expect(resolveEffectiveChatDelayMs(Number.NaN, null)).toBe(0);
+    expect(resolveEffectiveChatDelayMs(Number.POSITIVE_INFINITY, null)).toBe(0);
+  });
+
+  test('auto follows the measured video latency', () => {
+    expect(resolveEffectiveChatDelayMs('auto', 8.5)).toBe(8500);
+  });
+
+  test('auto is zero until a measurement lands', () => {
+    expect(resolveEffectiveChatDelayMs('auto', null)).toBe(0);
+  });
+
+  test('auto clamps negative and non-finite measurements to zero', () => {
+    expect(resolveEffectiveChatDelayMs('auto', -2)).toBe(0);
+    expect(resolveEffectiveChatDelayMs('auto', Number.NaN)).toBe(0);
+  });
+
+  test('auto caps the hold at the maximum', () => {
+    expect(resolveEffectiveChatDelayMs('auto', 120)).toBe(
+      MAX_AUTO_CHAT_DELAY_MS,
+    );
+  });
+});

--- a/src/components/Chat/util/chatDelay.ts
+++ b/src/components/Chat/util/chatDelay.ts
@@ -1,11 +1,30 @@
+import type { ChatDelaySetting } from '@app/store/preferenceStore';
+
+// Cap on the auto-sync hold so a stalled measurement can't park chat for minutes.
+export const MAX_AUTO_CHAT_DELAY_MS = 30_000;
+
 /**
- * Effective chat-delay (ms) from the manual delay preference. 0 = off.
+ * Effective chat-delay (ms) for a delay setting. 'auto' follows the measured
+ * video latency and is 0 until the first measurement lands. 0 = no delay.
  */
 export function resolveEffectiveChatDelayMs(
-  manualDelaySeconds: number,
+  setting: ChatDelaySetting,
+  measuredVideoLatencySeconds: number | null,
 ): number {
-  if (!Number.isFinite(manualDelaySeconds)) {
+  if (setting === 'auto') {
+    if (
+      typeof measuredVideoLatencySeconds !== 'number' ||
+      !Number.isFinite(measuredVideoLatencySeconds)
+    ) {
+      return 0;
+    }
+    return Math.min(
+      Math.max(0, measuredVideoLatencySeconds) * 1000,
+      MAX_AUTO_CHAT_DELAY_MS,
+    );
+  }
+  if (setting === 'off' || !Number.isFinite(setting)) {
     return 0;
   }
-  return Math.max(0, manualDelaySeconds) * 1000;
+  return Math.max(0, setting) * 1000;
 }

--- a/src/components/RootLayout/RootLayoutShell.tsx
+++ b/src/components/RootLayout/RootLayoutShell.tsx
@@ -25,6 +25,7 @@ import { useObserveEffect } from '@legendapp/state/react';
 import * as Font from 'expo-font';
 import { activateKeepAwakeAsync } from 'expo-keep-awake';
 
+import { PlayerWebViewPrewarm } from '@app/components/StreamPlayer/PlayerWebViewPrewarm';
 import { recordAppSession } from '@app/lib/expo-store-review';
 import { chatStore$ } from '@app/store/chat/observables/chatStore';
 import { preferences$ } from '@app/store/preferenceStore';
@@ -110,5 +111,10 @@ export function RootLayoutShell() {
     },
   );
 
-  return <RootLayoutNav />;
+  return (
+    <>
+      <RootLayoutNav />
+      <PlayerWebViewPrewarm />
+    </>
+  );
 }

--- a/src/components/StreamPlayer/PlayerWebViewPrewarm.tsx
+++ b/src/components/StreamPlayer/PlayerWebViewPrewarm.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { InteractionManager, StyleSheet, View } from 'react-native';
+import { WebView } from 'react-native-webview';
+
+/**
+ * Preconnect hints for the hosts the Twitch embed hits first (embed page,
+ * player assets, GQL, HLS manifests), so DNS and TLS are already done when
+ * the real player mounts.
+ */
+const PREWARM_HTML = `<!doctype html><html><head>
+<link rel="preconnect" href="https://player.twitch.tv">
+<link rel="preconnect" href="https://static.twitchcdn.net">
+<link rel="preconnect" href="https://gql.twitch.tv">
+<link rel="preconnect" href="https://usher.ttvnw.net">
+</head><body></body></html>`;
+
+// Boot is busy; wait out the first transitions before spending memory on the
+// throwaway WebView, then drop it once WebKit's processes are warm.
+const PREWARM_MOUNT_DELAY_MS = 2_500;
+const PREWARM_LIFETIME_MS = 10_000;
+
+/**
+ * Spawns the WebView engine's content/networking processes and preconnects
+ * to Twitch's player hosts once at boot, so the first stream open skips
+ * process launch and TLS setup. Renders nothing visible, never intercepts
+ * touches, and unmounts itself after a few seconds; the warmed processes and
+ * the shared process pool outlive it.
+ */
+export function PlayerWebViewPrewarm() {
+  const [phase, setPhase] = useState<'idle' | 'warming' | 'done'>('idle');
+
+  useEffect(() => {
+    if (phase === 'idle') {
+      let delayTimer: ReturnType<typeof setTimeout> | null = null;
+      const task = InteractionManager.runAfterInteractions(() => {
+        delayTimer = setTimeout(
+          () => setPhase('warming'),
+          PREWARM_MOUNT_DELAY_MS,
+        );
+      });
+      return () => {
+        task.cancel();
+        if (delayTimer) {
+          clearTimeout(delayTimer);
+        }
+      };
+    }
+
+    if (phase === 'warming') {
+      const lifeTimer = setTimeout(() => setPhase('done'), PREWARM_LIFETIME_MS);
+      return () => clearTimeout(lifeTimer);
+    }
+
+    return undefined;
+  }, [phase]);
+
+  if (phase !== 'warming') {
+    return null;
+  }
+
+  return (
+    <View style={styles.hidden} pointerEvents='none'>
+      <WebView
+        javaScriptEnabled={false}
+        source={{ html: PREWARM_HTML }}
+        originWhitelist={['*']}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  hidden: {
+    height: 1,
+    left: -2,
+    opacity: 0,
+    position: 'absolute',
+    top: -2,
+    width: 1,
+  },
+});

--- a/src/components/StreamPlayer/PlayerWebViewPrewarm.web.tsx
+++ b/src/components/StreamPlayer/PlayerWebViewPrewarm.web.tsx
@@ -1,0 +1,7 @@
+/**
+ * The web app has no WebView engine to warm; the native variant preconnects
+ * WebKit to Twitch's player hosts at boot.
+ */
+export function PlayerWebViewPrewarm() {
+  return null;
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -739,9 +739,11 @@ const en = {
     keepHistoryOnClearDescription:
       'Ignore moderator chat clears and keep your scrollback',
     sync: 'Sync',
-    syncFooter: 'Delay chat so it lines up with the video.',
+    syncFooter:
+      'Delay chat so it lines up with the video. Auto matches the measured stream latency.',
     chatDelay: 'Chat Delay',
     chatDelayDescription: 'Hold new messages before showing them',
+    chatDelayAuto: 'Auto',
     chatDelayOff: 'Off',
     chatDelay2s: '2s',
     chatDelay5s: '5s',

--- a/src/screens/Preferences/ChatPreferenceNativeForm.tsx
+++ b/src/screens/Preferences/ChatPreferenceNativeForm.tsx
@@ -232,11 +232,22 @@ export function ChatPreferenceNativeForm() {
           <Picker
             label={t('chatDelay')}
             systemImage='timer'
-            selection={preferences.chatDelay}
-            onSelectionChange={value => update({ chatDelay: value })}
+            selection={String(preferences.chatDelay)}
+            onSelectionChange={value => {
+              const option = CHAT_DELAY_OPTIONS.find(
+                item => String(item.value) === value,
+              );
+              if (option) {
+                update({ chatDelay: option.value });
+              }
+            }}
           >
             {CHAT_DELAY_OPTIONS.map(option => (
-              <NativeText key={option.value} modifiers={[tag(option.value)]}>
+              // SwiftUI tag matching needs one type; the values mix 'auto'/'off' and numbers.
+              <NativeText
+                key={option.value}
+                modifiers={[tag(String(option.value))]}
+              >
                 {t(option.labelKey)}
               </NativeText>
             ))}

--- a/src/screens/Preferences/__tests__/ChatPreferenceScreen.test.tsx
+++ b/src/screens/Preferences/__tests__/ChatPreferenceScreen.test.tsx
@@ -35,7 +35,7 @@ const mockPreferences: Preferences = {
   chatTimestampFormat: '24h',
   chatFontScale: 'default',
   chatScrollback: 150,
-  chatDelay: 0,
+  chatDelay: 'off',
   deletedMessageStyle: 'notice',
   ignoreClearChat: false,
   chatMentionHaptics: true,

--- a/src/screens/Preferences/chatPreferenceTypes.ts
+++ b/src/screens/Preferences/chatPreferenceTypes.ts
@@ -64,9 +64,10 @@ export const SCROLLBACK_OPTIONS = [
 
 export const SCROLLBACK_LABELS = SCROLLBACK_OPTIONS.map(option => option.label);
 
-// Manual chat-delay presets (seconds), shared by the iOS Picker and Android segmented control.
+// Chat-delay presets (auto-sync, off, manual seconds), shared by the iOS Picker and Android segmented control.
 export const CHAT_DELAY_OPTIONS = [
-  { labelKey: 'chatDelayOff', value: 0 as const },
+  { labelKey: 'chatDelayAuto', value: 'auto' as const },
+  { labelKey: 'chatDelayOff', value: 'off' as const },
   { labelKey: 'chatDelay2s', value: 2 as const },
   { labelKey: 'chatDelay5s', value: 5 as const },
   { labelKey: 'chatDelay8s', value: 8 as const },

--- a/src/store/__tests__/preferenceStore.test.tsx
+++ b/src/store/__tests__/preferenceStore.test.tsx
@@ -36,7 +36,7 @@ const basePreferences = {
   chatTimestampFormat: '24h',
   chatFontScale: 'default',
   chatScrollback: 150,
-  chatDelay: 0,
+  chatDelay: 'off',
   deletedMessageStyle: 'notice',
   ignoreClearChat: false,
   chatMentionHaptics: true,

--- a/src/store/preferenceStore.ts
+++ b/src/store/preferenceStore.ts
@@ -26,6 +26,7 @@ export type ChatFontScale = 'small' | 'default' | 'large';
 export type ChatTimestampFormat = '24h' | '12h';
 export type DeletedMessageStyle = 'notice' | 'hidden';
 export type ChatScrollbackLength = 150 | 200 | 250;
+export type ChatDelaySetting = 'auto' | 'off' | number;
 export type SevenTvPaintRenderer = 'off' | 'native' | 'skia' | 'webview';
 export type PaintRendererFlag = 'off' | 'native' | 'skia';
 
@@ -60,9 +61,11 @@ export interface Preferences {
   chatFontScale: ChatFontScale;
   chatScrollback: ChatScrollbackLength;
   /**
-   * Seconds to hold new chat messages before showing them. 0 = off.
+   * Hold on new chat messages so chat lines up with the latency-delayed
+   * video. 'auto' follows the measured stream latency, 'off' shows messages
+   * immediately, a number holds them for that many seconds.
    */
-  chatDelay: number;
+  chatDelay: ChatDelaySetting;
   deletedMessageStyle: DeletedMessageStyle;
   ignoreClearChat: boolean;
   chatMentionHaptics: boolean;
@@ -120,7 +123,7 @@ export const preferencesSchema = z.object({
   chatTimestampFormat: z.enum(['24h', '12h']),
   chatFontScale: z.enum(['small', 'default', 'large']),
   chatScrollback: z.union([z.literal(150), z.literal(200), z.literal(250)]),
-  chatDelay: z.number(),
+  chatDelay: z.union([z.literal('auto'), z.literal('off'), z.number()]),
   deletedMessageStyle: z.enum(['notice', 'hidden']),
   ignoreClearChat: z.boolean(),
   chatMentionHaptics: z.boolean(),
@@ -167,7 +170,7 @@ export const initialPreferences: Preferences = {
   chatTimestampFormat: '24h',
   chatFontScale: 'default',
   chatScrollback: 150,
-  chatDelay: 0,
+  chatDelay: 'auto',
   deletedMessageStyle: 'notice',
   ignoreClearChat: false,
   chatMentionHaptics: true,
@@ -199,6 +202,12 @@ when(persistedPreferences$?._state?.isLoadedLocal, () => {
 
   if ((preferences$.sevenTvPaintRenderer.peek() as string) === 'auto') {
     preferences$.sevenTvPaintRenderer.set('native');
+  }
+
+  // chatDelay 0 predates 'auto'/'off' and was the numeric Off default; the
+  // explicit value is 'off' now, so legacy zeros move to the new default.
+  if (preferences$.chatDelay.peek() === 0) {
+    preferences$.chatDelay.set('auto');
   }
 });
 

--- a/src/store/preferences/__tests__/preferenceStore.test.tsx
+++ b/src/store/preferences/__tests__/preferenceStore.test.tsx
@@ -33,7 +33,7 @@ const basePreferences = {
   chatTimestampFormat: '24h',
   chatFontScale: 'default',
   chatScrollback: 150,
-  chatDelay: 0,
+  chatDelay: 'off',
   deletedMessageStyle: 'notice',
   ignoreClearChat: false,
   chatMentionHaptics: true,


### PR DESCRIPTION
## Summary

Four independent fixes/improvements, one commit each:

### feat(chat): sync chat to video latency by default
Chat ran ~10s ahead of the video. `chatDelay` becomes `'auto' | 'off' | number` with **`'auto'` as the default**: messages are held for the measured `hlsLatencyBroadcaster` latency (30s cap) so chat lines up with the delayed video. Legacy persisted `0` migrates to `'auto'` at boot; explicit Off remains. `useChatSession` reconciles the delay queue when the measurement changes, and `useChatMessages` gains a guard so an auto delay collapsing to zero cannot reorder live messages past held ones. Both settings forms gained an Auto option (iOS Picker tags string-normalized for SwiftUI tag matching).

Note: until the first latency measurement lands (~4s after playback starts) chat flows undelayed, then syncs — one quiet gap of roughly the stream latency after opening a channel is expected.

### fix(chat): 7tv cosmetic username typography + phase-locked paint animations
- Skia painted names shaped true Montserrat 700 while plain usernames resolve to the 400 face on iOS (expo-font registers single-face aliased families, so style `fontWeight: '700'` has no bold sibling to pick). The rasterizer's inherited weight is now platform-matched (Normal on iOS, Bold on Android which faux-bolds).
- Trailing spaces in `"name: "` are shaped as NBSP so the painted bitmap keeps the gap SkParagraph would otherwise trim off `getLongestLine()`.
- Animated paint textures move to a shared per-URL frame clock (`useSharedPaintAnimationFrame`): every row with the same paint shows the same frame at the same time, and each frame decodes once total instead of once per row. Ref-counted with a 5s linger so recycled rows rejoin in phase.

### fix(native): bottom-sheet rotation crash (FOAM-TV-MOBILE-1F)
[Sentry 133706537](https://foam-tv.sentry.io/issues/133706537/): `@swmansion/react-native-bottom-sheet` calls `RCTFatal` when a fixed detent exceeds measured content height — hit transiently on rotation (native re-measures at new bounds while JS still holds detents from the old window height; 787 = round(0.85 × 926) portrait vs 402pt landscape content). Bun patch clamps the detent to content height and downgrades the report to `RCTLogError`.

⚠️ **Native patch — needs a native build before the next OTA.** Sentry issue left unresolved until the fixed build ships.

### perf(player): prewarm WebKit + preconnect Twitch hosts at boot
A short-lived hidden WebView spawns WebKit's content/networking processes and preconnects to `player.twitch.tv`, `static.twitchcdn.net`, `gql.twitch.tv`, and `usher.ttvnw.net` ~2.5s after boot, so the first stream open skips process launch and DNS/TLS setup (~300–700ms cold). The post-transition mount gate in `StreamPlayer` (compositing fix) is untouched.

## Testing

- Full suite: 305 suites / 9,731 tests pass; tsc, eslint, prettier clean
- New specs: `chatDelay.test.ts` (resolver incl. auto mode), `useChatMessages` ordering guard
- Not yet device-verified: sync feel, Skia weight/gap parity, animation lockstep — worth a quick TestFlight/device pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)