### PR TITLE
chore(app): enable vexo analytics

### DIFF
--- a/.github/actions/load-native-deploy-secrets/action.yml
+++ b/.github/actions/load-native-deploy-secrets/action.yml
@@ -37,4 +37,5 @@ runs:
         GOOGLE_SERVICES_IOS_PROD_BS4: op://ci-cd/foam-mobile-${{ inputs.variant == 'production' && 'production' || 'staging' }}/GOOGLE_SERVICES_IOS_PROD_BS4
         GOOGLE_SERVICES_ANDROID_PROD_BS4: op://ci-cd/foam-mobile-${{ inputs.variant == 'production' && 'production' || 'staging' }}/GOOGLE_SERVICES_ANDROID_PROD_BS4
         SLACK_WEBHOOK_URL: op://ci-cd/foam-mobile-${{ inputs.variant == 'production' && 'production' || 'staging' }}/SLACK_WEBHOOK_URL
+        EXPO_PUBLIC_VEXO_API_KEY: op://ci-cd/foam-mobile-${{ inputs.variant == 'production' && 'production' || 'staging' }}/EXPO_PUBLIC_VEXO_API_KEY
         OP_ENV_FILE: '.env'

--- a/.github/actions/load-ota-deploy-secrets/action.yml
+++ b/.github/actions/load-ota-deploy-secrets/action.yml
@@ -29,3 +29,4 @@ runs:
         EXPO_PUBLIC_AUTH_PROXY_API_KEY: op://ci-cd/foam-mobile-${{ inputs.variant == 'production' && 'production' || 'staging' }}/AUTH_PROXY_API_KEY
         EXPO_PUBLIC_TWITCH_CLIENT_ID: op://ci-cd/foam-mobile-${{ inputs.variant == 'production' && 'production' || 'staging' }}/TWITCH_CLIENT_ID
         EXPO_PUBLIC_STATSIG_CLIENT_KEY: op://ci-cd/foam-mobile-${{ inputs.variant == 'production' && 'production' || 'staging' }}/EXPO_PUBLIC_STATSIG_CLIENT_KEY
+        EXPO_PUBLIC_VEXO_API_KEY: op://ci-cd/foam-mobile-${{ inputs.variant == 'production' && 'production' || 'staging' }}/EXPO_PUBLIC_VEXO_API_KEY

--- a/src/dev/chatHotspotBench/measureSync.ts
+++ b/src/dev/chatHotspotBench/measureSync.ts
@@ -1,6 +1,3 @@
-// DEV-ONLY: sync microbench helper mirroring Reassure's measureFunction shape
-// (warmup + N timed runs → mean/median/min/max).
-
 export interface SyncMeasureOptions {
   runs?: number;
   warmupRuns?: number;

--- a/src/dev/chatHotspotBench/scenarios.ts
+++ b/src/dev/chatHotspotBench/scenarios.ts
@@ -1,4 +1,3 @@
-// DEV-ONLY: on-device workloads matching the Reassure chat hotspot scenarios.
 import {
   multiLayerPaint,
   paintedUsernames,

--- a/src/dev/imageBenchmark/LiveChatPerfOverlay.tsx
+++ b/src/dev/imageBenchmark/LiveChatPerfOverlay.tsx
@@ -1,6 +1,3 @@
-// DEV-ONLY: pure display of live chat-perf stats. The JS-thread rAF sampler
-// lives in useChatPerfSuite (single source); the UI-thread frame health comes
-// from useUiThreadFrameHealth (Reanimated, the real rendering smoothness).
 import { StyleSheet, Text, View } from 'react-native';
 
 import type { LiveStats } from './useChatPerfSuite';

--- a/src/dev/imageBenchmark/chatFixtureData.ts
+++ b/src/dev/imageBenchmark/chatFixtureData.ts
@@ -1,4 +1,3 @@
-// DEV-ONLY chatter colour palette for the chat-perf fixture.
 export const FIXTURE_COLORS: string[] = [
   '#FF4500',
   '#1E90FF',

--- a/src/dev/imageBenchmark/chatPerfSuite.ts
+++ b/src/dev/imageBenchmark/chatPerfSuite.ts
@@ -15,20 +15,27 @@ export interface PhaseResult {
   jankPerSec: number;
   droppedPct: number;
   messages: number;
-  // UI-thread frame health (Reanimated useFrameCallback) — the real rendering
-  // smoothness, vs the JS-thread fps/jank above which is inflated by the flood
-  // timer + Metro. uiJankPerSec is the metric that actually answers "no jank".
+  /**
+   * UI-thread frame health (Reanimated useFrameCallback) - the real rendering
+   * smoothness, vs the JS-thread fps/jank above which is inflated by the flood
+   * timer + Metro. uiJankPerSec is the metric that actually answers "no jank".
+   */
   uiFpsAvg: number;
   uiJankPerSec: number;
 }
 
 export const WARMUP_MS = 5000;
-// Flood-off gap between phases so decoded-image memory / GC can settle; without
-// it, back-to-back raid phases grow RSS unbounded and can OOM on the simulator.
+
+/**
+ * Flood-off gap between phases so decoded-image memory / GC can settle; without
+ * it, back-to-back raid phases grow RSS unbounded and can OOM on the simulator.
+ */
 export const COOLDOWN_MS = 4000;
 
-// Two intensities. Lower fps / higher jank = worse. Total visible time ≈
-// (WARMUP + measure + COOLDOWN) × phases.
+/**
+ * Two intensities. Lower fps / higher jank = worse. Total visible time ≈
+ * (WARMUP + measure + COOLDOWN) × phases.
+ */
 export const SUITE_PHASES: SuitePhase[] = [
   { preset: 'raid', measureMs: 15000 },
   { preset: 'steady60', measureMs: 15000 },

--- a/src/dev/imageBenchmark/cinnaEmoteWorkload.ts
+++ b/src/dev/imageBenchmark/cinnaEmoteWorkload.ts
@@ -1,5 +1,3 @@
-// DEV-ONLY benchmark workload: cinna (twitch id 204730616) 7TV emote set,
-// 942 emotes at chat inline scale (2x AVIF). Generated from 7tv.io.
 export const CINNA_EMOTE_URLS: string[] = [
   'https://cdn.7tv.app/emote/01EZPK39HG00077NX500A43YDD/2x.avif',
   'https://cdn.7tv.app/emote/01EZTAKBN80002GHH6006GD246/2x.avif',

--- a/src/dev/imageBenchmark/ircFixtureMessages.ts
+++ b/src/dev/imageBenchmark/ircFixtureMessages.ts
@@ -1,16 +1,3 @@
-// DEV-ONLY: an offline, hand-authored fixture of cinna-style IRC messages used
-// to drive the Chat Perf screen as a deterministic replay — so the harness never
-// depends on the live channel actually being online to produce traffic.
-//
-// Each entry is a compact record; `buildIrcFixtureMessage` expands it into the
-// full IRC tag set the real pipeline consumes (the same shape twitch-chat-service
-// hands to onMessage). Sender id + colour are derived deterministically from the
-// display name, so a recurring chatter keeps a stable identity (one 7TV cosmetics
-// lookup per user, not per message) and renders consistently across runs.
-//
-// The text references cinna's real 7TV emote names (see chatFixtureData), so when
-// her emote set is loaded the fixture renders with her actual animated emotes —
-// the dominant per-frame cost under a raid.
 import { FIXTURE_COLORS } from './chatFixtureData';
 
 export type FixtureRole = 'sub' | 'mod' | 'vip' | 'broadcaster';
@@ -39,7 +26,7 @@ export interface BuiltFixtureMessage {
   text: string;
 }
 
-// FNV-1a, stable across runs — used to derive a fixed id/colour per display name.
+// FNV-1a, stable across runs - used to derive a fixed id/colour per display name.
 function hashString(value: string): number {
   let hash = 2166136261;
   for (let i = 0; i < value.length; i += 1) {
@@ -106,9 +93,10 @@ export function buildIrcFixtureMessage(
   return { tags, text: entry.text };
 }
 
-// ~120 messages modelled on a busy cinna raid minute: heavy 7TV emote spam,
-// short reactions, the occasional sentence, @mentions and a few replies, mostly
-// subscribers with a sprinkling of mods/vips and the broadcaster.
+/**
+ * ~120 messages based on busy chatroom; heavy 7tv emote spam,
+ * sentences, mentions and replies
+ */
 export const IRC_FIXTURE_MESSAGES: IrcFixtureMessage[] = [
   { user: 'cinna', text: 'hi chat cinnaW peepoHey', role: 'broadcaster' },
   {

--- a/src/dev/imageBenchmark/runDecodeBenchmark.ts
+++ b/src/dev/imageBenchmark/runDecodeBenchmark.ts
@@ -1,5 +1,3 @@
-// DEV-ONLY: decode benchmark for expo-image. Uses the imperative decode API so
-// each pass produces a true "decoded + ready" signal.
 import { Image as ExpoImage } from 'expo-image';
 
 import type { PassResult } from './benchResults';
@@ -19,7 +17,6 @@ export async function prewarm(urls: string[]): Promise<void> {
   clearRetained();
 }
 
-// True cold = nothing in the in-memory decoded cache.
 export async function resetMemoryCache(): Promise<void> {
   await ExpoImage.clearMemoryCache().catch(() => undefined);
   clearRetained();

--- a/src/dev/imageBenchmark/syntheticChatControl.ts
+++ b/src/dev/imageBenchmark/syntheticChatControl.ts
@@ -1,7 +1,3 @@
-// DEV-ONLY: shared control for the synthetic chat flood. Mutated from the Image
-// Benchmark screen; read by useSyntheticChatFlood inside useChat. Kept as a
-// plain mutable singleton (not state) so it survives navigation between the
-// control screen and the chat screen.
 export interface SyntheticChatConfig {
   active: boolean;
   // Sustained baseline throughput.

--- a/src/dev/imageBenchmark/useChatPerfSuite.ts
+++ b/src/dev/imageBenchmark/useChatPerfSuite.ts
@@ -1,6 +1,3 @@
-// DEV-ONLY: runs the deterministic Chat Perf suite entirely on-device. Owns a
-// single rAF sampler (live FPS/jank/throughput) and a phase state machine that
-// drives renderer + seeded flood, exposing a live countdown and final results.
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useFrameCallback, useSharedValue } from 'react-native-reanimated';
 
@@ -68,15 +65,19 @@ export function useChatPerfSuite() {
   const cancelRef = useRef(false);
   const runningRef = useRef(false);
 
-  // UI-thread frame accumulators (the real rendering smoothness). Reanimated
-  // ticks this worklet on the UI thread; we gate accumulation to measure windows
-  // via uiActive and read the totals back on JS when each phase ends.
+  /**
+   * Reanimated ticks this worklet on the UI thread; we gate accumulation to
+   * measure windows via uiActive and read the totals back on JS when each
+   * phase ends.
+   */
   const uiFrames = useSharedValue(0);
   const uiJank = useSharedValue(0);
   const uiActive = useSharedValue(false);
-  // Countdown is driven here on the UI thread so it keeps ticking even while the
-  // JS thread is saturated by the flood being measured (a JS-state countdown
-  // freezes exactly when the suite is busiest).
+
+  /**
+   * Countdown is driven here on the UI thread so it keeps ticking even while
+   * the JS thread is saturated by the flood being measured.
+   */
   const phaseCountdownMs = useSharedValue(0);
   const totalCountdownMs = useSharedValue(0);
   const countdownTicking = useSharedValue(false);
@@ -199,6 +200,7 @@ export function useChatPerfSuite() {
         // Start the flood for warmup ramp; restart the fixture replay at measure
         // start so each run processes a byte-identical stream (repeatable).
         syntheticChatControl.current = SYNTHETIC_PRESETS[phase.preset]!;
+
         // eslint-disable-next-line react-doctor/async-await-in-loop, react-doctor/async-defer-await -- phases are ordered and the window must run to completion (it IS the work); cancellation is checked after
         await runWindow(i, label, 'warming up', WARMUP_MS, false, suiteEnd);
         if (cancelRef.current) {

--- a/src/dev/imageBenchmark/useCpuUsage.ts
+++ b/src/dev/imageBenchmark/useCpuUsage.ts
@@ -9,8 +9,6 @@ function readUsage(): number | null {
     : null;
 }
 
-// Polls process CPU usage (summed across all threads, like `top`) once a
-// second for the dev chat-perf overlay. iOS-only; returns 0 elsewhere.
 export function useCpuUsage(): number {
   const [pct, setPct] = useState(() => readUsage() ?? 0);
   useEffect(() => {

--- a/src/dev/imageBenchmark/useSyntheticChatFlood.gate.ts
+++ b/src/dev/imageBenchmark/useSyntheticChatFlood.gate.ts
@@ -11,11 +11,11 @@ interface SyntheticChatFloodArgs {
   enabled: boolean;
 }
 
-// No-op in production: the synthetic flood and its IRC fixture corpus
-// (ircFixtureMessages) only run in the dev-gated Chat Perf screen. The inline
-// EXPO_PUBLIC_APP_VARIANT literals let Metro drop the require — and the fixtures
-// — from production; do not hoist them into a shared constant (mirrors
-// StorybookRoute.tsx).
+/**
+ * No-op in production. The inline EXPO_PUBLIC_APP_VARIANT literals let Metro
+ * drop the require (and the fixtures) from production; do not hoist them into
+ * a shared constant (mirrors StorybookRoute.tsx).
+ */
 let useSyntheticChatFlood: (args: SyntheticChatFloodArgs) => void = () => {};
 
 if (

--- a/src/dev/imageBenchmark/useSyntheticChatFlood.ts
+++ b/src/dev/imageBenchmark/useSyntheticChatFlood.ts
@@ -1,13 +1,3 @@
-// DEV-ONLY: replays an offline fixture of cinna-style IRC messages
-// (ircFixtureMessages) through the real `onMessage(channel, tags, text)` handler
-// — the same path twitch-chat-service uses — so chat performance can be
-// stress-tested with repeatable high-burst traffic without depending on the
-// channel actually being live. The Chat Perf screen mounts Chat in
-// `syntheticTransport` mode so this flood is the *only* message source.
-//
-// The replay is deterministic by construction: the fixture is emitted in order
-// at the preset's rate. 7TV emotes render by name-matching the channel's loaded
-// emote set — point this at a channel whose set is loaded (e.g. cinna).
 import { useEffect } from 'react';
 
 import { useDevToolsAccess } from '@app/utils/devTools/devToolsGate';
@@ -25,9 +15,6 @@ type OnMessage = (
   text: string,
 ) => void;
 
-// Replay state is module-level so the suite can reset both renderers to the same
-// fixture position for a fair A/B (resetFloodReplay), and so the emit counter
-// keeps producing unique message ids across the whole session.
 let replayCursor = 0;
 let emitSeq = 0;
 /**
@@ -36,9 +23,11 @@ let emitSeq = 0;
  */
 let replayEpoch = 0;
 
-// The expanded {tags,text} pool is built once per room id (the fixture is
-// otherwise channel-independent) so emitting only costs a spread + two field
-// writes, not a tag-object rebuild.
+/**
+ * The expanded {tags,text} pool is built once per room id (the fixture is
+ * otherwise channel-independent) so emitting only costs a spread + two field
+ * writes, not a tag-object rebuild.
+ */
 let builtPool: BuiltFixtureMessage[] | null = null;
 let builtPoolRoomId: string | null = null;
 
@@ -52,8 +41,6 @@ function getFixturePool(roomId: string): BuiltFixtureMessage[] {
   return builtPool;
 }
 
-// Restart the replay from the top of the fixture. Called between A/B phases so
-// nitro and expo process a byte-identical stream.
 export function resetFloodReplay(): void {
   replayCursor = 0;
   replayEpoch += 1;
@@ -70,12 +57,6 @@ export function useSyntheticChatFlood({
   onMessage: OnMessage;
   enabled: boolean;
 }): void {
-  // Gated exactly like the dev menu: dev/internal/e2e builds, or an admin login
-  // on testflight/production (useDevToolsAccess). The flood only ever *emits*
-  // when a dev-tools screen flips syntheticChatControl.active, which is itself
-  // behind the same gate — so for a real user this stays inert and never arms
-  // the interval. Lets the synthetic raid run on a real device build (incl.
-  // TestFlight as an admin), not just __DEV__ Metro.
   const devToolsAccess = useDevToolsAccess();
   useEffect(() => {
     if (!enabled || devToolsAccess !== 'enabled') {
@@ -102,13 +83,11 @@ export function useSyntheticChatFlood({
       );
     };
 
-    // Real IRC delivers a raid's messages spread across event-loop ticks, never
-    // as one synchronous burst. Cap emissions per tick and carry the rest over
-    // so a burst surges instead of blocking the JS thread. (Dispatching each
-    // message via its own staggered setTimeout to mimic per-frame WS delivery
-    // was tried and measured *worse* — 180 timer fires/s is harness overhead the
-    // real transport doesn't pay — and the raid jank was unchanged either way,
-    // confirming the jank is GPU emote-upload, not delivery timing.)
+    /**
+     * Cap emissions per tick and carry the rest over so a burst surges instead
+     * of blocking the JS thread. Staggered per-message setTimeout was measured
+     * worse (180 timer fires/s is pure harness overhead) with unchanged jank.
+     */
     const MAX_EMIT_PER_TICK = 18;
 
     const interval = setInterval(() => {

--- a/src/dev/imageBenchmark/useUiThreadFrameHealth.ts
+++ b/src/dev/imageBenchmark/useUiThreadFrameHealth.ts
@@ -1,19 +1,6 @@
-// DEV-ONLY: measures frame health on the UI THREAD via Reanimated's
-// useFrameCallback, as opposed to the JS-thread requestAnimationFrame sampler in
-// useChatPerfSuite. This distinction matters under a synthetic raid: the JS-rAF
-// probe shares the JS thread with the flood timer, message processing and (in
-// dev) the Metro HMR socket, so it reports "jank" whenever those delay a JS
-// frame — even when the UI thread is actually presenting at a steady 60fps and
-// the user sees no stutter. useFrameCallback ticks on the UI thread (where rows
-// are actually rasterised), so its jank count reflects real, visible dropped
-// frames. Compare the two: a gap (JS jank ≫ UI jank) means the JS-rAF number is
-// a measurement artifact, not pipeline jank.
 import { useState } from 'react';
-import {
-  runOnJS,
-  useFrameCallback,
-  useSharedValue,
-} from 'react-native-reanimated';
+import { useFrameCallback, useSharedValue } from 'react-native-reanimated';
+import { scheduleOnRN } from 'react-native-worklets';
 
 export interface UiFrameHealth {
   fps: number;
@@ -47,7 +34,7 @@ export function useUiThreadFrameHealth(): UiFrameHealth {
     if (elapsed >= 1000) {
       const fps = Math.round((frames.value * 1000) / elapsed);
       const jankCount = jank.value;
-      runOnJS(setHealth)({ fps, jank: jankCount });
+      scheduleOnRN(setHealth, { fps, jank: jankCount });
       frames.value = 0;
       jank.value = 0;
       windowStart.value = frame.timestamp;

--- a/src/dev/imageBenchmark/useUsedMemory.ts
+++ b/src/dev/imageBenchmark/useUsedMemory.ts
@@ -1,8 +1,3 @@
-// DEV-ONLY: polls the app's resident memory (RSS) once a second for the Chat
-// Perf overlay. Decoded image bitmaps live in native memory (SDWebImage), not
-// the JS heap, so `performance.memory` wouldn't see them — DeviceInfo's
-// getUsedMemory reads the process's actual footprint, which is what climbs when
-// the image cache is unbounded.
 import { useEffect, useState } from 'react';
 import DeviceInfo from 'react-native-device-info';
 


### PR DESCRIPTION
Recreates #756.

Part of the main → 1.0.3 (`ddb9c48c`) rewind. main was hard-reset to unwind the bundle-mode black screen; this stack re-lands the work since 1.0.3 one PR at a time. Base branch: `recreate/754-disable-slide-in` - review/merge in stack order. Backup of pre-reset main: tag `backup/pre-reset-2d6a3d4b`.