### PR TITLE
feat(perf): add iOS signpost module for Instruments profiling

### DIFF
--- a/ast-grep/README.md
+++ b/ast-grep/README.md
@@ -9,12 +9,12 @@ to both exist in a `-ts` and a `-tsx` variant.
 
 ## Rules
 
-| Rule                            | Why                                                                                                                                                      |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `no-partial-object-matchers-ts` | `.ts` tests assert exact shapes with `toEqual`; `toMatchObject` / `expect.objectContaining` let fields drift silently. (`.tsx` test files are excluded.) |
-| `no-inline-renderitem-tsx`      | An inline `renderItem` creates a new function identity per render, defeating list row memoization. Hoist it or wrap in `useCallback`.                    |
-| `no-react-native-flatlist-*`    | Lists use `LegendList` (chat) or `FlashList`; core `FlatList`/`SectionList`/`VirtualizedList` regress scroll perf.                                       |
-| `prefer-create-mmkv-*`          | MMKV instances are created through `createMMKV` (see `src/lib/mmkv.ts`) so ids/modes stay centralised.                                                   |
+| Rule                            | Why                                                                                                                                                                                                 |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `no-partial-object-matchers-ts` | `.ts` tests assert exact shapes with `toEqual`; `toMatchObject` / `expect.objectContaining` let fields drift silently. (`.tsx` test files are excluded.)                                            |
+| `no-inline-renderitem-tsx`      | An inline `renderItem` creates a new function identity per render, defeating list row memoization. Hoist it or wrap in `useCallback`.                                                               |
+| `no-react-native-flatlist-*`    | Lists use `LegendList` (chat) or `FlashList`; core `FlatList`/`SectionList`/`VirtualizedList` regress scroll perf.                                                                                  |
+| `prefer-create-mmkv-*`          | MMKV instances are created through `createMMKV` (see `src/lib/mmkv.ts`) so ids/modes stay centralised.                                                                                              |
 | `no-animated-layout-props-*`    | Animating layout props (width/height/top/left/margin/padding/flex...) in `useAnimatedStyle` relayouts every frame; prefer `transform`/`opacity` (`warning`, genuine resizes can `ast-grep-ignore`). |
 
 ## Adding a rule

--- a/ast-grep/rule-tests/__snapshots__/no-animated-layout-props-ts-snapshot.yml
+++ b/ast-grep/rule-tests/__snapshots__/no-animated-layout-props-ts-snapshot.yml
@@ -2,57 +2,57 @@ id: no-animated-layout-props-ts
 snapshots:
   'const style = useAnimatedStyle(() => ({ aspectRatio: r.get() }));':
     labels:
-    - source: 'aspectRatio: r.get()'
-      style: primary
-      start: 40
-      end: 60
-    - source: 'useAnimatedStyle(() => ({ aspectRatio: r.get() }))'
-      style: secondary
-      start: 14
-      end: 64
-    - source: aspectRatio
-      style: secondary
-      start: 40
-      end: 51
+      - source: 'aspectRatio: r.get()'
+        style: primary
+        start: 40
+        end: 60
+      - source: 'useAnimatedStyle(() => ({ aspectRatio: r.get() }))'
+        style: secondary
+        start: 14
+        end: 64
+      - source: aspectRatio
+        style: secondary
+        start: 40
+        end: 51
   'const style = useAnimatedStyle(() => ({ paddingHorizontal: p.get() }));':
     labels:
-    - source: 'paddingHorizontal: p.get()'
-      style: primary
-      start: 40
-      end: 66
-    - source: 'useAnimatedStyle(() => ({ paddingHorizontal: p.get() }))'
-      style: secondary
-      start: 14
-      end: 70
-    - source: paddingHorizontal
-      style: secondary
-      start: 40
-      end: 57
+      - source: 'paddingHorizontal: p.get()'
+        style: primary
+        start: 40
+        end: 66
+      - source: 'useAnimatedStyle(() => ({ paddingHorizontal: p.get() }))'
+        style: secondary
+        start: 14
+        end: 70
+      - source: paddingHorizontal
+        style: secondary
+        start: 40
+        end: 57
   'const style = useAnimatedStyle(() => ({ width: w.get() }));':
     labels:
-    - source: 'width: w.get()'
-      style: primary
-      start: 40
-      end: 54
-    - source: 'useAnimatedStyle(() => ({ width: w.get() }))'
-      style: secondary
-      start: 14
-      end: 58
-    - source: width
-      style: secondary
-      start: 40
-      end: 45
+      - source: 'width: w.get()'
+        style: primary
+        start: 40
+        end: 54
+      - source: 'useAnimatedStyle(() => ({ width: w.get() }))'
+        style: secondary
+        start: 14
+        end: 58
+      - source: width
+        style: secondary
+        start: 40
+        end: 45
   'const style = useAnimatedStyle(() => { return { height: h.get() }; });':
     labels:
-    - source: 'height: h.get()'
-      style: primary
-      start: 48
-      end: 63
-    - source: 'useAnimatedStyle(() => { return { height: h.get() }; })'
-      style: secondary
-      start: 14
-      end: 69
-    - source: height
-      style: secondary
-      start: 48
-      end: 54
+      - source: 'height: h.get()'
+        style: primary
+        start: 48
+        end: 63
+      - source: 'useAnimatedStyle(() => { return { height: h.get() }; })'
+        style: secondary
+        start: 14
+        end: 69
+      - source: height
+        style: secondary
+        start: 48
+        end: 54

--- a/ast-grep/rule-tests/__snapshots__/no-animated-layout-props-tsx-snapshot.yml
+++ b/ast-grep/rule-tests/__snapshots__/no-animated-layout-props-tsx-snapshot.yml
@@ -2,71 +2,71 @@ id: no-animated-layout-props-tsx
 snapshots:
   'const style = useAnimatedStyle(() => ({ flex: f.get() }));':
     labels:
-    - source: 'flex: f.get()'
-      style: primary
-      start: 40
-      end: 53
-    - source: 'useAnimatedStyle(() => ({ flex: f.get() }))'
-      style: secondary
-      start: 14
-      end: 57
-    - source: flex
-      style: secondary
-      start: 40
-      end: 44
+      - source: 'flex: f.get()'
+        style: primary
+        start: 40
+        end: 53
+      - source: 'useAnimatedStyle(() => ({ flex: f.get() }))'
+        style: secondary
+        start: 14
+        end: 57
+      - source: flex
+        style: secondary
+        start: 40
+        end: 44
   'const style = useAnimatedStyle(() => ({ marginTop: m.get(), opacity: o.get() }));':
     labels:
-    - source: 'marginTop: m.get()'
-      style: primary
-      start: 40
-      end: 58
-    - source: 'useAnimatedStyle(() => ({ marginTop: m.get(), opacity: o.get() }))'
-      style: secondary
-      start: 14
-      end: 80
-    - source: marginTop
-      style: secondary
-      start: 40
-      end: 49
+      - source: 'marginTop: m.get()'
+        style: primary
+        start: 40
+        end: 58
+      - source: 'useAnimatedStyle(() => ({ marginTop: m.get(), opacity: o.get() }))'
+        style: secondary
+        start: 14
+        end: 80
+      - source: marginTop
+        style: secondary
+        start: 40
+        end: 49
   'const style = useAnimatedStyle(() => ({ top: y.get(), left: x.get() }));':
     labels:
-    - source: 'top: y.get()'
-      style: primary
-      start: 40
-      end: 52
-    - source: 'useAnimatedStyle(() => ({ top: y.get(), left: x.get() }))'
-      style: secondary
-      start: 14
-      end: 71
-    - source: top
-      style: secondary
-      start: 40
-      end: 43
+      - source: 'top: y.get()'
+        style: primary
+        start: 40
+        end: 52
+      - source: 'useAnimatedStyle(() => ({ top: y.get(), left: x.get() }))'
+        style: secondary
+        start: 14
+        end: 71
+      - source: top
+        style: secondary
+        start: 40
+        end: 43
   'const style = useAnimatedStyle(() => ({ width: w.get() }));':
     labels:
-    - source: 'width: w.get()'
-      style: primary
-      start: 40
-      end: 54
-    - source: 'useAnimatedStyle(() => ({ width: w.get() }))'
-      style: secondary
-      start: 14
-      end: 58
-    - source: width
-      style: secondary
-      start: 40
-      end: 45
+      - source: 'width: w.get()'
+        style: primary
+        start: 40
+        end: 54
+      - source: 'useAnimatedStyle(() => ({ width: w.get() }))'
+        style: secondary
+        start: 14
+        end: 58
+      - source: width
+        style: secondary
+        start: 40
+        end: 45
   'const style = useAnimatedStyle(() => { return { height: h.get() }; });':
     labels:
-    - source: 'height: h.get()'
-      style: primary
-      start: 48
-      end: 63
-    - source: 'useAnimatedStyle(() => { return { height: h.get() }; })'
-      style: secondary
-      start: 14
-      end: 69
-    - source: height
-      style: secondary
-      start: 48
-      end: 54
+      - source: 'height: h.get()'
+        style: primary
+        start: 48
+        end: 63
+      - source: 'useAnimatedStyle(() => { return { height: h.get() }; })'
+        style: secondary
+        start: 14
+        end: 69
+      - source: height
+        style: secondary
+        start: 48
+        end: 54

--- a/ast-grep/rule-tests/no-animated-layout-props-ts-test.yml
+++ b/ast-grep/rule-tests/no-animated-layout-props-ts-test.yml
@@ -2,7 +2,7 @@ id: no-animated-layout-props-ts
 valid:
   - 'const style = useAnimatedStyle(() => ({ transform: [{ translateX: x.get() }] }));'
   - 'const style = useAnimatedStyle(() => ({ opacity: progress.get() }));'
-  - "const staticStyle = StyleSheet.create({ box: { width: 44, height: 44, top: 0 } });"
+  - 'const staticStyle = StyleSheet.create({ box: { width: 44, height: 44, top: 0 } });'
 invalid:
   - 'const style = useAnimatedStyle(() => ({ width: w.get() }));'
   - 'const style = useAnimatedStyle(() => { return { height: h.get() }; });'

--- a/ast-grep/rule-tests/no-animated-layout-props-tsx-test.yml
+++ b/ast-grep/rule-tests/no-animated-layout-props-tsx-test.yml
@@ -2,7 +2,7 @@ id: no-animated-layout-props-tsx
 valid:
   - 'const style = useAnimatedStyle(() => ({ transform: [{ translateX: x.get() }] }));'
   - 'const style = useAnimatedStyle(() => ({ opacity: progress.get(), transform: [{ scale: scale.get() }] }));'
-  - "const staticStyle = StyleSheet.create({ box: { width: 44, height: 44, top: 0 } });"
+  - 'const staticStyle = StyleSheet.create({ box: { width: 44, height: 44, top: 0 } });'
   - 'const props = useAnimatedProps(() => ({ strokeWidth: w.get() }));'
 invalid:
   - 'const style = useAnimatedStyle(() => ({ width: w.get() }));'

--- a/modules/signpost/expo-module.config.json
+++ b/modules/signpost/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["SignpostModule"]
+  }
+}

--- a/modules/signpost/ios/Signpost.podspec
+++ b/modules/signpost/ios/Signpost.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+  s.name           = 'Signpost'
+  s.version        = '1.0.0'
+  s.summary        = 'Emits os_signpost Points of Interest for Instruments profiling.'
+  s.description    = 'Bridges JS to OSSignposter (.pointsOfInterest) so Foam events appear on the Instruments timeline next to Time Profiler and Core Animation.'
+  s.license        = { type: 'BSD-3-Clause' }
+  s.authors        = 'Foam'
+  s.homepage       = 'https://github.com/luke-h1/foam.git'
+  s.platforms      = {
+    :ios => '16.4',
+    :tvos => '16.4'
+  }
+  s.swift_version  = '5.9'
+  s.source         = { git: 'https://github.com/luke-h1/foam.git', tag: "v#{s.version}" }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+  }
+
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/modules/signpost/ios/SignpostModule.swift
+++ b/modules/signpost/ios/SignpostModule.swift
@@ -1,0 +1,51 @@
+import ExpoModulesCore
+import Foundation
+import OSLog
+
+/**
+ * JS bridge for `OSSignposter` Points of Interest so Instruments can line up
+ * Foam events with CPU / frame timelines.
+ *
+ * Signpost names must be `StaticString`, so the lane is always "Foam" and the
+ * JS label goes in the message (visible in the Points of Interest detail).
+ */
+public class SignpostModule: Module {
+  private let signposter = OSSignposter(
+    subsystem: Bundle.main.bundleIdentifier ?? "tv.foam",
+    category: .pointsOfInterest
+  )
+
+  private var intervals: [String: OSSignpostIntervalState] = [:]
+  private let lock = NSLock()
+
+  public func definition() -> ModuleDefinition {
+    Name("Signpost")
+
+    Function("mark") { (name: String) in
+      let id = self.signposter.makeSignpostID()
+      self.signposter.emitEvent("Foam", id: id, "\(name)")
+    }
+
+    Function("begin") { (name: String) in
+      let id = self.signposter.makeSignpostID()
+      let state = self.signposter.beginInterval("Foam", id: id, "\(name)")
+      self.lock.lock()
+      let previous = self.intervals.removeValue(forKey: name)
+      self.intervals[name] = state
+      self.lock.unlock()
+      if let previous {
+        self.signposter.endInterval("Foam", previous)
+      }
+    }
+
+    Function("end") { (name: String) in
+      self.lock.lock()
+      let state = self.intervals.removeValue(forKey: name)
+      self.lock.unlock()
+      guard let state else {
+        return
+      }
+      self.signposter.endInterval("Foam", state)
+    }
+  }
+}

--- a/modules/signpost/src/Signpost.types.ts
+++ b/modules/signpost/src/Signpost.types.ts
@@ -1,0 +1,18 @@
+export interface SignpostNativeModule {
+  /**
+   * Instant Points of Interest marker. The label is the signpost message in
+   * Instruments.
+   */
+  mark(name: string): void;
+
+  /**
+   * Begin a named interval. Pair with `end(name)` using the same string.
+   */
+  begin(name: string): void;
+
+  /**
+   * End a previously begun interval. No-op if `begin` was never called for
+   * `name`.
+   */
+  end(name: string): void;
+}

--- a/modules/signpost/src/SignpostModule.android.ts
+++ b/modules/signpost/src/SignpostModule.android.ts
@@ -1,0 +1,10 @@
+import type { SignpostNativeModule } from './Signpost.types';
+
+// iOS-only Instruments helper; Android is a no-op.
+const unavailableModule: SignpostNativeModule = {
+  mark() {},
+  begin() {},
+  end() {},
+};
+
+export default unavailableModule;

--- a/modules/signpost/src/SignpostModule.ts
+++ b/modules/signpost/src/SignpostModule.ts
@@ -1,0 +1,12 @@
+import { requireOptionalNativeModule } from 'expo-modules-core';
+
+import type { SignpostNativeModule } from './Signpost.types';
+
+const unavailableModule: SignpostNativeModule = {
+  mark() {},
+  begin() {},
+  end() {},
+};
+
+export default requireOptionalNativeModule<SignpostNativeModule>('Signpost') ??
+  unavailableModule;

--- a/src/dev/imageBenchmark/useChatPerfSuite.ts
+++ b/src/dev/imageBenchmark/useChatPerfSuite.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useFrameCallback, useSharedValue } from 'react-native-reanimated';
 
+import { beginSignpost, endSignpost, markSignpost } from '@app/lib/signpost';
 import { chatStore$ } from '@app/store/chat/observables/chatStore';
 
 import {
@@ -149,30 +150,36 @@ export function useChatPerfSuite() {
       measuring: boolean,
       suiteEnd: number,
     ) => {
-      const start = performance.now();
-      if (measuring) {
-        accum.current = { on: true, fps: [], jank: 0, frames: 0 };
-        uiFrames.value = 0;
-        uiJank.value = 0;
-        uiActive.value = true;
-      }
-      phaseCountdownMs.value = ms;
-      totalCountdownMs.value = Math.max(0, suiteEnd - start);
-      setSuite(s => ({
-        ...s,
-        phaseIndex,
-        phaseLabel: label,
-        phaseSub: sub,
-        measuring,
-      }));
-      while (performance.now() - start < ms) {
-        if (cancelRef.current) {
-          break;
+      const signpostName = `chat-perf.${label}.${sub}`;
+      beginSignpost(signpostName);
+      try {
+        const start = performance.now();
+        if (measuring) {
+          accum.current = { on: true, fps: [], jank: 0, frames: 0 };
+          uiFrames.value = 0;
+          uiJank.value = 0;
+          uiActive.value = true;
         }
-        await sleep(120);
+        phaseCountdownMs.value = ms;
+        totalCountdownMs.value = Math.max(0, suiteEnd - start);
+        setSuite(s => ({
+          ...s,
+          phaseIndex,
+          phaseLabel: label,
+          phaseSub: sub,
+          measuring,
+        }));
+        while (performance.now() - start < ms) {
+          if (cancelRef.current) {
+            break;
+          }
+          await sleep(120);
+        }
+        accum.current.on = false;
+        uiActive.value = false;
+      } finally {
+        endSignpost(signpostName);
       }
-      accum.current.on = false;
-      uiActive.value = false;
     },
     [phaseCountdownMs, totalCountdownMs, uiActive, uiFrames, uiJank],
   );
@@ -187,6 +194,7 @@ export function useChatPerfSuite() {
     const results: PhaseResult[] = [];
 
     setSuite({ ...IDLE, running: true });
+    markSignpost('chat-perf.suite-start');
     const suiteEnd = performance.now() + SUITE_TOTAL_MS;
 
     try {

--- a/src/lib/signpost.ts
+++ b/src/lib/signpost.ts
@@ -1,0 +1,22 @@
+import Signpost from '@modules/signpost/src/SignpostModule';
+
+/**
+ * Instant Points of Interest marker for Instruments.
+ */
+export function markSignpost(name: string): void {
+  Signpost.mark(name);
+}
+
+/**
+ * Begin a named interval; pair with `endSignpost(name)`.
+ */
+export function beginSignpost(name: string): void {
+  Signpost.begin(name);
+}
+
+/**
+ * End a previously begun interval.
+ */
+export function endSignpost(name: string): void {
+  Signpost.end(name);
+}

--- a/src/screens/Stream/LiveStreamScreen.tsx
+++ b/src/screens/Stream/LiveStreamScreen.tsx
@@ -43,6 +43,7 @@ import { useUserQuery } from '@app/hooks/queries/useUserQuery';
 import { useChannelPoll } from '@app/hooks/useChannelPoll';
 import { useChannelPrediction } from '@app/hooks/useChannelPrediction';
 import { useOnAppStateChange } from '@app/hooks/useOnAppStateChange';
+import { markSignpost } from '@app/lib/signpost';
 import { twitchService } from '@app/services/twitch-service';
 import { addCreatedClip } from '@app/store/createdClips/actions/createdClips';
 import {
@@ -523,6 +524,7 @@ export const LiveStreamScreen = memo(function LiveStreamScreen({
     contentWidthSV.set(contentWidth);
 
     if (orientationChanged) {
+      markSignpost('live-stream.orientation-change');
       cancelAnimation(videoWidth);
       cancelAnimation(videoHeight);
       cancelAnimation(chatWidth);
@@ -548,6 +550,10 @@ export const LiveStreamScreen = memo(function LiveStreamScreen({
       return;
     }
 
+    const layoutSignpost = isLandscapeChatHidden
+      ? 'live-stream.chat-hide'
+      : 'live-stream.chat-reveal';
+    markSignpost(layoutSignpost);
     videoWidth.set(withTiming(videoDimensions.width, RESIZE_ANIMATION_CONFIG));
     videoHeight.set(
       withTiming(videoDimensions.height, RESIZE_ANIMATION_CONFIG),


### PR DESCRIPTION
## Summary
- Local `signpost` Expo module lets JS emit os_signpost Points of Interest on iOS (Android is a no-op).
- Marks live-stream orientation changes and chat reveal/hide, and wraps each chat-perf suite phase window.
- Needs a native iOS rebuild so the pod links (`pod-install`).

## Test plan
- [ ] `pod-install` / rebuild Foam (dev)
- [ ] Instruments Blank template + Points of Interest: rotate a live stream or toggle landscape chat and confirm Foam markers with the expected messages
- [ ] Run DevTools chat-perf suite and confirm phase intervals (`chat-perf.*`)
- [ ] Smoke Android: app starts; signpost calls are silent no-ops


