### PR TITLE
fix(preferences): guard Appearance.setColorScheme from unhydrated theme

### DIFF
--- a/src/store/preferences/state.ts
+++ b/src/store/preferences/state.ts
@@ -249,7 +249,8 @@ when(persistedPreferences$?._state?.isLoadedLocal, () => {
 });
 
 observe(() => {
-  const mode = lightModeEnabled$.get() ? preferences$.theme.get() : 'dark';
+  const mode =
+    (lightModeEnabled$.get() ? preferences$.theme.get() : 'dark') ?? 'dark';
   if (typeof Appearance.setColorScheme === 'function') {
     Appearance.setColorScheme(mode === 'system' ? 'unspecified' : mode);
   }


### PR DESCRIPTION
Recreates #758.

Part of the main → 1.0.3 (`ddb9c48c`) rewind. main was hard-reset to unwind the bundle-mode black screen; this stack re-lands the work since 1.0.3 one PR at a time. Base branch: `recreate/rd-issues` - review/merge in stack order. Backup of pre-reset main: tag `backup/pre-reset-2d6a3d4b`.