### PR TITLE
chore(app): resolve rd issues

### DIFF
--- a/src/polyfills/arrayByCopy.ts
+++ b/src/polyfills/arrayByCopy.ts
@@ -55,6 +55,12 @@ if (typeof Array.prototype.toSpliced !== 'function') {
       // `splice` but returns the *modified copy* instead of the removed
       // elements. Forwarding to `Array#splice` mutates the copy then
       // returns it.
+      if (arguments.length === 0) {
+        // `toSpliced()` with no args returns an unchanged copy; guard here
+        // because `splice(undefined)` coerces start to 0 and would remove
+        // the whole array.
+        return copy;
+      }
       if (deleteCount === undefined) {
         // `splice(start)` removes everything from `start` to end.
         copy.splice(start);

--- a/src/screens/ErrorScreen/components/ErrorDetails.tsx
+++ b/src/screens/ErrorScreen/components/ErrorDetails.tsx
@@ -1,8 +1,7 @@
+import { type ErrorInfo, useState } from 'react';
 import { ScrollView, StyleSheet, useColorScheme, View } from 'react-native';
-import type { ErrorInfo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useObservable, useSelector } from '@legendapp/state/react';
 import { router } from 'expo-router';
 
 import { Button } from '@app/components/Button/Button';
@@ -31,10 +30,8 @@ export function ErrorDetails(props: ErrorDetailsProps) {
   const colorScheme = useColorScheme();
   const scheme = colorScheme === 'light' ? 'light' : 'dark';
   const { error, errorInfo, onReset } = props;
-  const showStackTrace$ = useObservable(false);
-  const showStackTrace = useSelector(showStackTrace$);
-  const reported$ = useObservable(false);
-  const reported = useSelector(reported$);
+  const [showStackTrace, setShowStackTrace] = useState(false);
+  const [reported, setReported] = useState(false);
 
   const errorTitle = `${error}`.trim();
   const errorCategory = categorizeError(error);
@@ -45,7 +42,7 @@ export function ErrorDetails(props: ErrorDetailsProps) {
     .join('\n');
 
   const handleReportBug = () => {
-    if (reported$.peek()) {
+    if (reported) {
       return;
     }
     sendFeedback({
@@ -55,7 +52,7 @@ export function ErrorDetails(props: ErrorDetailsProps) {
         : `(CRASH) ${errorTitle}`,
       associatedEventId: lastEventId(),
     });
-    reported$.set(true);
+    setReported(true);
   };
 
   return (
@@ -137,7 +134,7 @@ export function ErrorDetails(props: ErrorDetailsProps) {
 
         <Button
           style={styles.linkButton}
-          onPress={() => showStackTrace$.set(value => !value)}
+          onPress={() => setShowStackTrace(value => !value)}
         >
           <Text
             type='sm'


### PR DESCRIPTION
Loose commit fcb5c67f (no prior PR).

Part of the main → 1.0.3 (`ddb9c48c`) rewind. main was hard-reset to unwind the bundle-mode black screen; this stack re-lands the work since 1.0.3 one PR at a time. Base branch: `recreate/757-104-prep` - review/merge in stack order. Backup of pre-reset main: tag `backup/pre-reset-2d6a3d4b`.