### PR TITLE
fix(updates): retry transient OTA check/fetch so poisoned builds can self-heal

### DIFF
--- a/src/hooks/__tests__/useOTAUpdates.test.ts
+++ b/src/hooks/__tests__/useOTAUpdates.test.ts
@@ -1,0 +1,129 @@
+import { renderHook } from '@testing-library/react-native';
+import {
+  checkForUpdateAsync,
+  fetchUpdateAsync,
+  type UpdateCheckResultAvailable,
+  type UpdateFetchResultFailure,
+} from 'expo-updates';
+
+import { countOtaMetric } from '@app/lib/sentry';
+import { logger } from '@app/utils/logger';
+
+import { useOTAUpdates } from '../useOTAUpdates';
+
+jest.mock('expo-updates', () => ({
+  __esModule: true,
+  isEnabled: true,
+  channel: 'internal',
+  latestContext: { isUpdatePending: false },
+  checkForUpdateAsync: jest.fn(),
+  fetchUpdateAsync: jest.fn(),
+  setExtraParamAsync: jest.fn().mockResolvedValue(undefined),
+  reloadAsync: jest.fn(),
+  addUpdatesStateChangeListener: jest.fn(() => ({ remove: jest.fn() })),
+}));
+
+jest.mock('expo-application', () => ({
+  nativeBuildVersion: '123',
+}));
+
+jest.mock('@app/lib/sentry', () => ({
+  countOtaMetric: jest.fn(),
+}));
+
+jest.mock('@app/utils/logger', () => ({
+  logger: {
+    main: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@app/utils/appState/appStateTransitions', () => ({
+  subscribeToAppStateTransitions: jest.fn(() => jest.fn()),
+  isForegroundTransition: jest.fn(() => false),
+}));
+
+const mockedCheck = jest.mocked(checkForUpdateAsync);
+const mockedFetch = jest.mocked(fetchUpdateAsync);
+const mockedCountOtaMetric = jest.mocked(countOtaMetric);
+const mockedError = jest.mocked(logger.main.error);
+const mockedWarn = jest.mocked(logger.main.warn);
+
+const globalWithDev = global as typeof global & { __DEV__: boolean };
+const originalDev = globalWithDev.__DEV__;
+
+const fetchSuccess: UpdateFetchResultFailure = {
+  isNew: false,
+  manifest: undefined,
+  isRollBackToEmbedded: false,
+};
+
+describe('useOTAUpdates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    // shouldReceiveUpdates gates on `!__DEV__`; enable the update path.
+    globalWithDev.__DEV__ = false;
+    mockedCheck.mockResolvedValue({
+      isAvailable: true,
+      isRollBackToEmbedded: false,
+      reason: undefined,
+      manifest: { id: 'abc' },
+    } as UpdateCheckResultAvailable);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    globalWithDev.__DEV__ = originalDev;
+  });
+
+  test('retries a transient fetch failure and self-heals without logging an error', async () => {
+    mockedFetch
+      .mockRejectedValueOnce(new Error('ERR_UPDATES_FETCH: undefined reason'))
+      .mockResolvedValueOnce(fetchSuccess);
+
+    renderHook(() => useOTAUpdates());
+
+    // initial check (3s) → attempt 1 fetch rejects → backoff (4s) → attempt 2 succeeds
+    await jest.advanceTimersByTimeAsync(3e3);
+    await jest.advanceTimersByTimeAsync(4e3);
+
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+    expect(mockedError).not.toHaveBeenCalled();
+    expect(mockedWarn).toHaveBeenCalledTimes(1);
+    expect(mockedCountOtaMetric).toHaveBeenCalledWith('ota.check.retry', {
+      attempt: 1,
+      channel: 'internal',
+      environment: 'non-production',
+      platform: 'ios',
+    });
+    expect(mockedCountOtaMetric).toHaveBeenCalledWith('ota.update.fetched', {
+      channel: 'internal',
+      environment: 'non-production',
+      platform: 'ios',
+    });
+  });
+
+  test('logs a single error and a failed metric after exhausting retries', async () => {
+    mockedFetch.mockRejectedValue(
+      new Error('ERR_UPDATES_FETCH: undefined reason'),
+    );
+
+    renderHook(() => useOTAUpdates());
+
+    await jest.advanceTimersByTimeAsync(3e3);
+    await jest.advanceTimersByTimeAsync(4e3);
+    await jest.advanceTimersByTimeAsync(8e3);
+
+    expect(mockedFetch).toHaveBeenCalledTimes(3);
+    expect(mockedError).toHaveBeenCalledTimes(1);
+    expect(mockedCountOtaMetric).toHaveBeenCalledWith('ota.check.failed', {
+      channel: 'internal',
+      environment: 'non-production',
+      platform: 'ios',
+    });
+  });
+});

--- a/src/hooks/useOTAUpdates.ts
+++ b/src/hooks/useOTAUpdates.ts
@@ -25,6 +25,14 @@ import { logger } from '@app/utils/logger';
 
 const MINIMUM_MINIMIZE_TIME = 15 * 60e3; // 15 minutes
 const INITIAL_CHECK_DELAY = 3e3; // 3 seconds
+const MAX_CHECK_ATTEMPTS = 3;
+const RETRY_BACKOFF_MS = 4e3; // 4 seconds, multiplied by attempt
+
+function delay(ms: number) {
+  return new Promise<void>(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
 
 const OTA_RELOAD_SCREEN_OPTIONS = {
   backgroundColor: theme.color.background.dark,
@@ -66,77 +74,128 @@ export function useOTAUpdates() {
   const ranInitialCheck = useRef(false);
   const handledPendingUpdate = useRef(false);
   const timeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const isMounted = useRef(true);
 
+  const runUpdateCheck = useCallback(async () => {
+    await setExtraParams();
+
+    logger.main.info('Checking for OTA update', {
+      name: 'ota_updates_service_info',
+      category: 'ota',
+      action: 'check_started',
+      channel: Updates.channel || 'unknown',
+      buildVersion: nativeBuildVersion,
+      platform: Platform.OS,
+      isProduction,
+    });
+
+    countOtaMetric('ota.check.started', {
+      channel: Updates.channel || 'unknown',
+      environment: isProduction ? 'production' : 'non-production',
+      platform: Platform.OS,
+    });
+
+    const res = await checkForUpdateAsync();
+
+    if (!res.isAvailable) {
+      return;
+    }
+
+    logger.main.info('OTA update available', {
+      name: 'ota_updates_service_info',
+      category: 'ota',
+      action: 'update_available',
+      manifestId: res.manifest?.id,
+      channel: Updates.channel || 'unknown',
+      platform: Platform.OS,
+    });
+
+    countOtaMetric('ota.update.available', {
+      channel: Updates.channel || 'unknown',
+      environment: isProduction ? 'production' : 'non-production',
+      platform: Platform.OS,
+    });
+
+    await fetchUpdateAsync();
+
+    logger.main.info('OTA update fetched successfully', {
+      name: 'ota_updates_service_info',
+      category: 'ota',
+      action: 'update_fetched',
+      channel: Updates.channel || 'unknown',
+      platform: Platform.OS,
+    });
+
+    countOtaMetric('ota.update.fetched', {
+      channel: Updates.channel || 'unknown',
+      environment: isProduction ? 'production' : 'non-production',
+      platform: Platform.OS,
+    });
+  }, [isProduction]);
+
+  /**
+   * A single transient ERR_UPDATES_FETCH must not strand the device on a
+   * poisoned embedded bundle (#759) when a corrective update is available -
+   * retry the whole check-and-fetch with backoff so it self-heals in-session.
+   */
   const checkForUpdates = useCallback(async () => {
     if (!shouldReceiveUpdates) {
       return;
     }
 
-    try {
-      await setExtraParams();
+    for (let attempt = 1; attempt <= MAX_CHECK_ATTEMPTS; attempt += 1) {
+      try {
+        // eslint-disable-next-line react-doctor/async-await-in-loop -- retries are sequential by design (backoff between failing attempts)
+        await runUpdateCheck();
+        return;
+      } catch (error) {
+        if (attempt < MAX_CHECK_ATTEMPTS) {
+          logger.main.warn('OTA update check failed, retrying', {
+            name: 'ota_updates_service_info',
+            error: toError(error),
+            category: 'OTAUpdatesService',
+            action: 'check_retry',
+            attempt,
+            isProduction,
+            channel: Updates.channel || 'unknown',
+            platform: Platform.OS,
+          });
 
-      logger.main.info('Checking for OTA update', {
-        name: 'ota_updates_service_info',
-        category: 'ota',
-        action: 'check_started',
-        channel: Updates.channel || 'unknown',
-        buildVersion: nativeBuildVersion,
-        platform: Platform.OS,
-        isProduction,
-      });
+          countOtaMetric('ota.check.retry', {
+            attempt,
+            channel: Updates.channel || 'unknown',
+            environment: isProduction ? 'production' : 'non-production',
+            platform: Platform.OS,
+          });
 
-      countOtaMetric('ota.check.started', {
-        channel: Updates.channel || 'unknown',
-        environment: isProduction ? 'production' : 'non-production',
-        platform: Platform.OS,
-      });
+          await delay(RETRY_BACKOFF_MS * attempt);
 
-      const res = await checkForUpdateAsync();
+          if (!isMounted.current) {
+            return;
+          }
 
-      if (res.isAvailable) {
-        logger.main.info('OTA update available', {
-          name: 'ota_updates_service_info',
-          category: 'ota',
-          action: 'update_available',
-          manifestId: res.manifest?.id,
+          continue;
+        }
+
+        logger.main.error('OTA update check failed', {
+          name: 'ota_updates_service_error',
+          error: toError(error),
+          category: 'OTAUpdatesService',
+          action: 'check_failed',
+          attempts: MAX_CHECK_ATTEMPTS,
+          isProduction,
           channel: Updates.channel || 'unknown',
           platform: Platform.OS,
         });
 
-        countOtaMetric('ota.update.available', {
-          channel: Updates.channel || 'unknown',
-          environment: isProduction ? 'production' : 'non-production',
-          platform: Platform.OS,
-        });
-
-        await fetchUpdateAsync();
-
-        logger.main.info('OTA update fetched successfully', {
-          name: 'ota_updates_service_info',
-          category: 'ota',
-          action: 'update_fetched',
-          channel: Updates.channel || 'unknown',
-          platform: Platform.OS,
-        });
-
-        countOtaMetric('ota.update.fetched', {
+        countOtaMetric('ota.check.failed', {
           channel: Updates.channel || 'unknown',
           environment: isProduction ? 'production' : 'non-production',
           platform: Platform.OS,
         });
       }
-    } catch (error) {
-      logger.main.error('OTA update check failed', {
-        name: 'ota_updates_service_error',
-        error: toError(error),
-        category: 'OTAUpdatesService',
-        action: 'check_failed',
-        isProduction,
-        channel: Updates.channel || 'unknown',
-        platform: Platform.OS,
-      });
     }
-  }, [isProduction, shouldReceiveUpdates]);
+  }, [isProduction, runUpdateCheck, shouldReceiveUpdates]);
 
   const applyUpdate = useCallback(async () => {
     try {
@@ -198,6 +257,13 @@ export function useOTAUpdates() {
   checkForUpdatesRef.current = checkForUpdates;
   const promptAndReloadRef = useRef(promptAndReload);
   promptAndReloadRef.current = promptAndReload;
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (!shouldReceiveUpdates || ranInitialCheck.current) {

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -343,6 +343,8 @@ export type LogMetadata = {
 
 export type OtaMetrics =
   | 'ota.check.started'
+  | 'ota.check.retry'
+  | 'ota.check.failed'
   | 'ota.update.available'
   | 'ota.update.fetched'
   | 'ota.update.pending'


### PR DESCRIPTION
Loose commit 974aac8d (no prior PR).

Part of the main → 1.0.3 (`ddb9c48c`) rewind. main was hard-reset to unwind the bundle-mode black screen; this stack re-lands the work since 1.0.3 one PR at a time. Base branch: `recreate/760-avatar-orbs` - review/merge in stack order. Backup of pre-reset main: tag `backup/pre-reset-2d6a3d4b`.