### PR TITLE
chore(app): disable slide-in animation by default

### DIFF
--- a/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
+++ b/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
@@ -361,7 +361,7 @@ const setPreferences = (showRecentMessages = true) => {
     streamListLayout: 'compact',
     chatDensity: 'compact',
     showAlternatingChatRows: false,
-    animate: true,
+    animate: false,
     chatTimestamps: true,
     disableEmoteAnimations: false,
     disableChat: false,

--- a/src/screens/Preferences/__tests__/ChatPreferenceScreen.test.tsx
+++ b/src/screens/Preferences/__tests__/ChatPreferenceScreen.test.tsx
@@ -12,7 +12,7 @@ const mockPreferences: Preferences = {
   streamListLayout: 'compact',
   chatDensity: 'comfortable',
   showAlternatingChatRows: false,
-  animate: true,
+  animate: false,
   chatTimestamps: true,
   highlightOwnMentions: true,
   showInlineReplyContext: true,

--- a/src/store/__tests__/preferenceStore.test.tsx
+++ b/src/store/__tests__/preferenceStore.test.tsx
@@ -13,7 +13,7 @@ const basePreferences = {
   streamListLayout: 'compact',
   chatDensity: 'comfortable',
   showAlternatingChatRows: false,
-  animate: true,
+  animate: false,
   chatTimestamps: true,
   highlightOwnMentions: true,
   showInlineReplyContext: true,

--- a/src/store/preferenceStore.ts
+++ b/src/store/preferenceStore.ts
@@ -159,7 +159,7 @@ export const initialPreferences: Preferences = {
   streamListLayout: 'compact',
   chatDensity: 'comfortable',
   showAlternatingChatRows: false,
-  animate: true,
+  animate: false,
   chatTimestamps: false,
   highlightOwnMentions: true,
   showInlineReplyContext: true,

--- a/src/store/preferences/__tests__/preferenceStore.test.tsx
+++ b/src/store/preferences/__tests__/preferenceStore.test.tsx
@@ -10,7 +10,7 @@ const basePreferences = {
   streamListLayout: 'compact',
   chatDensity: 'comfortable',
   showAlternatingChatRows: false,
-  animate: true,
+  animate: false,
   chatTimestamps: true,
   highlightOwnMentions: true,
   showInlineReplyContext: true,


### PR DESCRIPTION
Recreates #754.

Part of the main → 1.0.3 (`ddb9c48c`) rewind. main was hard-reset to unwind the bundle-mode black screen; this stack re-lands the work since 1.0.3 one PR at a time. Base branch: `recreate/738-android-release` - review/merge in stack order. Backup of pre-reset main: tag `backup/pre-reset-2d6a3d4b`.