### PR TITLE
fix(twitch): handle undefined access_token in getDefaultToken

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -243,6 +243,10 @@ function useAuthContextValue({
         return;
       }
 
+      if (!result?.access_token) {
+        throw new Error('auth proxy returned no anon access token');
+      }
+
       const token = addExpirationTimestamp({
         accessToken: result.access_token,
         expiresIn: result.expires_in,

--- a/src/services/twitch-service.ts
+++ b/src/services/twitch-service.ts
@@ -407,7 +407,7 @@ export const twitchService = {
   /**
    * @returns a token for an anonymous user
    */
-  getDefaultToken: async (): Promise<DefaultTokenResponse> => {
+  getDefaultToken: async (): Promise<DefaultTokenResponse | undefined> => {
     const tokenUrl = isE2EMode
       ? `${mockServerUrl}/token`
       : `${authProxyBaseUrl}/token`;
@@ -415,11 +415,19 @@ export const twitchService = {
     const res = await fetch(tokenUrl, {
       headers: isE2EMode ? {} : { 'x-api-key': authProxyApiKey ?? '' },
     });
+
+    if (!res.ok) {
+      logger.auth.error(
+        `auth proxy returned error status ${res.status} when fetching token`,
+      );
+      return undefined;
+    }
+
     const body = await parseJsonOnWorklet<{ data: DefaultTokenResponse }>(
       await res.text(),
     );
 
-    if (!body.data.access_token) {
+    if (!body?.data?.access_token) {
       logger.auth.error('no token received from auth lambda');
     } else {
       // Fresh proxy tokens may be issued under a different client ID than
@@ -427,7 +435,7 @@ export const twitchService = {
       await twitchService.validateToken(body.data.access_token);
     }
 
-    return body.data;
+    return body?.data;
   },
 
   /**


### PR DESCRIPTION
Recreates #745.

Part of the main → 1.0.3 (`ddb9c48c`) rewind. main was hard-reset to unwind the bundle-mode black screen; this stack re-lands the work since 1.0.3 one PR at a time. Base branch: `recreate/749-chat-timestamps-emote-failures` - review/merge in stack order. Backup of pre-reset main: tag `backup/pre-reset-2d6a3d4b`.