### PR TITLE
feat(stream): per-channel gradient avatar orbs

### DIFF
--- a/src/components/LiveStreamCard/ChannelAvatarOrb.tsx
+++ b/src/components/LiveStreamCard/ChannelAvatarOrb.tsx
@@ -1,0 +1,42 @@
+import { memo } from 'react';
+import { StyleProp, ViewStyle } from 'react-native';
+
+import { LinearGradient } from 'expo-linear-gradient';
+
+import { Text } from '@app/components/ui/Text/Text';
+import type { ColorScheme } from '@app/styles/themes';
+import { deriveChannelAccent } from '@app/utils/color/deriveChannelAccent';
+
+interface Props {
+  seed: string;
+  initial: string;
+  scheme: ColorScheme;
+  style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * Gradient avatar shown for streamers without a cached profile picture. The
+ * palette is derived deterministically from the channel seed, so a given
+ * channel keeps the same orb across renders and sessions.
+ */
+export const ChannelAvatarOrb = memo(function ChannelAvatarOrb({
+  seed,
+  initial,
+  scheme,
+  style,
+}: Props) {
+  const accent = deriveChannelAccent(seed, scheme);
+
+  return (
+    <LinearGradient
+      colors={accent.colors}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={style}
+    >
+      <Text type='md' weight='bold' style={{ color: accent.text }}>
+        {initial}
+      </Text>
+    </LinearGradient>
+  );
+});

--- a/src/components/LiveStreamCard/LiveStreamCard.tsx
+++ b/src/components/LiveStreamCard/LiveStreamCard.tsx
@@ -22,6 +22,7 @@ import {
 import { Button } from '../Button/Button';
 import { Image } from '../Image/Image';
 import { PressableArea } from '../PressableArea/PressableArea';
+import { ChannelAvatarOrb } from './ChannelAvatarOrb';
 import { COMPACT_THUMBNAIL_SIZE, MEDIA_THUMBNAIL_SIZE } from './thumbnailSizes';
 
 interface Props {
@@ -65,9 +66,6 @@ function LiveStreamCard({ stream, layout = 'compact' }: Props) {
   const scheme = colorScheme === 'light' ? 'light' : 'dark';
   const schemeStyles = useMemo(
     () => ({
-      avatarFallback: {
-        backgroundColor: theme.color.pressedOverlay[scheme],
-      },
       container: {
         backgroundColor: theme.color.surface[scheme],
         borderColor: theme.color.border[scheme],
@@ -192,17 +190,12 @@ function LiveStreamCard({ stream, layout = 'compact' }: Props) {
                   transition={150}
                 />
               ) : (
-                <View
-                  style={[styles.avatarFallback, schemeStyles.avatarFallback]}
-                >
-                  <Text
-                    type='md'
-                    weight='bold'
-                    style={schemeStyles.primaryText}
-                  >
-                    {avatarInitial}
-                  </Text>
-                </View>
+                <ChannelAvatarOrb
+                  seed={stream.user_login}
+                  initial={avatarInitial}
+                  scheme={scheme}
+                  style={styles.avatarFallback}
+                />
               )}
             </PressableArea>
 

--- a/src/utils/color/__tests__/__fixtures__/deriveChannelAccent.fixture.ts
+++ b/src/utils/color/__tests__/__fixtures__/deriveChannelAccent.fixture.ts
@@ -1,0 +1,22 @@
+import type { ChannelAccent } from '@app/utils/color/deriveChannelAccent';
+
+export const xqcDarkAccent: ChannelAccent = {
+  colors: ['#5ff264', '#2ce89d', '#1b87c5'],
+  glow: '#5ff264',
+  base: '#2ce89d',
+  text: '#0F1620',
+};
+
+export const xqcLightAccent: ChannelAccent = {
+  colors: ['#abe3ad', '#7fd2b1', '#5d9cc1'],
+  glow: '#abe3ad',
+  base: '#7fd2b1',
+  text: '#0F1620',
+};
+
+export const pokimaneDarkAccent: ChannelAccent = {
+  colors: ['#f25f9a', '#e84b2c', '#c5ba1b'],
+  glow: '#f25f9a',
+  base: '#e84b2c',
+  text: '#FFFFFF',
+};

--- a/src/utils/color/__tests__/deriveChannelAccent.test.ts
+++ b/src/utils/color/__tests__/deriveChannelAccent.test.ts
@@ -1,0 +1,54 @@
+import { ChannelAccent, deriveChannelAccent } from '../deriveChannelAccent';
+import {
+  pokimaneDarkAccent,
+  xqcDarkAccent,
+  xqcLightAccent,
+} from './__fixtures__/deriveChannelAccent.fixture';
+
+const HEX = /^#[0-9a-fA-F]{6}$/;
+
+describe('deriveChannelAccent', () => {
+  test('produces the pinned palette for a known seed and scheme', () => {
+    expect(deriveChannelAccent('xqc', 'dark')).toEqual<ChannelAccent>(
+      xqcDarkAccent,
+    );
+    expect(deriveChannelAccent('xqc', 'light')).toEqual<ChannelAccent>(
+      xqcLightAccent,
+    );
+    expect(deriveChannelAccent('pokimane', 'dark')).toEqual<ChannelAccent>(
+      pokimaneDarkAccent,
+    );
+  });
+
+  test('is deterministic across calls', () => {
+    expect(deriveChannelAccent('pokimane', 'dark')).toEqual(
+      deriveChannelAccent('pokimane', 'dark'),
+    );
+  });
+
+  test('normalises the seed so casing and surrounding space do not matter', () => {
+    const canonical = deriveChannelAccent('xqc', 'dark');
+    expect(deriveChannelAccent('  XQC  ', 'dark')).toEqual(canonical);
+  });
+
+  test('gives different seeds different palettes', () => {
+    expect(deriveChannelAccent('xqc', 'dark').base).not.toBe(
+      deriveChannelAccent('pokimane', 'dark').base,
+    );
+  });
+
+  test('tunes the same seed differently per scheme', () => {
+    expect(deriveChannelAccent('xqc', 'dark').base).not.toBe(
+      deriveChannelAccent('xqc', 'light').base,
+    );
+  });
+
+  test('emits valid six-digit hex for every colour field', () => {
+    const accent = deriveChannelAccent('forsen', 'dark');
+    expect(accent.colors[0]).toMatch(HEX);
+    expect(accent.colors[1]).toMatch(HEX);
+    expect(accent.colors[2]).toMatch(HEX);
+    expect(accent.glow).toMatch(HEX);
+    expect(accent.base).toMatch(HEX);
+  });
+});

--- a/src/utils/color/deriveChannelAccent.ts
+++ b/src/utils/color/deriveChannelAccent.ts
@@ -1,0 +1,135 @@
+import type { ColorScheme } from '@app/styles/themes';
+
+/**
+ * A stable, scheme-tuned accent derived from a channel seed. `colors` is a
+ * three-stop gradient (light to deep), `glow` an outer-glow tint, `base` a
+ * solid representative colour, and `text` the readable ink to lay over it.
+ */
+export interface ChannelAccent {
+  colors: [string, string, string];
+  glow: string;
+  base: string;
+  text: string;
+}
+
+/**
+ * The three gradient stops as [hueOffset, saturation, lightness]. Offsets are
+ * small enough to stay recognisably one colour, wide enough to read as a
+ * gradient; the ramp darkens from top to deep.
+ */
+const STOPS: readonly [
+  readonly [number, number, number],
+  readonly [number, number, number],
+  readonly [number, number, number],
+] = [
+  [0, 0.72, 0.62],
+  [34, 0.68, 0.5],
+  [80, 0.64, 0.4],
+];
+
+/**
+ * Above this perceived luminance the orb is light enough that dark ink reads
+ * better than white.
+ */
+const DARK_INK_LUMINANCE = 0.6;
+const DARK_INK = '#0F1620';
+
+function hashString(input: string): number {
+  let hash = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    // eslint-disable-next-line no-bitwise
+    hash = (hash * 31 + input.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function hslToRgb(
+  h: number,
+  s: number,
+  l: number,
+): { r: number; g: number; b: number } {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r = 0;
+  let g = 0;
+  let b = 0;
+
+  if (h < 60) [r, g, b] = [c, x, 0];
+  else if (h < 120) [r, g, b] = [x, c, 0];
+  else if (h < 180) [r, g, b] = [0, c, x];
+  else if (h < 240) [r, g, b] = [0, x, c];
+  else if (h < 300) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+
+  return {
+    r: Math.round((r + m) * 255),
+    g: Math.round((g + m) * 255),
+    b: Math.round((b + m) * 255),
+  };
+}
+
+function toHex(r: number, g: number, b: number): string {
+  return `#${[r, g, b]
+    .map(value => value.toString(16).padStart(2, '0'))
+    .join('')}`;
+}
+
+/**
+ * Rec. 601 luma, good enough to pick between light and dark ink.
+ */
+function luminance(r: number, g: number, b: number): number {
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
+
+/**
+ * Light mode wants airy pastels that sit calmly on the white card surface;
+ * dark mode wants richer, brighter tones that glow against near-black.
+ */
+function tuneForScheme(
+  saturation: number,
+  lightness: number,
+  scheme: ColorScheme,
+): { s: number; l: number } {
+  if (scheme === 'dark') {
+    return { s: clamp01(saturation * 1.18), l: clamp01(lightness + 0.04) };
+  }
+  return { s: clamp01(saturation * 0.7), l: clamp01(lightness + 0.16) };
+}
+
+/**
+ * Derives a deterministic accent palette for a channel from any stable seed
+ * (use `user_login`), tuned for the active colour scheme. The same seed and
+ * scheme always yield the same palette, so a channel keeps its colour across
+ * renders and sessions without any stored state.
+ */
+export function deriveChannelAccent(
+  seed: string,
+  scheme: ColorScheme,
+): ChannelAccent {
+  const hue = hashString(seed.trim().toLowerCase()) % 360;
+
+  const stopAt = (stop: readonly [number, number, number]) => {
+    const [offset, saturation, lightness] = stop;
+    const tuned = tuneForScheme(saturation, lightness, scheme);
+    const { r, g, b } = hslToRgb((hue + offset) % 360, tuned.s, tuned.l);
+    return { hex: toHex(r, g, b), r, g, b };
+  };
+
+  const top = stopAt(STOPS[0]);
+  const mid = stopAt(STOPS[1]);
+  const deep = stopAt(STOPS[2]);
+  const text =
+    luminance(mid.r, mid.g, mid.b) > DARK_INK_LUMINANCE ? DARK_INK : '#FFFFFF';
+
+  return {
+    colors: [top.hex, mid.hex, deep.hex],
+    glow: top.hex,
+    base: mid.hex,
+    text,
+  };
+}


### PR DESCRIPTION
Recreates #760.

Part of the main → 1.0.3 (`ddb9c48c`) rewind. main was hard-reset to unwind the bundle-mode black screen; this stack re-lands the work since 1.0.3 one PR at a time. Base branch: `recreate/759-black-screen-resilience` - review/merge in stack order. Backup of pre-reset main: tag `backup/pre-reset-2d6a3d4b`.