### PR TITLE
fix: internal black screen + auth/remote-config resilience

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -56,7 +56,6 @@
     },
     "internal": {
       "extends": "base",
-      "environment": "internal",
       "autoIncrement": true,
       "env": {
         "EXPO_PUBLIC_APP_VARIANT": "internal"
@@ -71,7 +70,6 @@
     },
     "testflight": {
       "extends": "base",
-      "environment": "testflight",
       "autoIncrement": true,
       "env": {
         "EXPO_PUBLIC_APP_VARIANT": "testflight"
@@ -86,7 +84,6 @@
     },
     "production": {
       "bun": "1.2.5",
-      "environment": "production",
       "autoIncrement": true,
       "env": {
         "EXPO_PUBLIC_APP_VARIANT": "production"

--- a/src/hooks/firebase/useRemoteConfig.test.ts
+++ b/src/hooks/firebase/useRemoteConfig.test.ts
@@ -15,6 +15,7 @@ jest.mock('@app/utils/logger', () => ({
   logger: {
     remoteConfig: {
       error: jest.fn(),
+      warn: jest.fn(),
       info: jest.fn(),
     },
   },
@@ -26,6 +27,7 @@ jest.mock('@react-native-firebase/remote-config');
 
 const mockedFetchAndActivate = jest.mocked(fetchAndActivate);
 const mockRemoteConfigError = jest.mocked(logger.remoteConfig.error);
+const mockRemoteConfigWarn = jest.mocked(logger.remoteConfig.warn);
 const mockRemoteConfigInfo = jest.mocked(logger.remoteConfig.info);
 
 describe('useRemoteConfig', () => {
@@ -52,15 +54,32 @@ describe('useRemoteConfig', () => {
       expect(result.current.isRefetching).toBe(false);
     });
 
-    expect(mockRemoteConfigError).not.toHaveBeenCalledWith(
-      'fetchAndActivate failed',
-      expect.anything(),
-    );
+    expect(mockRemoteConfigWarn).not.toHaveBeenCalled();
+    expect(mockRemoteConfigError).not.toHaveBeenCalled();
     expect(mockRemoteConfigInfo.mock.calls[0]).toEqual([
       'fetchAndActivate cancelled',
       {
         error: '[remoteConfig/unknown] cancelled',
       },
     ]);
+  });
+
+  test('warns without erroring when fetchAndActivate fails to reach the server', async () => {
+    const failure = new Error(
+      '[remoteConfig/failure] fetch() operation cannot be completed successfully.',
+    );
+    mockedFetchAndActivate.mockRejectedValueOnce(failure);
+
+    const { result } = renderHook(() => useRemoteConfig(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isRefetching).toBe(false);
+    });
+
+    expect(mockRemoteConfigWarn.mock.calls[0]).toEqual([
+      'fetchAndActivate failed; using cached or default config',
+      failure,
+    ]);
+    expect(mockRemoteConfigError).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/firebase/useRemoteConfig.ts
+++ b/src/hooks/firebase/useRemoteConfig.ts
@@ -94,7 +94,10 @@ async function fetchRemoteConfig(): Promise<boolean> {
         return false;
       }
 
-      logger.remoteConfig.error('fetchAndActivate failed', error);
+      logger.remoteConfig.warn(
+        'fetchAndActivate failed; using cached or default config',
+        error,
+      );
       return false;
     })
     .finally(() => {

--- a/src/services/__tests__/twitch-service.test.ts
+++ b/src/services/__tests__/twitch-service.test.ts
@@ -1,3 +1,4 @@
+import type { DefaultTokenResponse } from '@app/types/twitch/auth';
 import type { TwitchCheermote } from '@app/types/twitch/bits';
 import type { FollowedChannel } from '@app/types/twitch/channel';
 import type { TwitchClip, TwitchCreatedClip } from '@app/types/twitch/clip';
@@ -5,6 +6,36 @@ import type { UserInfoResponse } from '@app/types/twitch/user';
 
 import { twitchApi } from '../api/clients';
 import { MAX_FOLLOWED_CHANNELS, twitchService } from '../twitch-service';
+
+const mockFetch = jest.fn();
+
+jest.mock('expo/fetch', () => ({
+  fetch: (...args: unknown[]) => mockFetch(...args) as Promise<unknown>,
+}));
+
+jest.mock('@app/lib/offThreadJson/parseJsonOnWorklet', () => ({
+  parseJsonOnWorklet: jest.fn(async (text: string) => JSON.parse(text)),
+}));
+
+jest.mock('@app/utils/logger', () => {
+  const categories: Record<string, unknown> = {};
+  return {
+    logger: new Proxy(
+      {},
+      {
+        get: (_target, prop: string) => {
+          categories[prop] ??= {
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+          };
+          return categories[prop];
+        },
+      },
+    ),
+  };
+});
 
 jest.mock('../api/clients', () => ({
   getTwitchClientId: jest.fn(() => 'client-id'),
@@ -431,5 +462,91 @@ describe('twitchService moderation endpoints', () => {
         moderator_id: '2',
       },
     });
+  });
+});
+
+describe('twitchService.getDefaultToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function jsonResponse(body: unknown, status = 200) {
+    return {
+      ok: status < 400,
+      status,
+      text: () => Promise.resolve(JSON.stringify(body)),
+    };
+  }
+
+  function pendingUntilAbort(init?: { signal?: AbortSignal }): Promise<never> {
+    return new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => {
+        reject(new Error('Aborted'));
+      });
+    });
+  }
+
+  const anonToken: DefaultTokenResponse = {
+    access_token: 'anon-abc',
+    expires_in: 3600,
+    token_type: 'bearer',
+  };
+
+  test('returns the anon token when the proxy and validation respond', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ data: anonToken }))
+      .mockResolvedValueOnce(
+        jsonResponse({ client_id: 'client-id', expires_in: 3600 }),
+      );
+
+    const result = await twitchService.getDefaultToken();
+
+    expect(result).toEqual<DefaultTokenResponse>(anonToken);
+  });
+
+  test('keeps the fetched token when validation never responds', async () => {
+    jest.useFakeTimers();
+    try {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({ data: anonToken }))
+        .mockImplementationOnce(
+          (_input: unknown, init?: { signal?: AbortSignal }) =>
+            pendingUntilAbort(init),
+        );
+
+      const pending = twitchService.getDefaultToken();
+      await jest.advanceTimersByTimeAsync(8_000);
+
+      expect(await pending).toEqual<DefaultTokenResponse>(anonToken);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('returns undefined when the proxy rejects the request', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ message: 'Forbidden' }, 403),
+    );
+
+    const result = await twitchService.getDefaultToken();
+
+    expect(result).toBeUndefined();
+  });
+
+  test('propagates the error when the token request never responds', async () => {
+    jest.useFakeTimers();
+    try {
+      mockFetch.mockImplementationOnce(
+        (_input: unknown, init?: { signal?: AbortSignal }) =>
+          pendingUntilAbort(init),
+      );
+
+      const pending = twitchService.getDefaultToken();
+      const assertion = expect(pending).rejects.toThrow('Aborted');
+      await jest.advanceTimersByTimeAsync(8_000);
+      await assertion;
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/src/services/twitch-service.ts
+++ b/src/services/twitch-service.ts
@@ -60,6 +60,24 @@ const authProxyApiKey =
   (Constants.expoConfig?.extra?.EXPO_PUBLIC_AUTH_PROXY_API_KEY as
     string | undefined) ?? process.env.EXPO_PUBLIC_AUTH_PROXY_API_KEY;
 
+const AUTH_PROXY_REQUEST_TIMEOUT_MS = 8_000;
+
+async function fetchWithTimeout(
+  input: string,
+  init?: Parameters<typeof fetch>[1],
+  timeoutMs = AUTH_PROXY_REQUEST_TIMEOUT_MS,
+) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // Cap follow-list pagination so a pathological follow count (Helix allows
 // thousands) can't fan out into dozens of sequential requests on tab load.
 export const MAX_FOLLOWED_CHANNELS = 400;
@@ -412,7 +430,7 @@ export const twitchService = {
       ? `${mockServerUrl}/token`
       : `${authProxyBaseUrl}/token`;
 
-    const res = await fetch(tokenUrl, {
+    const res = await fetchWithTimeout(tokenUrl, {
       headers: isE2EMode ? {} : { 'x-api-key': authProxyApiKey ?? '' },
     });
     const body = await parseJsonOnWorklet<{ data: DefaultTokenResponse }>(
@@ -424,7 +442,14 @@ export const twitchService = {
     } else {
       // Fresh proxy tokens may be issued under a different client ID than
       // EXPO_PUBLIC_TWITCH_CLIENT_ID; sync the Helix Client-Id header to it.
-      await twitchService.validateToken(body.data.access_token);
+      try {
+        await twitchService.validateToken(body.data.access_token);
+      } catch (e) {
+        logger.auth.warn(
+          'anon token validation did not complete; using token unvalidated',
+          e,
+        );
+      }
     }
 
     return body.data;
@@ -439,7 +464,7 @@ export const twitchService = {
     if (isE2EMode) {
       return true;
     }
-    const res = await fetch('https://id.twitch.tv/oauth2/validate', {
+    const res = await fetchWithTimeout('https://id.twitch.tv/oauth2/validate', {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (res.status !== 200) {


### PR DESCRIPTION
Recreates #759.

Part of the main → 1.0.3 (`ddb9c48c`) rewind. main was hard-reset to unwind the bundle-mode black screen; this stack re-lands the work since 1.0.3 one PR at a time. Base branch: `recreate/758-appearance-guard` - review/merge in stack order. Backup of pre-reset main: tag `backup/pre-reset-2d6a3d4b`.