### PR TITLE
chore(ci): swift + kotlin linting with commit hooks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,11 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.{kt,kts}]
+indent_size = 2
+max_line_length = 140
+ktlint_code_style = intellij_idea
+ktlint_standard_no-wildcard-imports = disabled
+ktlint_standard_import-ordering = disabled
+ktlint_standard_filename = disabled

--- a/.github/workflows/native-lint.yml
+++ b/.github/workflows/native-lint.yml
@@ -1,0 +1,38 @@
+name: Check Native Lint
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  swiftlint:
+    name: SwiftLint
+    runs-on: macos-latest
+    steps:
+      - name: 🏗 Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: 📦 Install SwiftLint and SwiftFormat
+        run: brew install swiftlint swiftformat
+
+      - name: 🦅 Run Swift lint
+        run: LINT_CHECK=1 ./scripts/lint-swift.sh
+
+  ktlint:
+    name: ktlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: 📦 Install ktlint
+        run: |
+          curl -sSLO https://github.com/pinterest/ktlint/releases/download/1.8.0/ktlint
+          chmod a+x ktlint
+          sudo mv ktlint /usr/local/bin/
+
+      - name: 🤖 Run Kotlin lint
+        run: LINT_CHECK=1 ./scripts/lint-kotlin.sh

--- a/.github/workflows/native-lint.yml
+++ b/.github/workflows/native-lint.yml
@@ -29,8 +29,14 @@ jobs:
           persist-credentials: false
 
       - name: 📦 Install ktlint
+        env:
+          KTLINT_VERSION: '1.8.0'
+          KTLINT_SHA256: 'a3fd620207d5c40da6ca789b95e7f823c54e854b7fade7f613e91096a3706d75'
         run: |
-          curl -sSLO https://github.com/pinterest/ktlint/releases/download/1.8.0/ktlint
+          set -euo pipefail
+
+          curl --fail -sSLO "https://github.com/pinterest/ktlint/releases/download/${KTLINT_VERSION}/ktlint"
+          echo "${KTLINT_SHA256}  ktlint" | sha256sum -c -
           chmod a+x ktlint
           sudo mv ktlint /usr/local/bin/
 

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,11 @@
+--swiftversion 5.9
+--indent 2
+--maxwidth 120
+--wraparguments before-first
+--wrapparameters before-first
+--wrapcollections before-first
+--self remove
+--commas inline
+--trimwhitespace always
+--disable wrapMultilineStatementBraces
+--exclude ios/Pods,ios/build,build,.build,node_modules

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,31 @@
+included:
+  - modules
+
+excluded:
+  - ios/Pods
+  - ios/build
+  - '**/build'
+  - '**/.build'
+  - node_modules
+
+disabled_rules:
+  - todo
+
+identifier_name:
+  min_length: 1
+  max_length: 60
+  allowed_symbols: ['_']
+  validates_start_with_lowercase: warning
+
+line_length:
+  warning: 140
+  error: 250
+  ignores_comments: true
+  ignores_urls: true
+
+force_cast: warning
+force_try: warning
+closure_parameter_position: warning
+
+type_name:
+  max_length: 60

--- a/modules/changelog/ios/BulletListChangelogItemView.swift
+++ b/modules/changelog/ios/BulletListChangelogItemView.swift
@@ -34,7 +34,6 @@ struct BulletListChangelogItemView: View {
                 .font(.body)
                 .foregroundStyle(.secondary)
             }
-
           }
         }
       }

--- a/modules/changelog/ios/ChangelogDTO.swift
+++ b/modules/changelog/ios/ChangelogDTO.swift
@@ -72,7 +72,6 @@ enum NoteItemDTO: Decodable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let kind = try container.decode(ItemKind.self, forKey: .type)
     switch kind {
-
     case .list:
       let title = try container.decode(String.self, forKey: .title)
       let rows = try container.decode([ListRowDTO].self, forKey: .rows)
@@ -89,7 +88,7 @@ enum NoteItemDTO: Decodable {
 
   func toModel() -> ChangelogVersionNoteItem {
     switch self {
-    case .list(let title, let rows):
+    case let .list(title, rows):
       return .list(
         title: title,
         rows: rows.map { row in
@@ -100,7 +99,7 @@ enum NoteItemDTO: Decodable {
           )
         }
       )
-    case .media(let kind, let url, let title, let description):
+    case let .media(kind, url, title, description):
       let mediaKind: ChangelogVersionNoteItem.MediaKind =
         kind == .image ? .image : .video
       return .media(
@@ -121,18 +120,17 @@ extension ChangelogVersionNotesDTO {
 
 extension ChangelogConfiguration {
   static func from(_ dto: ConfigurationDTO?) -> ChangelogConfiguration {
-    guard let dto = dto else {
+    guard let dto else {
       return ChangelogConfiguration()
     }
 
     let nextLabel = dto.nextButtonLabel ?? "Next"
     let doneLabel = dto.doneButtonLabel ?? "Done"
 
-    let accent: Color
-    if let hex = dto.accentColorHex, let ui = UIColor(ChangelogHex: hex) {
-      accent = Color(uiColor: ui)
+    let accent: Color = if let hex = dto.accentColorHex, let ui = UIColor(ChangelogHex: hex) {
+      Color(uiColor: ui)
     } else {
-      accent = .blue
+      .blue
     }
 
     return ChangelogConfiguration(

--- a/modules/changelog/ios/ChangelogDTO.swift
+++ b/modules/changelog/ios/ChangelogDTO.swift
@@ -127,7 +127,7 @@ extension ChangelogConfiguration {
     let nextLabel = dto.nextButtonLabel ?? "Next"
     let doneLabel = dto.doneButtonLabel ?? "Done"
 
-    let accent: Color = if let hex = dto.accentColorHex, let ui = UIColor(ChangelogHex: hex) {
+    let accent: Color = if let hex = dto.accentColorHex, let ui = UIColor(changelogHex: hex) {
       Color(uiColor: ui)
     } else {
       .blue
@@ -142,8 +142,8 @@ extension ChangelogConfiguration {
 }
 
 extension UIColor {
-  convenience init?(ChangelogHex: String) {
-    var string = ChangelogHex.trimmingCharacters(in: .whitespacesAndNewlines)
+  convenience init?(changelogHex: String) {
+    var string = changelogHex.trimmingCharacters(in: .whitespacesAndNewlines)
     guard string.hasPrefix("#") else {
       return nil
     }

--- a/modules/changelog/ios/ChangelogItemDetailsView.swift
+++ b/modules/changelog/ios/ChangelogItemDetailsView.swift
@@ -17,7 +17,6 @@ struct MediaChangelogItemDetailsView: View {
       Text(title)
         .font(.title3.weight(.bold))
       Text(description)
-
     }
     .multilineTextAlignment(.leading)
     .fixedSize(horizontal: false, vertical: true)

--- a/modules/changelog/ios/ChangelogItemImageView.swift
+++ b/modules/changelog/ios/ChangelogItemImageView.swift
@@ -15,7 +15,7 @@ struct ChangelogItemImageView: View {
       switch phase {
       case .empty:
         ProgressView()
-      case .success(let image):
+      case let .success(image):
         image
           .resizable()
           .scaledToFill()

--- a/modules/changelog/ios/ChangelogItemView.swift
+++ b/modules/changelog/ios/ChangelogItemView.swift
@@ -26,7 +26,7 @@ struct ChangelogItemView: View {
 
       VStack(alignment: .leading, spacing: 0) {
         switch item {
-        case .media(let mediaKind, let url, let title, let description):
+        case let .media(mediaKind, url, title, description):
           VStack(alignment: .center, spacing: 12) {
             let mediaPadding = 16.0
 
@@ -58,7 +58,7 @@ struct ChangelogItemView: View {
 
             Spacer()
           }
-        case .list(let title, let rows):
+        case let .list(title, rows):
           BulletListChangelogItemView(
             title: title,
             rows: rows,

--- a/modules/changelog/ios/ChangelogSheetContentView.swift
+++ b/modules/changelog/ios/ChangelogSheetContentView.swift
@@ -29,7 +29,7 @@ struct ChangelogSheetContentView: View {
   @Environment(\.colorScheme) private var colorScheme
 
   private var currentPage: Int {
-    return selectedPageID
+    selectedPageID
   }
 
   private var isIPad: Bool {
@@ -96,8 +96,8 @@ struct ChangelogSheetContentView: View {
             } label: {
               let buttonTitle: String =
                 isOnLastPage
-                ? configuration.doneButtonLabel
-                : configuration.nextButtonLabel
+                  ? configuration.doneButtonLabel
+                  : configuration.nextButtonLabel
 
               Text(buttonTitle)
                 .fontWeight(.bold)

--- a/modules/changelog/ios/ChangelogUIKitPresent.swift
+++ b/modules/changelog/ios/ChangelogUIKitPresent.swift
@@ -35,13 +35,11 @@ enum ChangelogUIKitPresenter {
       return findTop(from: presented)
     }
     if let navigation = viewController as? UINavigationController,
-      let visible = navigation.visibleViewController
-    {
+       let visible = navigation.visibleViewController {
       return findTop(from: visible)
     }
     if let tab = viewController as? UITabBarController,
-      let selected = tab.selectedViewController
-    {
+       let selected = tab.selectedViewController {
       return findTop(from: selected)
     }
     return viewController
@@ -96,7 +94,7 @@ final class ChangelogPresentationCompletion {
     switch seenMarker {
     case .currentVersion:
       ChangelogStorage.markCurrentVersionAsSeen()
-    case .otaVersion(let otaVersion):
+    case let .otaVersion(otaVersion):
       ChangelogStorage.markOTAVersionAsSeen(otaVersion)
     case nil:
       break
@@ -106,8 +104,7 @@ final class ChangelogPresentationCompletion {
 }
 
 final class ChangelogHostingController: UIHostingController<ChangelogSheetContentView>,
-  UIAdaptivePresentationControllerDelegate
-{
+  UIAdaptivePresentationControllerDelegate {
   private let completion: ChangelogPresentationCompletion
 
   init(
@@ -118,7 +115,8 @@ final class ChangelogHostingController: UIHostingController<ChangelogSheetConten
     super.init(rootView: rootView)
   }
 
-  @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+  @available(*, unavailable)
+  @MainActor dynamic required init?(coder _: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
 
@@ -127,7 +125,7 @@ final class ChangelogHostingController: UIHostingController<ChangelogSheetConten
     presentationController?.delegate = self
   }
 
-  func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+  func presentationControllerDidDismiss(_: UIPresentationController) {
     completion.completeIfNeeded()
   }
 }

--- a/modules/changelog/ios/ChangelogView.swift
+++ b/modules/changelog/ios/ChangelogView.swift
@@ -40,15 +40,16 @@ final class ChangelogView: ExpoView, WKNavigationDelegate {
   }
 
   func loadIfNeeded() {
-    guard let pendingURL = pendingURL,
-      webView.url != pendingURL else {
+    guard let pendingURL,
+          webView.url != pendingURL
+    else {
       return
     }
 
     webView.load(URLRequest(url: pendingURL))
   }
 
-  func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
+  func webView(_ webView: WKWebView, didFinish _: WKNavigation?) {
     guard let url = webView.url?.absoluteString else {
       return
     }

--- a/modules/changelog/ios/Helpers.swift
+++ b/modules/changelog/ios/Helpers.swift
@@ -7,14 +7,13 @@
 
 import Foundation
 
-final class Helpers {
+enum Helpers {
   static func getCurrentAppVersion() -> String {
-    return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
+    Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0"
   }
 
   static func getVersionNotes(for version: String, in notes: [ChangelogVersionNotes])
-    -> [ChangelogVersionNoteItem]
-  {
-    return notes.first(where: { $0.version == version })?.items ?? []
+    -> [ChangelogVersionNoteItem] {
+    notes.first(where: { $0.version == version })?.items ?? []
   }
 }

--- a/modules/changelog/ios/MediaChangelogItemVideoView.swift
+++ b/modules/changelog/ios/MediaChangelogItemVideoView.swift
@@ -83,7 +83,9 @@ struct MediaChangelogItemVideoView: View {
 
 private struct AspectFillVideoPlayer: UIViewRepresentable {
   final class PlayerView: UIView {
-    override static var layerClass: AnyClass { AVPlayerLayer.self }
+    override static var layerClass: AnyClass {
+      AVPlayerLayer.self
+    }
 
     var playerLayer: AVPlayerLayer {
       layer as! AVPlayerLayer
@@ -92,14 +94,14 @@ private struct AspectFillVideoPlayer: UIViewRepresentable {
 
   let player: AVPlayer?
 
-  func makeUIView(context: Context) -> PlayerView {
+  func makeUIView(context _: Context) -> PlayerView {
     let view = PlayerView()
     view.playerLayer.videoGravity = .resizeAspectFill
     view.clipsToBounds = true
     return view
   }
 
-  func updateUIView(_ uiView: PlayerView, context: Context) {
+  func updateUIView(_ uiView: PlayerView, context _: Context) {
     uiView.playerLayer.player = player
   }
 }

--- a/modules/changelog/ios/MediaChangelogItemVideoView.swift
+++ b/modules/changelog/ios/MediaChangelogItemVideoView.swift
@@ -54,8 +54,10 @@ struct MediaChangelogItemVideoView: View {
     let queuePlayer = AVQueuePlayer(playerItem: playerItem)
     queuePlayer.automaticallyWaitsToMinimizeStalling = true
 
-    videoStatusObserver = queuePlayer.observe(\.currentItem?.status, options: [.initial, .new]) {
-      observedPlayer, _ in
+    videoStatusObserver = queuePlayer.observe(
+      \.currentItem?.status,
+      options: [.initial, .new]
+    ) { observedPlayer, _ in
       Task { @MainActor in
         switch observedPlayer.currentItem?.status {
         case .readyToPlay, .failed:
@@ -88,7 +90,10 @@ private struct AspectFillVideoPlayer: UIViewRepresentable {
     }
 
     var playerLayer: AVPlayerLayer {
-      layer as! AVPlayerLayer
+      guard let playerLayer = layer as? AVPlayerLayer else {
+        preconditionFailure("layerClass is AVPlayerLayer")
+      }
+      return playerLayer
     }
   }
 

--- a/modules/changelog/ios/SafeAreaView.swift
+++ b/modules/changelog/ios/SafeAreaView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SafeAreaView<SafeAreaContent: View>: ViewModifier {
   @ViewBuilder var safeAreaContent: () -> SafeAreaContent
-  
+
   func body(content: Content) -> some View {
     if #available(iOS 26.0, *) {
       content.safeAreaBar(edge: .bottom) {

--- a/modules/changelog/ios/Storage.swift
+++ b/modules/changelog/ios/Storage.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public final class ChangelogStorage {
+public enum ChangelogStorage {
   public static func latestSeenAppVersion() -> String? {
     UserDefaults.standard.string(forKey: CHANGELOG_APP_STORAGE_LATEST_SEEN_APP_VERSION_KEY)
   }

--- a/modules/changelog/ios/Types.swift
+++ b/modules/changelog/ios/Types.swift
@@ -10,7 +10,8 @@ import SwiftUI
 
 public enum ChangelogVersionNoteItem: Sendable, Codable {
   case media(
-    kind: MediaKind, url: URL, title: String, description: String)
+    kind: MediaKind, url: URL, title: String, description: String
+  )
   case list(title: String, rows: [ListRow])
 
   public enum MediaKind: Sendable, Codable {

--- a/modules/cpu-usage/ios/CpuUsageModule.swift
+++ b/modules/cpu-usage/ios/CpuUsageModule.swift
@@ -20,13 +20,13 @@ public class CpuUsageModule: Module {
     var threadCount = mach_msg_type_number_t(0)
 
     guard task_threads(mach_task_self_, &threadList, &threadCount) == KERN_SUCCESS,
-      let threads = threadList
+          let threads = threadList
     else {
       return 0
     }
 
     defer {
-      for index in 0..<Int(threadCount) {
+      for index in 0 ..< Int(threadCount) {
         mach_port_deallocate(mach_task_self_, threads[index])
       }
 
@@ -39,7 +39,7 @@ public class CpuUsageModule: Module {
 
     var total = 0.0
 
-    for index in 0..<Int(threadCount) {
+    for index in 0 ..< Int(threadCount) {
       var info = thread_basic_info_data_t()
       var count = Self.basicInfoCount
 

--- a/modules/image-cache-limits/ios/ImageCacheLimitsAppDelegateSubscriber.swift
+++ b/modules/image-cache-limits/ios/ImageCacheLimitsAppDelegateSubscriber.swift
@@ -17,8 +17,8 @@ public class ImageCacheLimitsAppDelegateSubscriber: ExpoAppDelegateSubscriber {
   deinit {}
 
   public func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    _: UIApplication,
+    didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     let physicalMemory = ProcessInfo.processInfo.physicalMemory
     let minCost: UInt = 96 * 1024 * 1024

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "lint:ast-grep": "ast-grep scan",
     "lint:check": "eslint .",
     "lint:fix": "eslint . --fix",
+    "lint:kotlin": "./scripts/lint-kotlin.sh",
+    "lint:native": "bun run lint:swift && bun run lint:kotlin",
+    "lint:swift": "./scripts/lint-swift.sh",
     "metadata:push": "EXPO_PUBLIC_APP_VARIANT=production eas metadata:push --profile production",
     "ota": "./scripts/release-ota.sh",
     "ota:check": "./scripts/ota-compat-check.sh",
@@ -270,6 +273,8 @@
       "bunx prettier --write"
     ],
     "!(package).json": "bunx prettier --write",
+    "*.swift": "./scripts/lint-swift.sh",
+    "*.{kt,kts}": "./scripts/lint-kotlin.sh",
     "assets/icons/**/*.svg": "bash -c 'bun svgo -f ./assets/icons'"
   },
   "jest-junit": {

--- a/scripts/lint-kotlin.sh
+++ b/scripts/lint-kotlin.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Formats and lints Kotlin files with ktlint (config in .editorconfig),
+# autofixing in place. Passed staged *.kt/*.kts paths by lint-staged, or run
+# with no args for android/ and modules/. With LINT_CHECK=1 it verifies without
+# writing (for CI). Warns and exits 0 when ktlint isn't installed.
+#
+#  ./scripts/lint-kotlin.sh [file ...]
+#  LINT_CHECK=1 ./scripts/lint-kotlin.sh
+
+if ! command -v ktlint >/dev/null 2>&1; then
+  echo "⚠️  ktlint not found - skipping Kotlin lint. Install with: brew install ktlint" >&2
+  exit 0
+fi
+
+files=("$@")
+if [ "${#files[@]}" -eq 0 ]; then
+  # android/ is gitignored prebuild output (absent in CI) and modules/ has no
+  # Kotlin yet, so collect the real files and skip when there are none.
+  roots=()
+  for dir in android modules; do
+    [ -d "$dir" ] && roots+=("$dir")
+  done
+  if [ "${#roots[@]}" -gt 0 ]; then
+    while IFS= read -r file; do
+      files+=("$file")
+    done < <(find "${roots[@]}" -type f \( -name '*.kt' -o -name '*.kts' \))
+  fi
+  if [ "${#files[@]}" -eq 0 ]; then
+    echo "No Kotlin files to lint."
+    exit 0
+  fi
+fi
+
+if [ "${LINT_CHECK:-}" = "1" ]; then
+  ktlint --relative -- "${files[@]}"
+else
+  ktlint --format --relative -- "${files[@]}"
+fi

--- a/scripts/lint-swift.sh
+++ b/scripts/lint-swift.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Formats (SwiftFormat) and lints (SwiftLint) Swift files, autofixing in place.
+# Passed staged *.swift paths by lint-staged, or run with no args for the whole
+# project. With LINT_CHECK=1 it verifies formatting instead of writing (for CI).
+# Warns and exits 0 when the tools aren't installed.
+#
+#  ./scripts/lint-swift.sh [file ...]
+#  LINT_CHECK=1 ./scripts/lint-swift.sh
+
+if ! command -v swiftlint >/dev/null 2>&1; then
+  echo "⚠️  swiftlint not found - skipping Swift lint. Install with: brew install swiftlint" >&2
+  exit 0
+fi
+
+format() {
+  if ! command -v swiftformat >/dev/null 2>&1; then
+    echo "⚠️  swiftformat not found - skipping format. Install with: brew install swiftformat" >&2
+    return 0
+  fi
+  if [ "${LINT_CHECK:-}" = "1" ]; then
+    swiftformat --lint "$@"
+  else
+    swiftformat "$@"
+  fi
+}
+
+# Run format and lint independently and aggregate their status so a formatting
+# failure doesn't mask lint results (and vice versa) in a single run.
+files=("$@")
+status=0
+if [ "${#files[@]}" -eq 0 ]; then
+  format modules || status=1
+  [ "${LINT_CHECK:-}" = "1" ] || swiftlint lint --fix --quiet || true
+  swiftlint lint --quiet || status=1
+else
+  format "${files[@]}" || status=1
+  [ "${LINT_CHECK:-}" = "1" ] || swiftlint lint --fix --quiet -- "${files[@]}" || true
+  swiftlint lint --quiet -- "${files[@]}" || status=1
+fi
+exit "$status"

--- a/scripts/lint-swift.sh
+++ b/scripts/lint-swift.sh
@@ -33,10 +33,10 @@ status=0
 if [ "${#files[@]}" -eq 0 ]; then
   format modules || status=1
   [ "${LINT_CHECK:-}" = "1" ] || swiftlint lint --fix --quiet || true
-  swiftlint lint --quiet || status=1
+  swiftlint lint --strict --quiet || status=1
 else
   format "${files[@]}" || status=1
   [ "${LINT_CHECK:-}" = "1" ] || swiftlint lint --fix --quiet -- "${files[@]}" || true
-  swiftlint lint --quiet -- "${files[@]}" || status=1
+  swiftlint lint --strict --quiet -- "${files[@]}" || status=1
 fi
 exit "$status"


### PR DESCRIPTION
Recreates #750.

Part of the main → 1.0.3 (`ddb9c48c`) rewind. main was hard-reset to unwind the bundle-mode black screen; this stack re-lands the work since 1.0.3 one PR at a time. Base branch: `recreate/745-default-token-access` - review/merge in stack order. Backup of pre-reset main: tag `backup/pre-reset-2d6a3d4b`.