### PR TITLE
feat(chat): join/part system messages behind preference (#727)

### DIFF
--- a/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
+++ b/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
@@ -381,6 +381,7 @@ const setPreferences = (showRecentMessages = true) => {
     showTwitchEmotes: true,
     showTwitchBadges: true,
     showUnreadJumpPill: true,
+    showJoinPartMessages: false,
     blockedTerms: [],
     chatTimestampFormat: '24h',
     chatFontScale: 'default',

--- a/src/components/Chat/components/SettingsSheet/SettingsSheet.tsx
+++ b/src/components/Chat/components/SettingsSheet/SettingsSheet.tsx
@@ -50,6 +50,7 @@ const SettingsSheetComponent = ({
   const showInlineReplyContext = usePreference('showInlineReplyContext');
   const showTimestamps = usePreference('chatTimestamps');
   const showUnreadJumpPill = usePreference('showUnreadJumpPill');
+  const showJoinPartMessages = usePreference('showJoinPartMessages');
   const updatePreferences = useUpdatePreferences();
   const { bottom: bottomInset } = useSafeAreaInsets();
 
@@ -191,6 +192,18 @@ const SettingsSheetComponent = ({
               value={showUnreadJumpPill}
               onValueChange={value =>
                 updatePreferences({ showUnreadJumpPill: value })
+              }
+            />
+            <SettingsToggleRow
+              title={t('settingsSheet.showJoinPartMessages')}
+              icon={{
+                icon: 'person.badge.plus',
+                androidIcon: 'group_add',
+                color: ICON_TINT,
+              }}
+              value={showJoinPartMessages}
+              onValueChange={value =>
+                updatePreferences({ showJoinPartMessages: value })
               }
             />
           </SettingsSection>

--- a/src/components/Chat/hooks/__tests__/useChatIrcHandlers.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChatIrcHandlers.test.ts
@@ -5,6 +5,7 @@ import {
   clearMessages,
   clearMessagesWithNotice,
 } from '@app/store/chat/actions/messages';
+import { preferences$ } from '@app/store/preferenceStore';
 
 import { useChatIrcHandlers } from '../useChatIrcHandlers';
 
@@ -81,6 +82,10 @@ function renderIrcHandlers({
 describe('useChatIrcHandlers', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    preferences$.showJoinPartMessages.set(false);
   });
 
   test('skips the connected notice while recent history is loading', () => {
@@ -354,6 +359,39 @@ describe('useChatIrcHandlers', () => {
     expect(addedSystemMessageContents()).toEqual([
       'Chat modes active: slow mode (30s)',
     ]);
+  });
+
+  test('announces a chatter joining when join/part messages are enabled', () => {
+    preferences$.showJoinPartMessages.set(true);
+    const { result } = renderIrcHandlers();
+
+    act(() => {
+      result.current.onUserJoin('#foam', 'bob');
+    });
+
+    expect(addedSystemMessageContents()).toEqual(['bob joined']);
+  });
+
+  test('announces a chatter parting when join/part messages are enabled', () => {
+    preferences$.showJoinPartMessages.set(true);
+    const { result } = renderIrcHandlers();
+
+    act(() => {
+      result.current.onUserPart('#foam', 'bob');
+    });
+
+    expect(addedSystemMessageContents()).toEqual(['bob parted']);
+  });
+
+  test('suppresses join/part notices while the preference is off', () => {
+    const { result } = renderIrcHandlers();
+
+    act(() => {
+      result.current.onUserJoin('#foam', 'bob');
+      result.current.onUserPart('#foam', 'bob');
+    });
+
+    expect(mockAddMessage).not.toHaveBeenCalled();
   });
 
   test('reconnect resets the room state and announces the reconnect', () => {

--- a/src/components/Chat/hooks/useChatIrcHandlers.ts
+++ b/src/components/Chat/hooks/useChatIrcHandlers.ts
@@ -372,6 +372,26 @@ export function useChatIrcHandlers({
     ],
   );
 
+  const onUserJoin = useCallback(
+    (_channel: string, username: string) => {
+      if (!getPreferences().showJoinPartMessages) {
+        return;
+      }
+      appendSystemMessage(`${username} joined`);
+    },
+    [appendSystemMessage],
+  );
+
+  const onUserPart = useCallback(
+    (_channel: string, username: string) => {
+      if (!getPreferences().showJoinPartMessages) {
+        return;
+      }
+      appendSystemMessage(`${username} parted`);
+    },
+    [appendSystemMessage],
+  );
+
   const onNotice = useCallback(
     (_channel: string, tags: Record<string, string>, messageText: string) => {
       const noticeId = tags['msg-id'];
@@ -477,6 +497,8 @@ export function useChatIrcHandlers({
     onPart,
     onReconnect,
     onRoomState,
+    onUserJoin,
+    onUserPart,
     onUserNotice,
   };
 }

--- a/src/components/Chat/hooks/useChatSession.ts
+++ b/src/components/Chat/hooks/useChatSession.ts
@@ -247,6 +247,8 @@ export function useChatSession({
     onPart,
     onReconnect,
     onRoomState,
+    onUserJoin,
+    onUserPart,
     onUserNotice,
   } = useChatIrcHandlers({
     channelId,
@@ -286,6 +288,8 @@ export function useChatSession({
     onRoomState,
     onJoin,
     onPart,
+    onUserJoin,
+    onUserPart,
   });
 
   useSyntheticChatFlood({

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -221,6 +221,7 @@ const en = {
       highlightOwnMentions: 'Highlight Own Mentions',
       inlineReplyContext: 'Inline Reply Context',
       showJumpPill: 'Show Jump Pill',
+      showJoinPartMessages: 'Show Join/Part Messages',
       reconnect: 'Reconnect',
       clearCache: 'Clear Cache',
       syncToLive: 'Sync to Live',

--- a/src/screens/Preferences/__tests__/ChatPreferenceScreen.test.tsx
+++ b/src/screens/Preferences/__tests__/ChatPreferenceScreen.test.tsx
@@ -18,6 +18,7 @@ const mockPreferences: Preferences = {
   showInlineReplyContext: true,
   showRecentMessages: true,
   showUnreadJumpPill: true,
+  showJoinPartMessages: false,
   disableChat: false,
   disableStream: false,
   useUIKitForWebView: false,

--- a/src/services/__tests__/twitch-chat-service.test.ts
+++ b/src/services/__tests__/twitch-chat-service.test.ts
@@ -5,6 +5,7 @@ import { ReadyState } from '@app/hooks/ws/constants';
 import type { Options } from '@app/hooks/ws/types';
 import { useWebsocket } from '@app/hooks/ws/useWebsocket';
 import { useTwitchChat } from '@app/services/twitch-chat-service';
+import { preferences$ } from '@app/store/preferenceStore';
 import { subscribeToAppStateTransitions } from '@app/utils/appState/appStateTransitions';
 
 jest.mock('@app/context/AuthContext', () => ({
@@ -201,5 +202,91 @@ describe('useTwitchChat foreground liveness probe', () => {
 
     expect(reconnect).toHaveBeenCalledTimes(1);
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('useTwitchChat join/part routing', () => {
+  beforeEach(() => {
+    socketReadyState = WebSocket.OPEN;
+    wsOptions = {};
+    preferences$.showJoinPartMessages.set(false);
+    mockedUseWebsocket.mockImplementation((_url, options = {}) => {
+      wsOptions = options;
+      return {
+        sendMessage,
+        sendJsonMessage: jest.fn(),
+        lastMessage: new MessageEvent('message'),
+        lastJsonMessage: null,
+        readyState: ReadyState.OPEN,
+        getWebSocket: () => socket,
+        reconnect,
+      };
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function feedLine(line: string) {
+    act(() => {
+      wsOptions.onMessage?.(
+        new MessageEvent('message', { data: `${line}\r\n` }),
+      );
+    });
+  }
+
+  test('routes another chatter’s JOIN and PART to the user handlers', () => {
+    const onUserJoin = jest.fn();
+    const onUserPart = jest.fn();
+    const onJoin = jest.fn();
+    const onPart = jest.fn();
+    renderHook(() =>
+      useTwitchChat({
+        channel: 'foam',
+        onUserJoin,
+        onUserPart,
+        onJoin,
+        onPart,
+      }),
+    );
+    act(() => {
+      wsOptions.onOpen?.();
+    });
+
+    feedLine(':bob!bob@bob.tmi.twitch.tv JOIN #foam');
+    feedLine(':bob!bob@bob.tmi.twitch.tv PART #foam');
+
+    expect(onUserJoin).toHaveBeenCalledWith('#foam', 'bob');
+    expect(onUserPart).toHaveBeenCalledWith('#foam', 'bob');
+    expect(onJoin).not.toHaveBeenCalled();
+    expect(onPart).not.toHaveBeenCalled();
+  });
+
+  test('requests the membership capability only when join/part messages are enabled', () => {
+    preferences$.showJoinPartMessages.set(true);
+    renderHook(() => useTwitchChat({ channel: 'foam' }));
+    act(() => {
+      wsOptions.onOpen?.();
+    });
+
+    const capReq = sendMessage.mock.calls
+      .map(([payload]) => payload as string)
+      .find(payload => payload.startsWith('CAP REQ'));
+    expect(capReq).toBe(
+      'CAP REQ :twitch.tv/tags twitch.tv/commands twitch.tv/membership\r\n',
+    );
+  });
+
+  test('omits the membership capability when the preference is off', () => {
+    renderHook(() => useTwitchChat({ channel: 'foam' }));
+    act(() => {
+      wsOptions.onOpen?.();
+    });
+
+    const capReq = sendMessage.mock.calls
+      .map(([payload]) => payload as string)
+      .find(payload => payload.startsWith('CAP REQ'));
+    expect(capReq).toBe('CAP REQ :twitch.tv/tags twitch.tv/commands\r\n');
   });
 });

--- a/src/services/twitch-chat-service.ts
+++ b/src/services/twitch-chat-service.ts
@@ -5,6 +5,7 @@ import * as Network from 'expo-network';
 import { useAuthContext } from '@app/context/AuthContext';
 import { useLazyRef } from '@app/hooks/useLazyRef';
 import { isE2EMode } from '@app/services/api/clients';
+import { usePreference } from '@app/store/preferenceStore';
 import { UserNoticeTags } from '@app/types/chat/irc-tags/usernotice';
 import { subscribeToAppStateTransitions } from '@app/utils/appState/appStateTransitions';
 import { getHeartbeatAction } from '@app/utils/chat/chatHeartbeat';
@@ -63,6 +64,8 @@ interface UseTwitchChatOptions {
   ) => void;
   onJoin?: (channel: string) => void;
   onPart?: (channel: string) => void;
+  onUserJoin?: (channel: string, username: string) => void;
+  onUserPart?: (channel: string, username: string) => void;
   onNotice?: (
     channel: string,
     tags: Record<string, string>,
@@ -99,6 +102,9 @@ export function useTwitchChat(options: UseTwitchChatOptions = {}) {
   const optionsRef = useRef<UseTwitchChatOptions>({});
   optionsRef.current = options;
   const { authState, user } = useAuthContext();
+  const showJoinPartMessages = usePreference('showJoinPartMessages');
+  const showJoinPartMessagesRef = useRef(showJoinPartMessages);
+  showJoinPartMessagesRef.current = showJoinPartMessages;
   const channel = optionsRef.current.channel;
   const blockedUsers = optionsRef.current.blockedUsers ?? [];
   const mutedWords = optionsRef.current.mutedWords ?? [];
@@ -110,6 +116,10 @@ export function useTwitchChat(options: UseTwitchChatOptions = {}) {
   const anonymousNickRef = useRef(
     `justinfan${Math.floor(Math.random() * 90000) + 10000}`,
   );
+  // The nick we authenticated with (login or anonymous justinfan). JOIN/PART
+  // lines carry the acting user in their prefix, so this lets us tell our own
+  // connection join/part apart from other chatters'.
+  const currentNickRef = useRef('');
   const pendingIrcMessagesRef = useRef<string[]>([]);
   // Seeded on open and refreshed on every inbound line; the heartbeat only
   // reads it once readyState is OPEN, by which point onOpen has set it.
@@ -174,6 +184,13 @@ export function useTwitchChat(options: UseTwitchChatOptions = {}) {
     sendMessageFn(payload);
   }, []);
 
+  // A JOIN/PART with no prefix, or one matching the nick we authenticated with,
+  // is our own connection; anything else is another chatter.
+  const isSelfNick = (nick: string | undefined) =>
+    !nick ||
+    !currentNickRef.current ||
+    nick.toLowerCase() === currentNickRef.current.toLowerCase();
+
   const markChannelJoined = (channelName: string) => {
     const channelFormatted = formatIrcChannelName(channelName);
     pendingJoinChannelsRef.current.delete(channelFormatted);
@@ -219,6 +236,8 @@ export function useTwitchChat(options: UseTwitchChatOptions = {}) {
       ? `oauth:${accessToken}`
       : 'SCHMOOPIIE';
 
+    currentNickRef.current = nickname;
+
     logger.chat.info(
       canUseAuthenticatedChat
         ? 'Authenticating with Twitch IRC...'
@@ -231,7 +250,10 @@ export function useTwitchChat(options: UseTwitchChatOptions = {}) {
       );
     }
 
-    sendIrcCommand('CAP REQ :twitch.tv/tags twitch.tv/commands');
+    const capabilities = showJoinPartMessagesRef.current
+      ? 'twitch.tv/tags twitch.tv/commands twitch.tv/membership'
+      : 'twitch.tv/tags twitch.tv/commands';
+    sendIrcCommand(`CAP REQ :${capabilities}`);
     sendIrcCommand('PASS', passToken);
     sendIrcCommand('NICK', nickname);
 
@@ -486,9 +508,14 @@ export function useTwitchChat(options: UseTwitchChatOptions = {}) {
         if (params.length > 0) {
           const channelName = params[0];
           if (channelName) {
-            markChannelJoined(channelName);
-            logger.chat.info(`✅ Joined channel: ${channelName}`);
-            optionsRef.current.onJoin?.(channelName);
+            const nick = prefix?.split('!')[0];
+            if (isSelfNick(nick)) {
+              markChannelJoined(channelName);
+              logger.chat.info(`✅ Joined channel: ${channelName}`);
+              optionsRef.current.onJoin?.(channelName);
+            } else if (nick) {
+              optionsRef.current.onUserJoin?.(channelName, nick);
+            }
           }
         }
         break;
@@ -498,10 +525,15 @@ export function useTwitchChat(options: UseTwitchChatOptions = {}) {
         if (params.length > 0) {
           const channelName = params[0];
           if (channelName) {
-            logger.chat.info(`Left channel: ${channelName}`);
-            pendingJoinChannelsRef.current.delete(channelName);
-            joinedChannelsRef.current.delete(channelName);
-            optionsRef.current.onPart?.(channelName);
+            const nick = prefix?.split('!')[0];
+            if (isSelfNick(nick)) {
+              logger.chat.info(`Left channel: ${channelName}`);
+              pendingJoinChannelsRef.current.delete(channelName);
+              joinedChannelsRef.current.delete(channelName);
+              optionsRef.current.onPart?.(channelName);
+            } else if (nick) {
+              optionsRef.current.onUserPart?.(channelName, nick);
+            }
           }
         }
         break;
@@ -800,6 +832,25 @@ export function useTwitchChat(options: UseTwitchChatOptions = {}) {
       getWebSocketRef.current().close(4001, 'auth token refreshed');
     }
   }, [authState?.token?.accessToken, shouldConnect]);
+
+  // Membership is negotiated once at authenticate time, so a live socket won't
+  // start (or stop) receiving other users' JOIN/PART until it reconnects with a
+  // new CAP REQ. Bounce the socket when the preference flips.
+  const previousShowJoinPartRef = useRef(showJoinPartMessages);
+  useEffect(() => {
+    const previous = previousShowJoinPartRef.current;
+    previousShowJoinPartRef.current = showJoinPartMessages;
+    if (previous === showJoinPartMessages || !shouldConnect) {
+      return;
+    }
+    if (getWebSocketRef.current().readyState !== WebSocket.OPEN) {
+      return;
+    }
+    logger.chat.info(
+      '[useTwitchChat] Join/part preference changed, reconnecting IRC to renegotiate membership capability',
+    );
+    getWebSocketRef.current().close(4005, 'membership capability change');
+  }, [showJoinPartMessages, shouldConnect]);
 
   useEffect(() => {
     sendIrcMessageRef.current = sendWebSocketMessage;

--- a/src/store/__tests__/preferenceStore.test.tsx
+++ b/src/store/__tests__/preferenceStore.test.tsx
@@ -19,6 +19,7 @@ const basePreferences = {
   showInlineReplyContext: true,
   showRecentMessages: true,
   showUnreadJumpPill: true,
+  showJoinPartMessages: false,
   disableChat: false,
   disableStream: false,
   useUIKitForWebView: false,

--- a/src/store/preferenceStore.ts
+++ b/src/store/preferenceStore.ts
@@ -46,6 +46,12 @@ export interface Preferences {
   showInlineReplyContext: boolean;
   showRecentMessages: boolean;
   showUnreadJumpPill: boolean;
+  /**
+   * Show a system message when a user joins or leaves the channel's chat, like
+   * Chatterino. Requires the IRC membership capability, so toggling it
+   * reconnects chat.
+   */
+  showJoinPartMessages: boolean;
   disableChat: boolean;
   disableStream: boolean;
   useUIKitForWebView: boolean;
@@ -110,6 +116,7 @@ export const preferencesSchema = z.object({
   showInlineReplyContext: z.boolean(),
   showRecentMessages: z.boolean(),
   showUnreadJumpPill: z.boolean(),
+  showJoinPartMessages: z.boolean(),
   disableChat: z.boolean(),
   disableStream: z.boolean(),
   useUIKitForWebView: z.boolean(),
@@ -158,6 +165,7 @@ export const initialPreferences: Preferences = {
   showInlineReplyContext: true,
   showRecentMessages: true,
   showUnreadJumpPill: true,
+  showJoinPartMessages: false,
   disableChat: false,
   disableStream: false,
   useUIKitForWebView: false,

--- a/src/store/preferences/__tests__/preferenceStore.test.tsx
+++ b/src/store/preferences/__tests__/preferenceStore.test.tsx
@@ -16,6 +16,7 @@ const basePreferences = {
   showInlineReplyContext: true,
   showRecentMessages: true,
   showUnreadJumpPill: true,
+  showJoinPartMessages: false,
   disableChat: false,
   disableStream: false,
   useUIKitForWebView: false,


### PR DESCRIPTION
Closes #727

## What

Adds a **Show Join/Part Messages** chat preference (default **off**) that posts a Chatterino-style system line when other chatters join or leave the channel.

## How

- **Preference** (`preferenceStore.ts`): new `showJoinPartMessages: boolean`, default `false`, added to the interface, zod schema, and defaults.
- **IRC service** (`twitch-chat-service.ts`):
  - The `twitch.tv/membership` capability is only requested in `CAP REQ` when the preference is on - that capability is what makes Twitch deliver other users' JOIN/PART.
  - We track the nick we authenticated with (`currentNickRef`) and split JOIN/PART lines by their prefix: our own connection still drives `onJoin`/`onPart` (unchanged), while other chatters route to new `onUserJoin`/`onUserPart` callbacks.
  - Membership is negotiated once at connect time, so flipping the preference bounces the socket to renegotiate.
- **Handlers** (`useChatIrcHandlers.ts` → `useChatSession.ts`): `onUserJoin` posts `"{user} joined"`, `onUserPart` posts `"{user} parted"`, both gated on the preference.
- **UI** (`SettingsSheet.tsx` + `en.ts`): toggle row in the chat settings sheet's Appearance section.

## Notes

Twitch only reliably sends membership JOIN/PART for smaller channels and stops for very large ones, so these lines are sparse or absent on big streams - the same limitation Chatterino has.

## Tests

- `useChatIrcHandlers`: notices appear when enabled, suppressed when off, correct "joined"/"parted" wording.
- `twitch-chat-service`: other chatters' JOIN/PART route to the user handlers (not self); membership capability present in `CAP REQ` only when enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)