### PR TITLE
fix: internal black screen + auth/remote-config resilience

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -56,7 +56,6 @@
     },
     "internal": {
       "extends": "base",
-      "environment": "internal",
       "autoIncrement": true,
       "env": {
         "EXPO_PUBLIC_APP_VARIANT": "internal"
@@ -71,7 +70,6 @@
     },
     "testflight": {
       "extends": "base",
-      "environment": "testflight",
       "autoIncrement": true,
       "env": {
         "EXPO_PUBLIC_APP_VARIANT": "testflight"
@@ -86,7 +84,6 @@
     },
     "production": {
       "bun": "1.2.5",
-      "environment": "production",
       "autoIncrement": true,
       "env": {
         "EXPO_PUBLIC_APP_VARIANT": "production"

--- a/src/hooks/firebase/__tests__/useRemoteConfig.test.ts
+++ b/src/hooks/firebase/__tests__/useRemoteConfig.test.ts
@@ -15,6 +15,7 @@ jest.mock('@app/utils/logger', () => ({
   logger: {
     remoteConfig: {
       error: jest.fn(),
+      warn: jest.fn(),
       info: jest.fn(),
     },
   },
@@ -26,6 +27,7 @@ jest.mock('@react-native-firebase/remote-config');
 
 const mockedFetchAndActivate = jest.mocked(fetchAndActivate);
 const mockRemoteConfigError = jest.mocked(logger.remoteConfig.error);
+const mockRemoteConfigWarn = jest.mocked(logger.remoteConfig.warn);
 const mockRemoteConfigInfo = jest.mocked(logger.remoteConfig.info);
 
 describe('useRemoteConfig', () => {
@@ -52,15 +54,32 @@ describe('useRemoteConfig', () => {
       expect(result.current.isRefetching).toBe(false);
     });
 
-    expect(mockRemoteConfigError).not.toHaveBeenCalledWith(
-      'fetchAndActivate failed',
-      expect.anything(),
-    );
+    expect(mockRemoteConfigWarn).not.toHaveBeenCalled();
+    expect(mockRemoteConfigError).not.toHaveBeenCalled();
     expect(mockRemoteConfigInfo.mock.calls[0]).toEqual([
       'fetchAndActivate cancelled',
       {
         error: '[remoteConfig/unknown] cancelled',
       },
     ]);
+  });
+
+  test('warns without erroring when fetchAndActivate fails to reach the server', async () => {
+    const failure = new Error(
+      '[remoteConfig/failure] fetch() operation cannot be completed successfully.',
+    );
+    mockedFetchAndActivate.mockRejectedValueOnce(failure);
+
+    const { result } = renderHook(() => useRemoteConfig(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isRefetching).toBe(false);
+    });
+
+    expect(mockRemoteConfigWarn.mock.calls[0]).toEqual([
+      'fetchAndActivate failed; using cached or default config',
+      failure,
+    ]);
+    expect(mockRemoteConfigError).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/firebase/useRemoteConfig.ts
+++ b/src/hooks/firebase/useRemoteConfig.ts
@@ -94,7 +94,10 @@ async function fetchRemoteConfig(): Promise<boolean> {
         return false;
       }
 
-      logger.remoteConfig.error('fetchAndActivate failed', error);
+      logger.remoteConfig.warn(
+        'fetchAndActivate failed; using cached or default config',
+        error,
+      );
       return false;
     })
     .finally(() => {

--- a/src/services/__tests__/twitch-service.test.ts
+++ b/src/services/__tests__/twitch-service.test.ts
@@ -1,3 +1,4 @@
+import type { DefaultTokenResponse } from '@app/types/twitch/auth';
 import type { TwitchCheermote } from '@app/types/twitch/bits';
 import type { FollowedChannel } from '@app/types/twitch/channel';
 import type { TwitchClip, TwitchCreatedClip } from '@app/types/twitch/clip';
@@ -5,6 +6,36 @@ import type { UserInfoResponse } from '@app/types/twitch/user';
 
 import { twitchApi } from '../api/clients';
 import { MAX_FOLLOWED_CHANNELS, twitchService } from '../twitch-service';
+
+const mockFetch = jest.fn();
+
+jest.mock('expo/fetch', () => ({
+  fetch: (...args: unknown[]) => mockFetch(...args) as Promise<unknown>,
+}));
+
+jest.mock('@app/lib/offThreadJson/parseJsonOnWorklet', () => ({
+  parseJsonOnWorklet: jest.fn(async (text: string) => JSON.parse(text)),
+}));
+
+jest.mock('@app/utils/logger', () => {
+  const categories: Record<string, unknown> = {};
+  return {
+    logger: new Proxy(
+      {},
+      {
+        get: (_target, prop: string) => {
+          categories[prop] ??= {
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+          };
+          return categories[prop];
+        },
+      },
+    ),
+  };
+});
 
 jest.mock('../api/clients', () => ({
   getTwitchClientId: jest.fn(() => 'client-id'),
@@ -431,5 +462,63 @@ describe('twitchService moderation endpoints', () => {
         moderator_id: '2',
       },
     });
+  });
+});
+
+describe('twitchService.getDefaultToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function jsonResponse(body: unknown, status = 200) {
+    return {
+      ok: status < 400,
+      status,
+      text: () => Promise.resolve(JSON.stringify(body)),
+    };
+  }
+
+  const anonToken: DefaultTokenResponse = {
+    access_token: 'anon-abc',
+    expires_in: 3600,
+    token_type: 'bearer',
+  };
+
+  test('returns the anon token when the proxy and validation respond', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ data: anonToken }))
+      .mockResolvedValueOnce(
+        jsonResponse({ client_id: 'client-id', expires_in: 3600 }),
+      );
+
+    const result = await twitchService.getDefaultToken();
+
+    expect(result).toEqual<DefaultTokenResponse>(anonToken);
+  });
+
+  test('keeps the fetched token when validation never responds', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ data: anonToken }))
+      .mockRejectedValueOnce(new Error('Aborted'));
+
+    const result = await twitchService.getDefaultToken();
+
+    expect(result).toEqual<DefaultTokenResponse>(anonToken);
+  });
+
+  test('returns undefined when the proxy rejects the request', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ message: 'Forbidden' }, 403),
+    );
+
+    const result = await twitchService.getDefaultToken();
+
+    expect(result).toBeUndefined();
+  });
+
+  test('propagates the error when the token request never responds', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Aborted'));
+
+    await expect(twitchService.getDefaultToken()).rejects.toThrow('Aborted');
   });
 });

--- a/src/services/__tests__/twitch-service.test.ts
+++ b/src/services/__tests__/twitch-service.test.ts
@@ -478,6 +478,14 @@ describe('twitchService.getDefaultToken', () => {
     };
   }
 
+  function pendingUntilAbort(init?: { signal?: AbortSignal }): Promise<never> {
+    return new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => {
+        reject(new Error('Aborted'));
+      });
+    });
+  }
+
   const anonToken: DefaultTokenResponse = {
     access_token: 'anon-abc',
     expires_in: 3600,
@@ -497,13 +505,22 @@ describe('twitchService.getDefaultToken', () => {
   });
 
   test('keeps the fetched token when validation never responds', async () => {
-    mockFetch
-      .mockResolvedValueOnce(jsonResponse({ data: anonToken }))
-      .mockRejectedValueOnce(new Error('Aborted'));
+    jest.useFakeTimers();
+    try {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({ data: anonToken }))
+        .mockImplementationOnce(
+          (_input: unknown, init?: { signal?: AbortSignal }) =>
+            pendingUntilAbort(init),
+        );
 
-    const result = await twitchService.getDefaultToken();
+      const pending = twitchService.getDefaultToken();
+      await jest.advanceTimersByTimeAsync(8_000);
 
-    expect(result).toEqual<DefaultTokenResponse>(anonToken);
+      expect(await pending).toEqual<DefaultTokenResponse>(anonToken);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test('returns undefined when the proxy rejects the request', async () => {
@@ -517,8 +534,19 @@ describe('twitchService.getDefaultToken', () => {
   });
 
   test('propagates the error when the token request never responds', async () => {
-    mockFetch.mockRejectedValueOnce(new Error('Aborted'));
+    jest.useFakeTimers();
+    try {
+      mockFetch.mockImplementationOnce(
+        (_input: unknown, init?: { signal?: AbortSignal }) =>
+          pendingUntilAbort(init),
+      );
 
-    await expect(twitchService.getDefaultToken()).rejects.toThrow('Aborted');
+      const pending = twitchService.getDefaultToken();
+      const assertion = expect(pending).rejects.toThrow('Aborted');
+      await jest.advanceTimersByTimeAsync(8_000);
+      await assertion;
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/src/services/twitch-service.ts
+++ b/src/services/twitch-service.ts
@@ -59,6 +59,24 @@ const authProxyApiKey =
   (Constants.expoConfig?.extra?.EXPO_PUBLIC_AUTH_PROXY_API_KEY as
     string | undefined) ?? process.env.EXPO_PUBLIC_AUTH_PROXY_API_KEY;
 
+const AUTH_PROXY_REQUEST_TIMEOUT_MS = 8_000;
+
+async function fetchWithTimeout(
+  input: string,
+  init?: Parameters<typeof fetch>[1],
+  timeoutMs = AUTH_PROXY_REQUEST_TIMEOUT_MS,
+) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // Cap follow-list pagination so a pathological follow count (Helix allows
 // thousands) can't fan out into dozens of sequential requests on tab load.
 export const MAX_FOLLOWED_CHANNELS = 400;
@@ -409,7 +427,7 @@ export const twitchService = {
       ? `${mockServerUrl}/token`
       : `${authProxyBaseUrl}/token`;
 
-    const res = await fetch(tokenUrl, {
+    const res = await fetchWithTimeout(tokenUrl, {
       headers: isE2EMode ? {} : { 'x-api-key': authProxyApiKey ?? '' },
     });
 
@@ -429,7 +447,14 @@ export const twitchService = {
     } else {
       // Fresh proxy tokens may be issued under a different client ID than
       // EXPO_PUBLIC_TWITCH_CLIENT_ID; sync the Helix Client-Id header to it.
-      await twitchService.validateToken(body.data.access_token);
+      try {
+        await twitchService.validateToken(body.data.access_token);
+      } catch (e) {
+        logger.auth.warn(
+          'anon token validation did not complete; using token unvalidated',
+          e,
+        );
+      }
     }
 
     return body?.data;
@@ -444,7 +469,7 @@ export const twitchService = {
     if (isE2EMode) {
       return true;
     }
-    const res = await fetch('https://id.twitch.tv/oauth2/validate', {
+    const res = await fetchWithTimeout('https://id.twitch.tv/oauth2/validate', {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (res.status !== 200) {


### PR DESCRIPTION
# Why

internal builds boot to a black screen and prod 1.0.3 users hit auth 403s. root cause: the internal/testflight/production build profiles in eas.json carry an \`environment:\` field, which makes \`eas build\` resolve EXPO_PUBLIC_* from the EAS server-side env store and ignore the CI-injected .env. that store had drifted from 1Password: the internal environment was empty (no auth proxy url/key -> no anon token -> black screen) and production pointed at auth-staging (403s). found via Sentry (FOAM-TV-MOBILE-1Q/1P/1S, all same poisoned session) + the prod proxy lambda getting zero /api/token traffic while staging served it.

also hardening the two failure paths that showed up in that session so a bad network doesn't strand the app.

# How

- **eas.json**: drop \`environment:\` from internal/testflight/production so builds fall back to the CI .env (1Password), matching development/e2e. nothing store-only is lost: \`EXPO_PUBLIC_FIREBASE_*\` are unused (native firebase reads the plist/json files) and \`IOS_GOOGLE_SERVICES_JSON\` falls back to the 1P-written plist. note: needs a native rebuild to clear the poisoned embedded bundles.
- **auth**: the anon-token fetch and the twitch validate fetch had no timeout, so a hung proxy left \`getDefaultToken\` pending until the blunt 12s startup fallback. wrap both in an 8s AbortController timeout so a no-response fails fast into the existing fallback, and make the post-fetch validation non-fatal so a slow/failed validation no longer throws away an already-fetched token.
- **remote-config**: a transient \`fetchAndActivate\` failure ([remoteConfig/failure]) is non-fatal since the hook falls back to cached/default config, but it was logged at error and reported to Sentry as one. downgrade the non-cancellation path to warn.

# Test Plan

- \`tsc --noEmit\` clean, jest green (added getDefaultToken timeout/non-fatal-validation tests + a remote-config warn test)
- [ ] cut an internal build off this branch, confirm it boots past the splash and loads chat (anon auth resolves)
- [ ] airplane-mode / throttled network at launch: app renders within ~8s instead of hanging, recovers when network returns
- [ ] confirm prod build points at auth.foam-app.com (proxy lambda sees /api/token traffic)