### PR TITLE
fix(preferences): render chat settings emote/badge previews inside native form

### DIFF
--- a/src/screens/Preferences/ChatPreferenceNativeForm.tsx
+++ b/src/screens/Preferences/ChatPreferenceNativeForm.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement, useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, useWindowDimensions, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -40,10 +40,10 @@ import {
   TIMESTAMP_FORMAT_OPTIONS,
 } from './chatPreferenceTypes';
 
-function hostPreview(node: ReactElement, padded = true) {
+function hostPreview(node: ReactElement, width: number, padded = true) {
   return (
     <RNHostView matchContents>
-      {padded ? <View style={styles.previewRow}>{node}</View> : node}
+      <View style={[{ width }, padded ? styles.previewRow : null]}>{node}</View>
     </RNHostView>
   );
 }
@@ -52,6 +52,8 @@ export function ChatPreferenceNativeForm() {
   const { t } = useTranslation('preferences');
   const preferences = usePreferences();
   const { update } = preferences;
+  const { width: windowWidth } = useWindowDimensions();
+  const previewWidth = windowWidth - theme.space16 * 2;
 
   const emojiPreviewEmotes = useMemo(() => {
     const emotes = getEmojiEmotes(preferences.emojiStyle);
@@ -120,7 +122,10 @@ export function ChatPreferenceNativeForm() {
               </NativeText>
             ))}
           </Picker>
-          {hostPreview(<DensityPreview density={preferences.chatDensity} />)}
+          {hostPreview(
+            <DensityPreview density={preferences.chatDensity} />,
+            previewWidth,
+          )}
           <Picker
             label={t('fontSize')}
             systemImage='textformat.size'
@@ -138,6 +143,7 @@ export function ChatPreferenceNativeForm() {
               variant='fontScale'
               value={preferences.chatFontScale}
             />,
+            previewWidth,
           )}
           <Toggle
             label={t('alternatingRows')}
@@ -150,6 +156,7 @@ export function ChatPreferenceNativeForm() {
               variant='alternatingRows'
               value={preferences.showAlternatingChatRows}
             />,
+            previewWidth,
           )}
           <Toggle
             label={t('newMessageAnimation')}
@@ -172,7 +179,10 @@ export function ChatPreferenceNativeForm() {
               </NativeText>
             ))}
           </Picker>
-          {hostPreview(<EmojiStylePreview emotes={emojiPreviewEmotes} />)}
+          {hostPreview(
+            <EmojiStylePreview emotes={emojiPreviewEmotes} />,
+            previewWidth,
+          )}
         </Section>
 
         <Section title={t('context')}>
@@ -228,6 +238,7 @@ export function ChatPreferenceNativeForm() {
                 />
               </View>
             </View>,
+            previewWidth,
           )}
         </Section>
 
@@ -330,6 +341,7 @@ export function ChatPreferenceNativeForm() {
                 provider={section.provider}
                 variant='emotes'
               />,
+              previewWidth,
               false,
             )}
             <Toggle
@@ -344,6 +356,7 @@ export function ChatPreferenceNativeForm() {
                 provider={section.provider}
                 variant='badges'
               />,
+              previewWidth,
               false,
             )}
           </Section>
@@ -364,6 +377,7 @@ export function ChatPreferenceNativeForm() {
               variant='emoteAnimations'
               value={preferences.disableEmoteAnimations}
             />,
+            previewWidth,
           )}
         </Section>
       </Form>

--- a/src/screens/Preferences/ChatPreferencesPreview.tsx
+++ b/src/screens/Preferences/ChatPreferencesPreview.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import type { ReactNode } from 'react';
 
+import { EmoteRenderer } from '@app/components/Chat/components/ChatMessage/renderers/EmoteRenderer';
 import { RichChatMessage } from '@app/components/Chat/components/ChatMessage/RichChatMessage';
 import { SymbolView } from '@app/components/ui/Icon/Icon';
 import { Text } from '@app/components/ui/Text/Text';
@@ -12,6 +13,7 @@ import { type UserStateTags } from '@app/types/chat/irc-tags/userstate';
 import { type SanitisedEmote } from '@app/types/emote';
 import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
 import { type ParsedPart } from '@app/utils/chat/parsedPart';
+import { getParsedPartStringContent } from '@app/utils/chat/parsedPartContent';
 import { replaceTextWithEmotes } from '@app/utils/chat/replaceTextWithEmotes';
 
 import { chatPreferencePreviewFixtures } from './chatPreferencePreviewFixtures';
@@ -228,10 +230,12 @@ export const ChatPreferencePreview = memo(function ChatPreferencePreview(
 
     case 'emoteAnimations': {
       return (
-        <ChatPreviewSurface
-          messages={[previewMessages.emoteAnimations]}
-          settings={{ disableEmoteAnimations: value }}
+        <PreviewEmoteLine
+          disableAnimations={value}
+          parts={previewMessages.emoteAnimations.message}
           testID='chat-preference-preview-emote-animations'
+          username='EmoteFan'
+          usernameColor={theme.color.chatSample.amber}
         />
       );
     }
@@ -347,6 +351,61 @@ const ChatPreviewSurface = function ChatPreviewSurface({
   );
 };
 
+/**
+ * Renders `username: text [emote] text` with plain primitives. The full
+ * RichChatMessage flex body collapses its standalone text nodes to a few pixels
+ * inside the RNHostView-embedded SwiftUI form, so the words vanish; EmoteRenderer
+ * still measures correctly and keeps the animation toggle for the emote parts.
+ */
+const PreviewEmoteLine = function PreviewEmoteLine({
+  disableAnimations = false,
+  parts,
+  testID,
+  username,
+  usernameColor,
+}: {
+  disableAnimations?: boolean;
+  parts: ParsedPart[];
+  testID: string;
+  username: string;
+  usernameColor: string;
+}) {
+  return (
+    <PreviewCard testID={testID}>
+      <View style={styles.providerPreviewSurface} pointerEvents='none'>
+        <View style={styles.providerEmoteRow}>
+          <Text style={{ color: usernameColor }} type='caption' weight='bold'>
+            {username}:
+          </Text>
+          {parts.map(part => {
+            if (part.type === 'emote') {
+              return (
+                <EmoteRenderer
+                  key={`emote-${part.name}`}
+                  disableAnimations={disableAnimations}
+                  part={part}
+                  targetSize={24}
+                />
+              );
+            }
+
+            const content = getParsedPartStringContent(part).trim();
+            if (!content) {
+              return null;
+            }
+
+            return (
+              <Text key={`text-${content}`} color='gray' type='caption'>
+                {content}
+              </Text>
+            );
+          })}
+        </View>
+      </View>
+    </PreviewCard>
+  );
+};
+
 const ProviderAssetPreview = function ProviderAssetPreview({
   enabled,
   provider,
@@ -359,6 +418,18 @@ const ProviderAssetPreview = function ProviderAssetPreview({
   variant: 'badges' | 'emotes';
 }) {
   const sample = getProviderPreviewSample(provider);
+
+  if (variant === 'emotes' && enabled && sample.emotes.length > 0) {
+    return (
+      <PreviewEmoteLine
+        parts={buildProviderEmoteParts(provider, sample.emotes)}
+        testID={testID}
+        username='username'
+        usernameColor={getProviderPreviewColor(provider)}
+      />
+    );
+  }
+
   const message =
     variant === 'emotes'
       ? createPreviewMessage({
@@ -627,6 +698,14 @@ const styles = StyleSheet.create({
   previewStatePillText: {
     color: theme.colorWhite,
     fontSize: theme.fontSize12,
+  },
+  providerEmoteRow: {
+    alignItems: 'center',
+    columnGap: theme.space4,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    paddingHorizontal: theme.space12,
+    rowGap: theme.space2,
   },
   providerPreviewSurface: {
     backgroundColor: theme.color.backgroundSecondary.dark,

--- a/src/screens/Preferences/chatPreferencePreviewFixtures.ts
+++ b/src/screens/Preferences/chatPreferencePreviewFixtures.ts
@@ -25,12 +25,12 @@ function requireValue<T>(value: T | undefined, message: string): T {
 }
 
 const sevenTvBadgeFallback: SanitisedBadgeSet = {
-  id: 'preview-7tv-badge',
+  id: '62f99d0ce46eb00e438a6984',
   provider: '7tv',
   set: 'preview-7tv',
   title: '7TV Supporter',
   type: '7TV Badge',
-  url: 'https://cdn.7tv.app/emote/01F5PA9D3000034VRANA2SYVDP/4x.avif',
+  url: 'https://cdn.7tv.app/badge/62f99d0ce46eb00e438a6984/4x.webp',
 };
 
 // BTTV badge previews have no runtime source or existing fixture in the app yet.


### PR DESCRIPTION
# Why

Chat settings previews render inside `RNHostView` in the iOS SwiftUI form, and a few were broken: the emote previews (7TV/BTTV/FFZ/Twitch) and the Media animation preview lost their `username:` + text (only emotes showed), and the 7TV badge preview 404'd.

# How

- The emote path routes through RichChatMessage's flex body, whose standalone `<Text>` nodes collapse to ~4px inside the host (confirmed on-device), so words vanished. Badge previews survived because they use the inline single-`<Text>` path. That flex path is intentional for real chat, so this stays preview-only: a `PreviewEmoteLine` helper draws the line with plain `Text` + `EmoteRenderer` (keeps aspect ratio and the animate/still toggle).
- `RNHostView matchContents` doesn't inherit a width from the SwiftUI row, so previews had nothing to lay out against - thread an explicit width into `hostPreview`.
- 7TV badge preview used a placeholder id, and `normalizeSevenTvBadge` rebuilds the CDN url from it. Point the fixture at a real badge.

iOS-only; the Android ScrollView path was never affected.

# Test Plan

Verified on the iPhone 17 Pro simulator: all four provider emote previews, both badge previews, and the Media animation preview render `username:` + text + emotes correctly, and the 7TV badge image loads. `tsc`, `eslint`, and `ChatPreferenceScreen.test.tsx` pass.