### PR TITLE
fix(app): ios 18 tab bar

### DIFF
--- a/src/app/tabs/_layout.tsx
+++ b/src/app/tabs/_layout.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
+import { isLiquidGlassAvailable } from 'expo-glass-effect';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 
 import { useAuthContext } from '@app/context/AuthContext';
@@ -10,8 +11,16 @@ export default function TabsLayout() {
   const isLoggedIn = authState?.isLoggedIn ?? false;
   const { t } = useTranslation('tabs');
 
+  // Below iOS 26 the default scroll-edge appearance is transparent, so pin an opaque material.
+  const liquidGlass = isLiquidGlassAvailable();
+
   return (
-    <NativeTabs tintColor={theme.colorWhite} minimizeBehavior='onScrollDown'>
+    <NativeTabs
+      tintColor={theme.colorWhite}
+      minimizeBehavior='onScrollDown'
+      blurEffect={liquidGlass ? undefined : 'systemChromeMaterial'}
+      disableTransparentOnScrollEdge={!liquidGlass}
+    >
       <NativeTabs.Trigger name='following' hidden={!isLoggedIn}>
         <NativeTabs.Trigger.Label>{t('following')}</NativeTabs.Trigger.Label>
         <NativeTabs.Trigger.Icon sf='person.2' md='group' />

--- a/src/screens/Preferences/BlockedUsersScreen.tsx
+++ b/src/screens/Preferences/BlockedUsersScreen.tsx
@@ -1,6 +1,7 @@
 import { type RefObject, useCallback, useRef } from 'react';
 import { Alert, Platform, ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
   Host,
@@ -297,6 +298,7 @@ function NativeBlockedUsersList({
   onUnblockDirect: (userId: string) => void;
 }) {
   const { t } = useTranslation('preferences');
+  const insets = useSafeAreaInsets();
 
   const handleDelete = (indices: number[]) => {
     for (const index of indices) {
@@ -308,7 +310,10 @@ function NativeBlockedUsersList({
   };
 
   return (
-    <Host style={styles.content} colorScheme='dark'>
+    <Host
+      style={[styles.content, { paddingBottom: insets.bottom }]}
+      colorScheme='dark'
+    >
       <List
         modifiers={[
           listStyle('insetGrouped'),


### PR DESCRIPTION
# Why

Fixes tab bar being transparent on ios 18 and below

# How

If liquid glass available transparent else opaque

# Test Plan

Tested on IOS 18 device 