### PR TITLE
chore(ci): validate artifact variant, keep anti-bricking outside dev

### DIFF
--- a/.github/actions/native-build-submit/action.yml
+++ b/.github/actions/native-build-submit/action.yml
@@ -68,6 +68,8 @@ runs:
             exit 1
           fi
 
+          ./scripts/validate-native-artifact.sh "$VARIANT" ios "$ipa_path"
+
           unzip -q "$ipa_path" -d "$extracted_dir"
 
           dsym_search_paths=("$extracted_dir")
@@ -128,11 +130,13 @@ runs:
           SENTRY_AUTH_TOKEN="${SENTRY_AUTH_TOKEN:-}" \
             SENTRY_RELEASE="${EXPO_PUBLIC_SENTRY_RELEASE}" \
             SENTRY_DIST="${EXPO_PUBLIC_SENTRY_DIST}" \
-            SENTRY_LOAD_DOTENV=0 \
+          SENTRY_LOAD_DOTENV=0 \
             EXPO_PUBLIC_APP_VARIANT="$VARIANT" \
             EXPO_PUBLIC_SENTRY_RELEASE="${EXPO_PUBLIC_SENTRY_RELEASE}" \
             EXPO_PUBLIC_SENTRY_DIST="${EXPO_PUBLIC_SENTRY_DIST}" \
             bun run eas build --platform android --profile "$VARIANT" --non-interactive --local --output=./build-artifacts/app.aab
+
+          ./scripts/validate-native-artifact.sh "$VARIANT" android ./build-artifacts/app.aab
 
           # shellcheck source=scripts/sentry-upload.sh
           source ./scripts/sentry-upload.sh

--- a/app.config.ts
+++ b/app.config.ts
@@ -172,7 +172,7 @@ const config: ExpoConfig = {
     // Updates are checked manually after the app has fully loaded
     checkAutomatically: 'NEVER',
     fallbackToCacheTimeout: 30000,
-    disableAntiBrickingMeasures: variant !== 'production',
+    disableAntiBrickingMeasures: variant === 'development',
   },
   runtimeVersion: {
     policy: 'appVersion',

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,6 +47,8 @@ build_ios() {
     exit 1
   fi
 
+  ./scripts/validate-native-artifact.sh "$profile" ios "$ipa_path"
+
   unzip -q "$ipa_path" -d "$extracted_dir"
 
   local dsym_search_paths=("$extracted_dir")
@@ -90,6 +92,8 @@ build_android() {
     echo "Unable to find an Android artifact at $artifact_path"
     exit 1
   fi
+
+  ./scripts/validate-native-artifact.sh "$profile" android "$artifact_path"
 
   run_sentry_helper sentry_upload_size_analysis "$artifact_path"
 }

--- a/scripts/validate-native-artifact.sh
+++ b/scripts/validate-native-artifact.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+variant="${1:-}"
+platform="${2:-}"
+artifact="${3:-}"
+
+if [ -z "$variant" ] || [ -z "$platform" ] || [ -z "$artifact" ]; then
+  echo "Usage: $0 <internal|testflight|production> <ios|android> <artifact>" >&2
+  exit 1
+fi
+
+case "$variant" in
+  internal)
+    expected_ios_bundle_id='foam-tv-internal'
+    expected_android_package='com.lhowsam.foam.internal'
+    ;;
+  testflight)
+    expected_ios_bundle_id='foam-tv-testflight'
+    expected_android_package='com.lhowsam.foam.testflight'
+    ;;
+  production)
+    expected_ios_bundle_id='foam-tv'
+    expected_android_package='com.lhowsam.foam_tv'
+    ;;
+  *)
+    echo "Unsupported variant: $variant" >&2
+    exit 1
+    ;;
+esac
+
+if [ ! -f "$artifact" ]; then
+  echo "Native artifact does not exist: $artifact" >&2
+  exit 1
+fi
+
+case "$platform" in
+  ios)
+    info_plist_path="$(unzip -Z1 "$artifact" | rg -m 1 '^Payload/[^/]+\.app/Info\.plist$' || true)"
+    if [ -z "$info_plist_path" ]; then
+      echo "Unable to find the iOS app Info.plist in $artifact" >&2
+      exit 1
+    fi
+
+    actual_bundle_id="$(unzip -p "$artifact" "$info_plist_path" | plutil -extract CFBundleIdentifier raw -o - -)"
+    if [ "$actual_bundle_id" != "$expected_ios_bundle_id" ]; then
+      echo "Native artifact variant mismatch: expected iOS bundle $expected_ios_bundle_id, got $actual_bundle_id" >&2
+      exit 1
+    fi
+    ;;
+  android)
+    if ! command -v bundletool >/dev/null 2>&1; then
+      echo 'bundletool is required to validate an Android App Bundle' >&2
+      exit 1
+    fi
+
+    actual_package="$(bundletool dump manifest --bundle="$artifact" | sed -n 's/.*package="\([^"]*\)".*/\1/p' | head -n 1)"
+    if [ "$actual_package" != "$expected_android_package" ]; then
+      echo "Native artifact variant mismatch: expected Android package $expected_android_package, got ${actual_package:-<missing>}" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "Unsupported platform: $platform" >&2
+    exit 1
+    ;;
+esac
+
+echo "Validated $variant $platform native artifact: $artifact"


### PR DESCRIPTION
Loose commit. Bundle-id validation before submit + anti-bricking scoped to dev only.

Part of the main → 1.0.3 (`ddb9c48c`) rewind. main was hard-reset to unwind the bundle-mode black screen; this stack re-lands the work since 1.0.3 one PR at a time. Base branch: `recreate/disable-bundle-mode` - review/merge in stack order. Backup of pre-reset main: tag `backup/pre-reset-2d6a3d4b`.