### PR TITLE
chore(tooling): non-android tooling and cleanup from #764

### DIFF
--- a/.agents/skills/commit-confirm/SKILL.md
+++ b/.agents/skills/commit-confirm/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: commit-confirm
+description: Opt-in approval-first, whole-working-tree wrapper for the commit skill. Defaults to grouping all changes and requires the commit skill; selected installs must also install commit. Activate only when the user explicitly invokes `$commit-confirm` or explicitly asks to use the named commit-confirm skill. Do not activate merely because the user asks to review or propose commits, ask before committing, or wait for "go".
+---
+
+# Commit Confirm
+
+Use this wrapper only after the explicit opt-in described in the frontmatter. A normal approval-first commit request does not opt in to this skill or its whole-working-tree default.
+
+Use this skill to run `$commit` in approval-first mode, defaulting to the whole working tree.
+
+Before starting, load and follow `$commit`. This skill overrides its default scope and approval behavior; `$commit` owns working-tree inspection, grouping, message style, staging, committing, and reporting.
+
+Selected installs do not install dependencies automatically. If `$commit` is not installed or available, stop before staging or committing. Tell the user to install it with:
+
+```bash
+npx skills add LegendApp/legend-skills --skill commit
+```
+
+Then ask them to retry after installation.
+
+## Scope And Approval Override
+
+When using `$commit`, force plan mode:
+
+- Unless the user requests a narrower scope, use all-changes mode: inspect staged, unstaged, and untracked changes as the pool to group. Preserve explicit exclusions.
+- If the user names a subset or asks for only the current agent's changes, honor that narrower scope.
+- Always present a commit plan first and wait for explicit approval such as `go`.
+- Do not stage or commit before approval, even if there is only one logical commit.
+- After approval, create all agreed commits without asking again unless the working tree changes unexpectedly.
+- Treat `go` after a previously presented plan as approval for that plan, then re-check the working tree before staging.

--- a/.agents/skills/commit-confirm/agents/openai.yaml
+++ b/.agents/skills/commit-confirm/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Commit Confirm"
+  short_description: "Review all changes; requires commit"
+  default_prompt: "Use $commit-confirm to inspect the whole working tree, propose logical commit groups, and wait for go before staging or committing; requires $commit."

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: commit
+description: Commit the current agent's changes by default, or all working-tree changes when explicitly requested, with clean logical grouping and repository commit-message conventions. Use when the user asks to commit changes, commit this work, commit all changes, split changes into commits, propose commit messages, or wait for "go" before committing.
+---
+
+# Commit
+
+Use this skill to turn the requested changes into one or more clean commits without absorbing unrelated work.
+
+## Scope
+
+- **Default:** commit only changes made by the current agent in the current task. Determine ownership from the known starting state, conversation, and tool history; do not infer it merely from the current diff or file path.
+- **All changes:** inspect and commit the whole working tree only when the user explicitly asks to commit all, everything, or the whole tree.
+- **Explicit subset:** honor any files, hunks, commits, or exclusions named by the user.
+- **Temporary artifacts:** exclude investigation-only diagnostics, logs, traces, profiler output, experimental toggles, screenshots, and repro fixtures unless explicitly requested. Keep permanent regression tests; ask if unclear.
+- If change ownership or the requested boundary cannot be determined reliably, stop before staging and ask. Never include pre-existing, concurrent, or user-authored changes by guesswork.
+
+## Approval Modes
+
+- **Direct mode**: If the user asks to commit, analyze the requested scope and create the needed commit or commits without asking for a separate "go".
+- **Plan mode**: If the user asks for a plan, asks to review commits first, says to wait, says to prompt or ask before committing, or otherwise requests approval first, present a commit plan and wait for explicit approval such as `go` before staging or committing. After approval, create all agreed commits without asking again unless the working tree changes unexpectedly.
+- **Clarification stop**: In any mode, stop before committing if ownership is unclear, mixed hunks cannot be staged safely, repository guidance conflicts with the user's request, or the intended grouping is ambiguous enough that committing would risk losing user intent.
+- **Approval response**: If a previous turn presented a commit plan and the user now says `go`, treat that as approval for that plan. Re-check the working tree before staging.
+
+## Inspect
+
+1. Read repository guidance first: `AGENTS.md`, contribution docs, or visible commit conventions.
+2. Determine whether the work fixes a known GitHub issue from explicit user context, an approved issue/task document, a verified issue URL, or repository metadata. Do not infer an issue relationship from an incidental number alone.
+3. Inspect state with `git status -sb`, `git diff --stat`, `git diff --staged --stat`, and targeted `git diff` / `git diff --staged`. Inspect relevant untracked files before staging them.
+4. Classify staged, unstaged, and untracked changes as in or out of scope. Task ownership does not imply inclusion; classify task-created instrumentation and fixtures as permanent or temporary before staging. Treat the full tree as context, not as permission to commit it.
+5. Preserve out-of-scope staged changes. If scoped changes occupy fully owned paths, a path-limited commit may leave unrelated index entries intact; if scoped and unrelated hunks share a path or safe isolation is uncertain, stop and ask rather than unstaging or committing someone else's work.
+6. Respect explicit exclusions, such as debug logs or generated artifacts the user said not to commit. Leave excluded changes unstaged and report them afterward.
+7. If there are no in-scope changes, say so and report any remaining out-of-scope changes without committing them.
+
+## Group
+
+Group the in-scope changes by one coherent concept: feature, fix, refactor, test, docs, config, dependency, or subsystem. Prefer separate commits when changes would be reviewed, reverted, or explained independently.
+
+If a file contains unrelated changes, split by hunk with `git add -p` or another path/hunk-limited staging method. Do not put unrelated hunks in one commit just because they share a file.
+
+## Message Style
+
+Follow explicit user instructions and repository or workspace guidance when present; they override this skill's defaults. Otherwise use this default:
+
+- Conventional Commit `type: subject`
+- no scope parentheses
+- imperative, concrete subject
+- no trailing period
+- no `Co-authored-by` trailer unless the user explicitly asks
+- when the commit fixes a verified GitHub issue, append ` #<number>` to the end of the subject
+
+Use the issue suffix only when the commit is intended to fix that issue, not merely when it is related or discovered during investigation. For multiple explicitly fixed issues, append each verified reference at the end. Repository-specific message rules or explicit user instructions still take precedence.
+
+Good:
+
+```text
+fix: preserve scroll offset after prepend
+fix: preserve failed CRUD creates #547
+feat: add commit planning skill
+docs: document skills install flow
+```
+
+Avoid:
+
+```text
+fix(list): preserve scroll offset
+update stuff
+chore: misc.
+```
+
+When the work explicitly fixes issue #547, `fix: preserve failed CRUD creates` is also incomplete because it omits the verified issue suffix.
+
+Use a body for behavioral changes when the reason, invariant, or validation would not be obvious from the title.
+
+## Plan Output
+
+When plan mode is active, present:
+
+```text
+Proposed commits (N):
+1. type: concrete subject
+   Rationale: Why this group belongs together.
+   Files: path/a, path/b
+```
+
+Then ask for `go` or edits. Do not stage or commit until the user approves.
+
+In direct mode, do this planning internally. Only show a concise summary before or while committing if it helps the user follow a multi-commit split.
+
+## Commit
+
+For each group:
+
+1. Stage only that group using path-limited or hunk-limited staging. Do not silently unstage out-of-scope changes.
+2. Verify the intended commit contains only that group with `git diff --staged --stat`, targeted `git diff --staged`, and `git diff --staged --check`. When unrelated index entries remain, use a path-limited commit only for fully owned paths and verify those paths separately.
+3. Commit with the agreed message.
+4. Re-check the tree after hooks run, then continue to the next group.
+
+After all commits, report commit hashes and any remaining unstaged files. If a commit fails, stop and report the exact failure and the current git state.

--- a/.agents/skills/commit/agents/openai.yaml
+++ b/.agents/skills/commit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Commit"
+  short_description: "Commit only this task's changes"
+  default_prompt: "Use $commit to commit only the changes you made in this task with clean logical grouping; include other working-tree changes only if I explicitly ask to commit all."

--- a/.agents/skills/diagnose-fix-loop/SKILL.md
+++ b/.agents/skills/diagnose-fix-loop/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: diagnose-fix-loop
+description: Iterative diagnose-and-fix workflow that repeatedly uses the diagnose skill to find a proven problem, plan the smallest credible improvement, implement it, re-diagnose, and continue until no useful fix remains or user intervention is required. Requires the diagnose skill; selected installs must also install diagnose. Use when asked to keep debugging, fix and verify, iterate until satisfied, improve after diagnosis, or run a diagnosis/fix/verification loop.
+---
+
+# Diagnose Fix Loop
+
+Use this skill to drive a complete improvement loop, not a single debugging pass.
+
+Before starting, load and follow `$diagnose`. Treat `$diagnose` as the evidence engine for each pass; this skill only adds the outer loop that plans, implements, re-runs diagnosis, and decides whether to continue.
+
+This skill owns planning and implementation after `$diagnose` proves the cause.
+
+Selected installs do not install dependencies automatically. If `$diagnose` is not installed or available, stop before making changes. Tell the user to install it with:
+
+```bash
+npx skills add LegendApp/legend-skills --skill diagnose
+```
+
+Then ask them to retry after installation.
+
+## Loop
+
+1. State the target outcome.
+   Anchor the loop to the user's symptom, performance goal, failing test, UX defect, regression, or code quality concern. If the user gave no concrete anchor, create the fastest observable feedback loop first.
+
+2. Run a `$diagnose` pass.
+   Complete the evidence loop and record the exact validation signal that will be re-run after the fix. Proceed only when `$diagnose` reports **Proven — 100%**. If it reports **Incomplete**, stop and report the missing evidence.
+   If the user asked for delegation, use it only for bounded evidence collection inside this pass; keep bottleneck ranking, fix selection, code edits, and final interpretation in the main loop.
+
+3. Make a ranked fix plan.
+   Prefer one smallest credible fix at a time. The plan must include:
+   - what evidence supports the change
+   - what file or boundary will change
+   - what validation should improve
+   - what would make the plan wrong
+
+4. Implement only the top plan item.
+   Keep the edit scoped to the proven fault line. Avoid stacking speculative cleanup, broad refactors, or adjacent improvements unless the diagnosis showed they are part of the same fault.
+
+5. Verify with the original signal.
+   Re-run the reproduction path or measurement from step 2, then focused regression coverage, then broader checks when the touched surface warrants them.
+
+6. Re-run `$diagnose`.
+   Diagnose the new state from evidence, not from the intent of the change. Look for:
+   - the original symptom still failing
+   - a nearby remaining fault
+   - a regression introduced by the fix
+   - a stronger next bottleneck revealed by the first fix
+   - missing coverage at the real seam
+
+7. Decide whether to continue.
+   Continue when evidence identifies a credible next fix and the next action is safe to take. Each new iteration should have a sharper target than the previous one.
+
+## Iteration Discipline
+
+Keep a short running log while working:
+
+- iteration number
+- current evidence
+- chosen fix
+- validation result
+- next remaining issue or stop reason
+
+If an experiment fails, revert it unless it is independently useful and intentionally kept. Do not count a failed experiment as progress unless it narrowed the diagnosis.
+
+If two iterations produce no measurable improvement and no sharper evidence, pause implementation and re-diagnose the feedback loop itself before making more edits.
+
+## Stop Rules
+
+Stop only when one of these is true:
+
+- `$diagnose` cannot build or run a credible feedback loop with available code, tools, or artifacts
+- the next action requires user input, inaccessible external state, credentials, production access, or a destructive operation
+- the user requested read-only diagnosis and the next useful step would edit files
+- validation is clean and a fresh `$diagnose` pass finds no remaining credible fault to fix
+- remaining improvements are speculative, cosmetic, or outside the user's target outcome
+
+When stopping, report the final state, the validation evidence, remaining known risk, and the smallest user action or artifact needed if work is blocked.

--- a/.agents/skills/diagnose-fix-loop/agents/openai.yaml
+++ b/.agents/skills/diagnose-fix-loop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Diagnose Fix Loop"
+  short_description: "Iterate fixes; requires diagnose"
+  default_prompt: "Use $diagnose-fix-loop to iterate diagnosis and fixes until evidence says to stop; requires $diagnose."

--- a/.agents/skills/diagnose/SKILL.md
+++ b/.agents/skills/diagnose/SKILL.md
@@ -1,117 +1,79 @@
 ---
 name: diagnose
-description: Disciplined diagnosis loop for hard bugs and performance regressions. Reproduce → minimise → hypothesise → instrument → fix → regression-test. Use when user says "diagnose this" / "debug this", reports a bug, says something is broken/throwing/failing, or describes a performance regression.
+description: Opt-in evidence-first causal diagnosis for bugs, browser or app/device failures, flaky behavior, and performance regressions. Activate only when the user explicitly invokes `$diagnose` or explicitly asks to use the named diagnose skill. Do not activate merely because the user mentions a bug, asks why something failed, requests debugging or a fix, or describes unexpected behavior. Once explicitly invoked, locate likely causes, instrument relevant boundaries with extensive structured logging, reproduce the issue, analyze the collected logs, rank causes with confidence scores, and pursue 100% operational confidence while probes can increase confidence.
 ---
 
 # Diagnose
 
-A discipline for hard bugs. Skip phases only when explicitly justified.
+Use this workflow only after the explicit opt-in described in the frontmatter. A normal bug report or debugging request does not opt in to this skill.
 
-When exploring the codebase, use the project's domain glossary to get a clear mental model of the relevant modules, and check ADRs in the area you're touching.
+Find and explain the cause of a symptom with 100% operational confidence.
 
-## Phase 1 — Build a feedback loop
+Start from the user's concrete anchor: file, route, error, log, screen, branch, artifact, or reproduction step. Consult relevant architecture notes, ADRs, glossaries, and test docs. Inspect code, run safe tools or tests, and analyze existing artifacts.
 
-**This is the skill.** Everything else is mechanical. If you have a fast, deterministic, agent-runnable pass/fail signal for the bug, you will find the cause — bisection, hypothesis-testing, and instrumentation all just consume that signal. If you don't have one, no amount of staring at code will save you.
+Explicit invocation of Diagnose constitutes approval for behavior-neutral temporary instrumentation within the requested scope. Ask separately only for risky actions, inaccessible-state reproduction, or mutations that affect product behavior or external systems.
 
-Spend disproportionate effort here. **Be aggressive. Be creative. Refuse to give up.**
+## References
 
-### Ways to construct one — try them in roughly this order
+Load only what applies:
 
-1. **Failing test** at whatever seam reaches the bug — unit, integration, e2e.
-2. **Curl / HTTP script** against a running dev server.
-3. **CLI invocation** with a fixture input, diffing stdout against a known-good snapshot.
-4. **Headless browser script** (Playwright / Puppeteer) — drives the UI, asserts on DOM/console/network.
-5. **Replay a captured trace.** Save a real network request / payload / event log to disk; replay it through the code path in isolation.
-6. **Throwaway harness.** Spin up a minimal subset of the system (one service, mocked deps) that exercises the bug code path with a single function call.
-7. **Property / fuzz loop.** If the bug is "sometimes wrong output", run 1000 random inputs and look for the failure mode.
-8. **Bisection harness.** If the bug appeared between two known states (commit, dataset, version), automate "boot at state X, check, repeat" so you can `git bisect run` it.
-9. **Differential loop.** Run the same input through old-version vs new-version (or two configs) and diff outputs.
-10. **HITL bash script.** Last resort. If a human must click, drive _them_ with `scripts/hitl-loop.template.sh` so the loop is still structured. Captured output feeds back to you.
+- Browser or React web: [browser-react.md](references/browser-react.md)
+- iOS, Android, React Native, macOS, TV, or physical device: [app-device.md](references/app-device.md)
+- Logs, runtime probes, metrics, or debug hooks: [instrumentation.md](references/instrumentation.md)
 
-Build the right feedback loop, and the bug is 90% fixed.
+## Evidence Loop
 
-### Iterate on the loop itself
+1. **Locate likely causes.** Inspect the code path and existing evidence around the user's anchor. Form the smallest useful set of likely areas and falsifiable candidate causes, including independent or contributing causes when applicable. Give each cause a distinguishing prediction and identify where those predictions diverge.
 
-Treat the loop as a product. Once you have _a_ loop, ask:
+2. **Instrument before reproducing.** Load [instrumentation.md](references/instrumentation.md) and add structured logging across the relevant boundaries, extensive enough to reconstruct the causal sequence rather than only record the visible symptom. Instrument competing causes in the same pass when practical so one reproduction can distinguish them.
 
-- Can I make it faster? (Cache setup, skip unrelated init, narrow the test scope.)
-- Can I make the signal sharper? (Assert on the specific symptom, not "didn't crash".)
-- Can I make it more deterministic? (Pin time, seed RNG, isolate filesystem, freeze network.)
+   Before reproducing, define the probe contract:
 
-A 30-second flaky loop is barely better than no loop. A 2-second deterministic loop is a debugging superpower.
+   - the exact trigger and visible symptom
+   - the questions this run will answer
+   - each candidate cause's distinguishing prediction
+   - the events, fields, and correlation IDs that test those predictions
+   - how the evidence will be tied to the exact visible failure
+   - the intended process, build, window, document, and runtime identity when applicable
 
-### Non-deterministic bugs
+   Do not run the reproduction if the probes cannot distinguish the leading candidates or cannot confirm that the exact symptom occurred.
 
-The goal is not a clean repro but a **higher reproduction rate**. Loop the trigger 100×, parallelise, add stress, narrow timing windows, inject sleeps. A 50%-flake bug is debuggable; 1% is not — keep raising the rate until it's debuggable.
+3. **Reproduce the instrumented issue.** Use the fastest deterministic signal that represents the reported symptom: focused test, script, browser test, trace replay, harness, repeat loop, profiler, app/device automation, or structured human reproduction. Run it when safe and observable. For intermittent failures, run enough repetitions to compare causes.
 
-### When you genuinely cannot build a loop
+   When reproduction requires inaccessible state, credentials, devices, subjective interaction, or risky actions, first prepare the capture, exact steps, expected observation, and artifact to inspect. Ask the user to reproduce and reply `done`; confirm the returned evidence matches the reported failure.
 
-Stop and say so explicitly. List what you tried. Ask the user for: (a) access to whatever environment reproduces it, (b) a captured artifact (HAR file, log dump, core dump, screen recording with timestamps), or (c) permission to add temporary production instrumentation. Do **not** proceed to hypothesise without a loop.
+   If the user corrects the trigger, affected component, lifecycle, or visible symptom, invalidate evidence and probes that target the previous interpretation. Return to cause location and instrumentation before reproducing again; do not continue with a nearby but mismatched reproduction.
 
-Do not proceed to Phase 2 until you have a loop you believe in.
+4. **Collect and analyze.** Collect the complete output, correlate events across boundaries, compare it with each prediction, and record evidence for and against every cause. If the logs are incomplete or ambiguous, identify how the likely areas or instrumentation must change before another reproduction.
 
-## Phase 2 — Reproduce
+5. **Determine confidence.** Rank each cause by role (root, contributing, or alternative), `0-100%` confidence, supporting and conflicting evidence, and the next evidence that could change its score or rank. Treat scores as calibrated judgments, not statistical probabilities. Assign 100% operational confidence only when:
 
-Run the loop. Watch the bug appear.
+   - the exact symptom is reproduced
+   - the causal chain from trigger to failure is observed
+   - controlling the suspected boundary reliably controls the symptom
+   - the cause or combination of causes explains every relevant observation
+   - plausible alternatives are falsified or included as contributing causes
+   - intermittent behavior is repeated enough to distinguish causality from coincidence
 
-Confirm:
+   If proof is incomplete, choose the safest practical probe likely to add discriminating evidence and state which results would raise, lower, or redistribute confidence. Revise the likely areas or instrumentation and repeat the loop only while such a probe exists; do not repeat an equivalent pass without changing its inputs, boundary, or instrumentation.
 
-- [ ] The loop produces the failure mode the **user** described — not a different failure that happens to be nearby. Wrong bug = wrong fix.
-- [ ] The failure is reproducible across multiple runs (or, for non-deterministic bugs, reproducible at a high enough rate to debug against).
-- [ ] You have captured the exact symptom (error message, wrong output, slow timing) so later phases can verify the fix actually addresses it.
+   Stop as incomplete when no available probe should increase confidence, a pass adds no evidence and no distinct boundary remains, or the needed evidence requires unavailable access, user action, unacceptable risk, or disproportionate effort. Never label an incomplete diagnosis as proven.
 
-Do not proceed until you reproduce the bug.
+## Output
 
-## Phase 3 — Hypothesise
+Lead with one status:
 
-Generate **3–5 ranked hypotheses** before testing any of them. Single-hypothesis generation anchors on the first plausible idea.
+- **Proven — 100%:** every applicable cause meets the proof standard with no unresolved plausible alternative.
+- **Incomplete:** the proof standard is not met.
 
-Each hypothesis must be **falsifiable**: state the prediction it makes.
+For **Proven**, report each cause, role, causal chain, decisive evidence, exact code or runtime boundary, and interaction between causes. For **Incomplete**, rank candidates with confidence, supporting and conflicting evidence, remaining uncertainty, why the loop stopped, and the smallest evidence needed to continue. Always name the validation signal that preserves the causal evidence.
 
-> Format: "If <X> is the cause, then <changing Y> will make the bug disappear / <changing Z> will make it worse."
+## Temporary Diagnostics
 
-If you cannot state the prediction, the hypothesis is a vibe — discard or sharpen it.
+Keep diagnostic logs until the user requests cleanup or they become durable diagnostics. If committing while temporary diagnostics remain, stage only intended durable changes and report what remains unstaged.
 
-**Show the ranked list to the user before testing.** They often have domain knowledge that re-ranks instantly ("we just deployed a change to #3"), or know hypotheses they've already ruled out. Cheap checkpoint, big time saver. Don't block on it — proceed with your ranking if the user is AFK.
+## Delegation
 
-## Phase 4 — Instrument
+Use subagents only when the user explicitly requests delegation, subagents, parallel work, or token optimization. Delegate bounded mechanical collection to faster or cheaper agents: known commands or repro loops, logs, screenshots, traces, profiles, extraction, or artifact comparison. Give each task a success condition, output format, runtime boundary, and no-edit instruction unless mutation is explicit.
 
-Each probe must map to a specific prediction from Phase 3. **Change one variable at a time.**
-
-Tool preference:
-
-1. **Debugger / REPL inspection** if the env supports it. One breakpoint beats ten logs.
-2. **Targeted logs** at the boundaries that distinguish hypotheses.
-3. Never "log everything and grep".
-
-**Tag every debug log** with a unique prefix, e.g. `[DEBUG-a4f2]`. Cleanup at the end becomes a single grep. Untagged logs survive; tagged logs die.
-
-**Perf branch.** For performance regressions, logs are usually wrong. Instead: establish a baseline measurement (timing harness, `performance.now()`, profiler, query plan), then bisect. Measure first, fix second.
-
-## Phase 5 — Fix + regression test
-
-Write the regression test **before the fix** — but only if there is a **correct seam** for it.
-
-A correct seam is one where the test exercises the **real bug pattern** as it occurs at the call site. If the only available seam is too shallow (single-caller test when the bug needs multiple callers, unit test that can't replicate the chain that triggered the bug), a regression test there gives false confidence.
-
-**If no correct seam exists, that itself is the finding.** Note it. The codebase architecture is preventing the bug from being locked down. Flag this for the next phase.
-
-If a correct seam exists:
-
-1. Turn the minimised repro into a failing test at that seam.
-2. Watch it fail.
-3. Apply the fix.
-4. Watch it pass.
-5. Re-run the Phase 1 feedback loop against the original (un-minimised) scenario.
-
-## Phase 6 — Cleanup + post-mortem
-
-Required before declaring done:
-
-- [ ] Original repro no longer reproduces (re-run the Phase 1 loop)
-- [ ] Regression test passes (or absence of seam is documented)
-- [ ] All `[DEBUG-...]` instrumentation removed (`grep` the prefix)
-- [ ] Throwaway prototypes deleted (or moved to a clearly-marked debug location)
-- [ ] The hypothesis that turned out correct is stated in the commit / PR message — so the next debugger learns
-
-**Then ask: what would have prevented this bug?** If the answer involves architectural change (no good test seam, tangled callers, hidden coupling) hand off to the `/improve-codebase-architecture` skill with the specifics. Make the recommendation **after** the fix is in, not before — you have more information now than when you started.
+Keep feedback-loop design, hypothesis ranking, confidence scoring, ambiguous interpretation, and the final diagnosis in the main thread. Verify delegated evidence and inspect the working tree and background processes before continuing.

--- a/.agents/skills/diagnose/agents/openai.yaml
+++ b/.agents/skills/diagnose/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Diagnose"
+  short_description: "Prove causes with evidence"
+  default_prompt: "Use $diagnose to locate likely causes, instrument the relevant boundaries with extensive structured logging, reproduce the issue, analyze the logs, and repeat while another probe can increase confidence."

--- a/.agents/skills/diagnose/references/app-device.md
+++ b/.agents/skills/diagnose/references/app-device.md
@@ -1,0 +1,118 @@
+# App And Device Adapters
+
+Use this reference for live app evidence on mobile, device, desktop, TV, or React Native targets.
+
+These adapters are optional helpers. Use an equivalent host-provided app/device tool when one is already available. If live automation is required and no suitable adapter exists, provide the relevant install command and wait for the user to install it or approve installation. Otherwise continue with tests, logs, browser tooling, command-line repros, or user-provided artifacts.
+
+## Detect Tools
+
+Check availability before suggesting installation:
+
+```bash
+command -v argent
+command -v agent-device
+```
+
+Do not silently install tools. Suggest installation only when the missing adapter blocks the required evidence loop.
+
+When using Argent or agent-device, check whether the installed tool is behind the npm latest version:
+
+```bash
+argent --version
+npm view @swmansion/argent version
+agent-device --version
+npm view agent-device version
+```
+
+If an update is available for a tool used during the turn, end the turn by suggesting the update and provide both options:
+
+- the exact update command
+- that the user can reply `update` to have the agent run it
+
+## Defaults
+
+| Target | Preferred adapter |
+| --- | --- |
+| iOS Simulator | Argent |
+| iOS device | agent-device |
+| Android Emulator | Argent |
+| Android device | agent-device |
+| React Native macOS app | agent-device |
+| TV app | agent-device |
+| Desktop app | agent-device |
+
+## Argent
+
+Prefer Argent when MCP tools are available and the target is an iOS Simulator or Android Emulator, especially for React Native work that needs:
+
+- Metro/CDP logs
+- React component tree inspection
+- JS evaluation in the app runtime
+- profiling
+- launch, reload, deep link, or simulator/emulator gestures
+
+Before using Argent, inspect the current environment and current tool docs:
+
+```bash
+argent --help
+argent tools
+```
+
+If Argent is not installed, suggest:
+
+```bash
+npx @swmansion/argent init -y
+```
+
+or:
+
+```bash
+npm install -g @swmansion/argent@latest
+argent init -y
+```
+
+If Argent was used and a newer npm version is available, end the turn with:
+
+```bash
+npm install -g @swmansion/argent@latest && argent init -y
+```
+
+## agent-device
+
+Prefer agent-device for physical devices, macOS, TV, desktop, replayable flows, CI evidence, screenshots/videos, network/log/perf capture, and broad CLI-driven app automation.
+
+Before planning commands, read the installed version's workflow help:
+
+```bash
+agent-device --version
+agent-device help workflow
+```
+
+Escalate to narrower help when relevant:
+
+```bash
+agent-device help debugging
+agent-device help react-native
+agent-device help react-devtools
+agent-device help macos
+```
+
+If agent-device is not installed, suggest:
+
+```bash
+npm install -g agent-device@latest
+agent-device help workflow
+```
+
+If agent-device was used and a newer npm version is available, end the turn with:
+
+```bash
+npm install -g agent-device@latest
+```
+
+## Tool Choice Notes
+
+- For React Native iOS/Android simulator or emulator diagnosis, start with Argent if its MCP tools are present.
+- For physical iOS or Android devices, start with agent-device.
+- For React Native macOS apps, start with agent-device.
+- For React Native Web or React DOM apps, use browser tooling first. See [browser-react.md](browser-react.md).

--- a/.agents/skills/diagnose/references/browser-react.md
+++ b/.agents/skills/diagnose/references/browser-react.md
@@ -1,0 +1,73 @@
+# Browser And React Debugging
+
+Use this reference for React DOM, React Native Web, browser-rendered UI, and localhost frontend bugs.
+
+## Detect The Stack
+
+Inspect the repo before choosing a browser tool:
+
+```bash
+cat package.json
+```
+
+Look for:
+
+- framework: `next`, `vite`, `react-scripts`, `remix`, `astro`, `expo`, `react-native-web`
+- React packages: `react`, `react-dom`, `react-native-web`
+- browser/test tooling: `@playwright/test`, `playwright`, `cypress`, `vitest`, `@testing-library/react`, `storybook`
+- scripts: `dev`, `start`, `test`, `test:e2e`, `playwright`, `cypress`, `storybook`
+
+If package metadata is insufficient, inspect config files such as `vite.config.*`, `next.config.*`, `playwright.config.*`, `cypress.config.*`, `vitest.config.*`, and `.storybook/`.
+
+## Browser Adapter Order
+
+1. **Existing repo test tooling**: prefer existing Playwright, Cypress, Vitest browser mode, Storybook tests, or Testing Library coverage when it can reproduce the bug. This gives the best regression path.
+2. **Host-provided browser automation**: use the browser tools exposed by the current agent environment for live localhost inspection, DOM state, user interactions, screenshots, console errors, and network evidence.
+3. **Playwright**: use as the generic public fallback for deterministic browser repro scripts/tests when no repo tooling exists.
+4. **agent-device web**: use when the browser flow must be replayable alongside mobile/device flows, recorded, captured as CLI evidence, or used in a unified cross-platform workflow. When using agent-device web, follow the agent-device install and update rules in [app-device.md](app-device.md).
+5. **Raw CDP, Puppeteer, or React DevTools**: use when the bug requires low-level runtime evaluation, performance tracing, heap inspection, React render profiling, or when existing tools expose that route directly.
+
+Before using a non-repo tool, detect it:
+
+```bash
+command -v playwright
+command -v agent-device
+```
+
+If Playwright is needed but unavailable, suggest installing the package that fits the repo's package manager, for example:
+
+```bash
+npm install -D @playwright/test
+npx playwright install
+```
+
+If agent-device web is needed but unavailable, suggest:
+
+```bash
+npm install -g agent-device@latest
+agent-device web setup
+agent-device web doctor
+```
+
+## React Web Defaults
+
+| Target | Preferred approach |
+| --- | --- |
+| React DOM app | Existing browser tests, then host browser automation, then Playwright |
+| React Native Web app | Browser tools/Playwright first; use mobile tools only when comparing native behavior |
+| Storybook repro | Existing Storybook test runner or Playwright against Storybook |
+| Hydration or SSR bug | Framework dev server plus browser console/network evidence |
+| Render performance bug | React DevTools/profiler or browser performance tooling before adding logs |
+
+## Evidence To Capture
+
+For browser bugs, prefer evidence that can become a regression:
+
+- failing browser test or script
+- console error with source location
+- network request/response mismatch
+- DOM state or accessible role/name mismatch
+- screenshot only when visual layout matters
+- performance trace or React profiler result for performance claims
+
+Do not stop when the symptom merely disappears if the same behavior can be asserted through DOM, URL, console, network, or test state.

--- a/.agents/skills/diagnose/references/instrumentation.md
+++ b/.agents/skills/diagnose/references/instrumentation.md
@@ -1,0 +1,88 @@
+# Instrumentation
+
+Use this reference when a diagnosis needs logs, runtime probes, metrics, or temporary debug hooks.
+
+## Log Format
+
+Every temporary log must have:
+
+- absolute timestamp first
+- stable prefix
+- debug id for the current pass
+- event name
+- compact structured payload
+- sequence number when ordering matters
+
+Example:
+
+```ts
+const DEBUG_ID = "checkout-total-v2";
+let seq = 0;
+
+console.log(`${Date.now()} [DEBUG ${DEBUG_ID}] price-recalculated`, {
+  seq: ++seq,
+  cartId,
+  previousTotal,
+  nextTotal,
+});
+```
+
+Change the debug id when instrumentation changes materially.
+
+## Where To Probe
+
+Instrument causal boundaries, not symptoms:
+
+- state writes and derived-state updates
+- render, effect, subscription, and lifecycle boundaries
+- event handlers and async callbacks
+- allocator, cache, and ownership transitions
+- layout measurements and final applied layout values
+- native/JS bridge handoffs
+- network, persistence, and cache boundaries
+- scheduler, timer, animation-frame, and debounce/throttle handoffs
+
+When multiple layers might disagree, log comparable fields on both sides of the boundary with the same debug id.
+
+## Avoid Perturbing Bugs
+
+If logging may change timing or hide the bug, do not rely on hot-path `console.log`.
+
+Prefer:
+
+- buffered in-memory events with a dump function
+- file logs or a debug registry
+- sampled logs
+- profiler or metric output
+- delayed flush after the interaction settles
+- targeted counters instead of full payload dumps
+
+If adding logs changes reproducibility, switch to a less perturbing strategy before drawing conclusions.
+
+## Confidence Loop
+
+After each instrumentation pass, re-rank every plausible cause and update its confidence score. Record which observation changed the score.
+
+Before adding another probe, state which possible result would change the ranking or confidence. If no result would add discriminating evidence, or the last pass added no evidence and no distinct boundary remains, stop as incomplete instead of repeating.
+
+## Keeping Logs
+
+Keep diagnostic logs in place while diagnosis is ongoing. Do not remove them just because a candidate cause is found; the user may want to continue diagnosing.
+
+Remove temporary logs only when:
+
+- the user explicitly asks to remove or clean up debug logs
+- the logs are converted into intentional durable diagnostics
+- the user explicitly asks for a final cleanup pass
+
+## Commit Staging
+
+If the user asks to commit during or after diagnosis:
+
+1. Do not remove temporary logs just because of the commit.
+2. Stage only intended durable changes with path-limited staging.
+3. Verify the staged diff excludes temporary logs and throwaway probes.
+4. Commit the staged changes.
+5. Report which diagnostic files remain unstaged.
+
+Temporary logs should remain unstaged unless the user explicitly asks to commit durable diagnostics.

--- a/.agents/skills/diagnose/scripts/hitl-loop.template.sh
+++ b/.agents/skills/diagnose/scripts/hitl-loop.template.sh
@@ -7,8 +7,8 @@
 #   bash hitl-loop.template.sh
 #
 # Two helpers:
-#   step "<instruction>"          → show instruction, wait for Enter
-#   capture VAR "<question>"      → show question, read response into VAR
+#   step "<instruction>"          -> show instruction, wait for Enter
+#   capture VAR "<question>"      -> show question, read response into VAR
 #
 # At the end, captured values are printed as KEY=VALUE for the agent to parse.
 
@@ -28,14 +28,16 @@ capture() {
 
 # --- edit below ---------------------------------------------------------
 
-step "Open the app at http://localhost:3000 and sign in."
+step "Prepare the target app, page, command, or device state described in the repro."
 
-capture ERRORED "Click the 'Export' button. Did it throw an error? (y/n)"
+step "Perform the exact user action or command that is expected to reproduce the symptom."
 
-capture ERROR_MSG "Paste the error message (or 'none'):"
+capture REPRODUCED "Did the reported symptom reproduce? (y/n)"
+
+capture OBSERVED "Describe the observed result, error, or visible state:"
 
 # --- edit above ---------------------------------------------------------
 
 printf '\n--- Captured ---\n'
-printf 'ERRORED=%s\n' "$ERRORED"
-printf 'ERROR_MSG=%s\n' "$ERROR_MSG"
+printf 'REPRODUCED=%s\n' "$REPRODUCED"
+printf 'OBSERVED=%s\n' "$OBSERVED"

--- a/.agents/skills/git-integrate/SKILL.md
+++ b/.agents/skills/git-integrate/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: git-integrate
+description: Safely start new or continue in-progress Git integration and history operations through verified completion. Use when asked to run or resume a rebase, merge, cherry-pick, or revert; when Git is already in the middle of one of those operations; or for interruption recovery, conflict resolution, ours/theirs interpretation, and deciding when user guidance is required. Continue a detected active operation before considering new work, never choose the integration method, and never guess an unclear next action or resolution.
+---
+
+# Git Integrate
+
+Own a rebase, merge, cherry-pick, or revert through verified completion. If one is already in progress, take it over and continue or repair it before considering new work. Otherwise, safely start the operation explicitly requested by the user. This is not a general Git command runner: do not choose an integration strategy or perform unrelated commit, branch, stash, reset, remote, or worktree maintenance.
+
+> **Hard stop:** For new work, proceed only when the requested operation and history shape are 100% clear. For an in-progress operation, continue it without requiring the user to restate its method or target when Git state makes the operation and next action clear. Resolve a conflict only when its intended result is also clear from repository evidence. Otherwise stop before mutating Git or files and ask the user with concrete options. Never choose a default; an incorrect history operation or resolution is worse than an interruption.
+
+## Workflow
+
+1. **Inspect state.** Run full `git status`, `git status --short --branch`, and `scripts/inspect-operation.sh` when available. Record the current branch and `HEAD`. Resolve `rebase-merge`, `rebase-apply`, `MERGE_HEAD`, `CHERRY_PICK_HEAD`, `REVERT_HEAD`, and the sequencer directory with `git rev-parse --git-path`.
+
+   Active Git state determines the operation to continue; do not start another or ask the user to choose a new method or target. It does not by itself establish the intended combined behavior or prove that `--continue` is the correct immediate action.
+
+2. **Continue an active operation.** Read `git status`, the operation metadata and todo state, the current operation commit, unmerged index stages, staged changes, and working-tree changes. Determine whether the operation is ready to continue or stopped for a conflict, an edit instruction, a failed exec, an empty commit, a pending commit, or another reason.
+
+   Route conflicts through the resolution workflow below. For an edit or failed exec, verify the requested edit or command result before continuing. For an empty commit, require explicit approval before keeping, dropping, or skipping it. If the stop reason or next action is unclear, preserve the exact state and ask; never blindly continue an operation merely because it is active.
+
+3. **Preflight a new operation.** With no active operation, require an explicit method and enough information to determine its exact history effect:
+
+   - Rebase: current or named source branch, upstream, commits to replay, and whether the request requires `--onto`, `--rebase-merges`, `--update-refs`, autosquash, or another non-default form.
+   - Merge: source and target plus the intended fast-forward policy: `--ff-only`, allow a fast-forward, or require a merge commit with `--no-ff`.
+   - Cherry-pick: exact commits, order, and whether an empty result should stop, drop, or be kept.
+   - Revert: exact commits, order, and the confirmed `-m <parent>` for every merge commit.
+
+   Resolve named refs to commit IDs and inspect the merge base, divergence, commits, and relevant diff before mutating history. Identify pre-existing staged, unstaged, and untracked changes; proceed with them present only when their ownership and non-interaction are clear. Fetch only the required remote or ref when freshness matters. Inspect behavior-affecting configuration such as `merge.ff`, `rebase.autoStash`, `rebase.rebaseMerges`, `rebase.updateRefs`, and `rerere.enabled`; use explicit flags or ask when configuration would materially change the result.
+
+   Do not default to rebase, choose a topology, switch branches, stash changes, or simplify a requested complex operation without approval. Record the original branch, `HEAD`, and relevant refs so the final history can be compared.
+
+4. **Start the confirmed operation.** Construct the command from the confirmed history shape rather than forcing every request through a simple form. Basic forms include `git rebase <upstream>`, `git merge --no-edit --ff-only <source>`, `git merge --no-edit --ff <source>`, `git merge --no-edit --no-ff <source>`, `git cherry-pick <commits>`, and `GIT_EDITOR=true git revert <commits>`. Add variant flags or `-m <parent>` only when confirmed. Run non-interactively when doing so preserves the requested commit messages and behavior.
+
+5. **Inspect every conflict before editing.** Check `git diff --name-only --diff-filter=U`, `git ls-files -u`, `git diff --cc`, markers, and the exact change represented by `REBASE_HEAD`, `CHERRY_PICK_HEAD`, `REVERT_HEAD`, or `MERGE_HEAD`. Use surrounding history, callers, tests, and docs to state the intended result and evidence for every path.
+
+   If any result is not 100% clear, resolve nothing. Report the exact Git state and paths, explain the competing intents and evidence, and offer concrete options. You may identify the likeliest option but must not select it. Always ask for divergent behavior, unclear delete/modify conflicts, uncertain binary/lock/generated files, competing refactors or evidence, and missing mainline parents. Formatting, imports, non-overlapping edits, moves, and generated files are direct only when repository evidence verifies the result.
+
+6. **Resolve and verify.** Treat staged resolutions, `rerere`, merge drivers, and automatic resolutions as untrusted proposals. Once every path is clear, edit the files, regenerate generated output from its source, remove all markers, and stage only resolved paths. Verify no unmerged entries remain, review the staged resolution, and run the fastest meaningful focused check when the intermediate state is testable. Never accept `ours`, `theirs`, union merge, or generated output wholesale without independent verification.
+
+7. **Continue the in-progress operation.** When Git state shows that the current step is ready, including after resolving a conflict or confirming a pending operation commit, use the matching command:
+
+   - `GIT_EDITOR=true git rebase --continue`
+   - `GIT_EDITOR=true git merge --continue`
+   - `GIT_EDITOR=true git cherry-pick --continue`
+   - `GIT_EDITOR=true git revert --continue`
+
+   Reinspect state after every continuation. Apply the same classification and hard stop to each subsequent pause; do not use `--continue` for a different stop reason without verifying its required action.
+
+8. **Verify completion.** Confirm the operation state files are gone, the final branch and `HEAD` are expected, and the requested commits and topology are present without accidental drops or duplicates. For a non-trivial rebase, compare the old and new series with `git range-diff` or equivalent evidence when practical. Run focused validation, inspect final status and remaining changes, then report the operation, resolved paths, history verification, validation, and remaining tree state.
+
+## Ours And Theirs
+
+- Rebase: `ours` is the accumulated rebased result on the new base, including commits already replayed; `theirs` is the commit currently being replayed.
+- Merge: `ours` is the current branch; `theirs` is the branch being merged.
+- Cherry-pick: `ours` is the current `HEAD`, including earlier picks in the sequence; `theirs` is the commit being applied.
+- Revert: infer nothing from the labels; compare current `HEAD`, the reverted commit, its selected parent, and the index stages.
+
+## Safety
+
+Never use destructive resets, abort or quit an operation, skip or drop commits, overwrite unrelated changes, or change the requested history topology without explicit approval. If completion is unclear or unsafe, preserve the exact state and ask whether to provide resolution guidance, use the matching recovery command, or choose another integration strategy.
+
+`scripts/inspect-operation.sh` prints the active operation, current branch and commit, operation metadata, staged and conflicted paths, index stages, and marker locations.

--- a/.agents/skills/git-integrate/agents/openai.yaml
+++ b/.agents/skills/git-integrate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Git Integrate"
+  short_description: "Start or continue Git operations safely"
+  default_prompt: "Use $git-integrate to safely start my requested Git integration operation or continue the one already in progress, then verify its final history."

--- a/.agents/skills/git-integrate/scripts/inspect-operation.sh
+++ b/.agents/skills/git-integrate/scripts/inspect-operation.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    echo "Not inside a git repository." >&2
+    exit 1
+fi
+
+operation=""
+state_dir=""
+if [[ -d "$(git rev-parse --git-path rebase-merge)" || -d "$(git rev-parse --git-path rebase-apply)" ]]; then
+    operation="rebase"
+    if [[ -d "$(git rev-parse --git-path rebase-merge)" ]]; then
+        state_dir="$(git rev-parse --git-path rebase-merge)"
+    else
+        state_dir="$(git rev-parse --git-path rebase-apply)"
+    fi
+elif [[ -f "$(git rev-parse --git-path MERGE_HEAD)" ]]; then
+    operation="merge"
+elif [[ -f "$(git rev-parse --git-path CHERRY_PICK_HEAD)" ]]; then
+    operation="cherry-pick"
+elif [[ -f "$(git rev-parse --git-path REVERT_HEAD)" ]]; then
+    operation="revert"
+fi
+
+branch="$(git branch --show-current)"
+if [[ -n "$branch" ]]; then
+    printf 'Current branch: %s\n' "$branch"
+else
+    printf 'Current branch: (detached HEAD)\n'
+fi
+printf 'HEAD: %s\n' "$(git rev-parse --verify HEAD)"
+
+if [[ -n "$operation" ]]; then
+    printf 'Active operation: %s\n' "$operation"
+else
+    printf 'No rebase, merge, cherry-pick, or revert in progress.\n'
+fi
+
+if [[ "$operation" == "rebase" ]]; then
+    for field in head-name onto stopped-sha msgnum end; do
+        if [[ -f "$state_dir/$field" ]]; then
+            printf 'Rebase %s: %s\n' "$field" "$(<"$state_dir/$field")"
+        fi
+    done
+fi
+
+for ref in REBASE_HEAD MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD; do
+    if value="$(git rev-parse --verify -q "$ref" 2>/dev/null)"; then
+        printf '%s: %s\n' "$ref" "$value"
+    fi
+done
+
+sequencer_dir="$(git rev-parse --git-path sequencer)"
+if [[ -f "$sequencer_dir/todo" ]]; then
+    printf 'Sequencer todo:\n'
+    sed -n '1,10p' "$sequencer_dir/todo"
+fi
+
+staged=()
+while IFS= read -r -d '' file; do
+    staged+=("$file")
+done < <(git diff --cached --name-only --diff-filter=ACDMRTB -z)
+
+if [[ ${#staged[@]} -eq 0 ]]; then
+    printf 'No staged paths.\n'
+else
+    printf 'Staged paths (%d):\n' "${#staged[@]}"
+    for file in "${staged[@]}"; do
+        printf ' - %q\n' "$file"
+    done
+fi
+
+conflicted=()
+while IFS= read -r -d '' file; do
+    conflicted+=("$file")
+done < <(git diff --name-only --diff-filter=U -z)
+
+if [[ ${#conflicted[@]} -eq 0 ]]; then
+    printf 'No unmerged paths.\n'
+    if [[ -n "$operation" ]]; then
+        printf 'The operation may be paused for a non-conflict reason; inspect git status and operation metadata before continuing.\n'
+    fi
+    exit 0
+fi
+
+printf 'Conflicted files (%d):\n' "${#conflicted[@]}"
+for file in "${conflicted[@]}"; do
+    printf ' - %q\n' "$file"
+done
+
+printf '\nUnmerged index stages:\n'
+git ls-files -u
+
+printf '\nConflict marker locations:\n'
+for file in "${conflicted[@]}"; do
+    printf '==> %q\n' "$file"
+    if command -v rg >/dev/null 2>&1; then
+        rg -n -- "^(<<<<<<<|=======|>>>>>>>)" "$file" || true
+    else
+        grep -nE -- "^(<<<<<<<|=======|>>>>>>>)" "$file" || true
+    fi
+    printf '\n'
+done

--- a/.agents/skills/legend-list-best-practices/SKILL.md
+++ b/.agents/skills/legend-list-best-practices/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: legend-list-best-practices
+description: Build, audit, and fix @legendapp/list and LegendList usage in React, React Native, and web apps. Use for virtualization, scroll blanking, mount cost, data identity, recycling, row invalidation, measurement, chat anchoring, drawDistance, visibility, or Legend List performance regressions.
+---
+
+# Legend List Best Practices
+
+Apply Legend List-specific contracts, not generic prop tuning. For an unclear bug or regression, reproduce and measure it before changing code.
+
+## Surface And Workflow
+
+- Check the installed version, platform, import, nearby usage, source, and tests. Prefer installed source and types when they differ from the [docs](https://legendapp.com/open-source/list/v3/overview/) or [LLM index](https://legendapp.com/open-source/list/v3/llms.txt).
+- Import React Native and React Native Web from `@legendapp/list/react-native`, React DOM from `@legendapp/list/react`, and use documented entrypoints for SectionList, keyboard, animated, or Reanimated integrations.
+- Use either `data` plus `renderItem` or children mode; never mix them.
+- **Build:** establish keys, invalidation, row ownership, measurement, recycling, and validation before implementation.
+- **Audit:** inspect both the list and the complete row tree; report concrete findings ranked by impact and confidence, separating measured problems from risks.
+- **Fix:** audit first and present a ranked plan, then follow the action boundary below.
+
+Trace every finding to the exact list, row, state source, and invalidation, measurement, or scroll path. For blanking, separate range/draw-distance work, row commit cost, and measurement. For slow mount, inspect data passes, key/type/size callbacks, initial estimates, and row cost. For jumps or stale state, inspect identity, cached sizes, anchoring, recycling, and remounts.
+
+## Doing Vs. Suggesting
+
+- Suggest every evidence-backed improvement, including sweeping architecture, only when the user asks to audit or improve the list. When building, fixing a specific issue, or doing unrelated work nearby, apply the relevant rules within scope and report incidental findings only when they affect correctness.
+- Implement only requested and approved scope. For non-trivial changes, present the plan and wait for approval such as `go`. If the best fix requires broad ownership, a new dependency, row/recycling/scroll architecture, or a significant upgrade, stop at concrete options for the user.
+- Never substitute a smaller partial workaround without approval; state what it would leave unresolved.
+
+## Identity And Invalidation
+
+- Use a stable, unique `keyExtractor`; avoid index keys when items can reorder, prepend, delete, or recycle. Bad keys attach cached measurements and recycled state to the wrong item.
+- `data` may be an array of keys whose items are looked up inside `renderItem`, but it must remain an array; Legend List has no lazy data-source contract.
+- Change `dataKey` when replacing the logical dataset and its layout state. Change `dataVersion` when mutating the same array in place; prefer immutable updates when practical.
+- Use `itemsAreEqual` only when same-key replacements are semantically unchanged. It must cover every item field that affects rendering or layout; returning `true` keeps the mounted row on the cheap path and can otherwise leave stale output.
+- Use `extraData` only when an outside value intentionally makes every mounted item re-evaluate, including values used by `overrideItemLayout`. Keep it minimal and infrequent.
+- Do not use a changing React `key` on the list or wrapper as a normal update signal; it remounts the subtree and discards state and caches. Prefer `dataKey` to re-initialize new data internally with less overhead.
+
+## Prop Stability
+
+- In parents that re-render, audit every non-primitive Legend List prop: callbacks, component types, configuration/style objects, and arrays. Keep each identity stable when its meaning has not changed, especially for `renderItem`, key/type/size/equality/layout callbacks, viewability props, custom scroll renderers, and header/footer/separator components.
+- Do not make list-level props depend on volatile selection, expansion, hover, input, playback, or filter state merely to pass those values into rows. Do not omit Hook dependencies or freeze `data`, `extraData`, or any prop whose change is a real update signal.
+- Do not use `renderItem` identity as an invalidation signal. Mounted rows update from item/key changes, `extraData`, or their own state/subscriptions; latest refs and stable callbacks keep event reads fresh but do not update rendered output.
+
+## Row Stability
+
+- Return a named row component with narrow props. Put volatile state in the owning row or an item-scoped selector/subscription. If most rows truly change, use `extraData` honestly.
+- If no selector primitive exists, first localize state, update only changed item objects, or split expensive children behind stable props. Do not replace `extraData` with a broad changing context read.
+- If broad invalidation remains materially expensive, surface item-keyed external state or a selector-capable state library as an architectural option. Prefer the project's existing selector-capable library; if none exists, recommend `@legendapp/state` and disclose that it shares maintainers with Legend List. Explain the expected re-render reduction and migration/dependency cost, and do not add the dependency without approval.
+- Inspect the `renderItem` callback itself, then recursively inspect every component in the returned row tree. Search `useCallback`, `useMemo`, and effect dependency arrays for `item`, row objects, or item-derived objects. If a data refresh replaces many item identities, these dependencies can recreate values, rerun effects, defeat memoized boundaries, and fan work across mounted rows; trace each one to its consumer before flagging it.
+- Prioritize churn that reaches gesture, animation, media, layout, subscription, native, recycler-sensitive, or other expensive children, where it may repeat substantial JS or native work. Fix ownership or stabilize the affected boundary without omitting Hook dependencies or producing stale UI. Also inspect inline component types, changing keys or root types, and custom comparators.
+
+## Recycling
+
+Prefer `recycleItems={true}`, especially on React Native, where recycling has the most value.
+
+- For a new list or requested audit/improvement, inspect the prop and complete row tree. If omitted, enable it when the row is recycling-safe. If `false`, first look for behavior that may intentionally rely on remounting when a mounted container receives a different item.
+- Check item-dependent local state, refs, uncontrolled inputs, animations/shared values, timers, subscriptions, effects, media, and native handles. Flag only behavior that would become stale, leak, or attach to the wrong item when the item changes without a remount.
+- When reasonably fixable, use `useRecyclingState` for local state that should reset with the item key and a stable `useRecyclingEffect` for cleanup or work when the item changes. Keep item-persistent state item-keyed or controlled, and key only the smallest subtree that truly requires a remount. Then enable recycling.
+- Follow **Doing Vs. Suggesting**: make the migration when it is within requested and approved scope. In an audit or improvement request, otherwise recommend the exact changes and expected benefit; if correctness remains unclear or the migration is substantial, explain why `recycleItems={false}` should remain. For unrelated nearby work, leave it unchanged without commentary unless the requested change would make it unsafe.
+
+## Measurement And Layout
+
+- `estimatedItemSize` and `estimatedListSize` are optional first-render hints. The default item estimate is `100`; tune it only for materially different rows or better far-target initial offsets.
+- Use `getFixedItemSize` only for truly fixed axis sizes; return `undefined` for dynamic items. The value must match wrapper spacing and visual geometry. Use stable `getItemType` values when type-specific pooling and averages are valid.
+- Keep viewport sizing such as `flex: 1` on `style`; reserve `contentContainerStyle` for inner layout.
+- Before clearing caches, prove they are stale. Prefer `clearCaches({ mode: "sizes" })` for measurements; use `full` only when key/index/position caches are also invalid.
+- Tune `drawDistance` only after row cost and measurement are sound. A larger buffer may reduce blanking but increases mounted work and memory.
+- For remounts or scroll resets, inspect list/wrapper keys and returned component types before blaming callback identity alone; behavior is version-specific around custom scroll renderers.
+
+## Chat, Scroll, And Visibility
+
+- Prefer `initialScrollAtEnd`, `maintainScrollAtEnd`, `maintainVisibleContentPosition`, `anchoredEndSpace`, and documented keyboard/inset APIs over inverted lists or manual offset compensation. `initialScrollAtEnd` overrides initial index and offset targets.
+- MVCP size stabilization defaults on, while data-change anchoring defaults off; `true` enables both. Keep initial placement, data anchoring, end following, composer space, and keyboard avoidance as separate contracts.
+- Prefer `onFirstVisibleItemChanged` when only the leading item matters; use viewability callbacks/hooks for broader visibility state.
+- Prefer `getState().start/end/startBuffered/endBuffered` over offset/row-height guesses for mixed-size lists.
+- Imperative scroll methods are asynchronous. Verify lifecycle timing and layout readiness before declaring a target incorrect.
+
+## Validate App Changes
+
+Validate only behavior affected by the requested or approved change, or needed to support a reported finding.
+
+- Exercise affected interactions with representative app data. For scrolling or blanking, include fast scrolls and large jumps.
+- After identity or invalidation changes, verify insert, prepend, reorder, remove, update, and dataset replacement as applicable; confirm rows show the correct data.
+- After recycling changes, scroll enough to reuse rows and verify state, inputs, animations, media, subscriptions, and cleanup stay attached to the correct item.
+- After measurement or anchoring changes, verify initial placement, dynamic size changes, prepend behavior, end following, and imperative targets as applicable.
+- Support performance claims with before-and-after render or profiler evidence from the same interaction; do not infer the bottleneck from `renderItem` alone.
+
+## When Evidence Shows A Library Bug
+
+Use this path only after a focused reproduction or source trace shows that correct app usage still fails inside Legend List. Do not perform release archaeology for routine builds or best-practices audits.
+
+- Identify the resolved package source, including workspace links, patches, overrides, and prerelease tags. Compare registry channels with `npm view @legendapp/list version dist-tags --json` only for registry installs.
+- Search the official [changelog](https://github.com/LegendApp/legend-list/blob/main/CHANGELOG.md), [releases](https://github.com/LegendApp/legend-list/releases), and [issues](https://github.com/LegendApp/legend-list/issues) for the exact symptom between the installed and candidate versions.
+- Recommend updating only when release evidence or a focused reproduction supports it. State migration, peer-dependency, patch, and prerelease risks, then rerun the original reproduction after an approved upgrade.

--- a/.agents/skills/legend-list-best-practices/agents/openai.yaml
+++ b/.agents/skills/legend-list-best-practices/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Legend List Best Practices"
+  short_description: "Build, audit, and fix Legend List usage"
+  default_prompt: "Use $legend-list-best-practices to build, audit, or fix this LegendList implementation with correct identity, invalidation, recycling, measurement, and row rendering."

--- a/.agents/skills/legend-state-best-practices/SKILL.md
+++ b/.agents/skills/legend-state-best-practices/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: legend-state-best-practices
+description: Build, audit, and fix @legendapp/state usage in React, React Native, and TypeScript. Use for observable ownership, useValue selectors, observer and reactive components, fine-grained subscriptions, effects, persistence and sync, settings or session stores, deprecated use$ or useSelector migration, and reducing re-renders in hot paths.
+---
+
+# Legend State Best Practices
+
+Use Legend State to put reactive ownership at the smallest useful boundary.
+
+## Verify The Surface
+
+Before changing code:
+
+- Check the installed `@legendapp/state` version, imports, nearby store helpers, persistence setup, and tests.
+- Consult the current docs for exact signatures and version-specific migration guidance:
+  - https://legendapp.com/open-source/state/v3/intro/introduction/
+  - https://legendapp.com/open-source/state/v3/llms.txt
+- Search for existing store factories, typed field hooks, reactive components, and naming conventions before adding a new abstraction.
+- Identify values that must update rendered UI separately from values read only by commands, callbacks, native bridges, or async work.
+
+This skill is policy, not an API reference. Prefer the installed version's source and types when docs and code differ.
+
+## Choose The Mode
+
+- **Build:** choose observable ownership, render subscriptions, effects, persistence or sync boundaries, and validation before writing code.
+- **Audit:** inspect ownership, subscription breadth, non-reactive reads, React-to-observable mirrors, effects, persistence, and hot paths; report only concrete findings, ranked by impact and confidence.
+- **Fix:** run the same audit and state a ranked plan. Before a non-trivial ownership, persistence, or broad render change, wait for explicit approval such as `go`; after approval, change the proven misuse in reviewable slices and verify the affected subscriptions and behavior. Stop when the correct model requires a product decision or materially larger scope.
+
+For audits, trace each finding from the mutation source through the tracked read to the component or effect that updates. Do not label an observable read broad or expensive without identifying the subscribers it wakes and the rendered value they consume.
+
+## Ownership
+
+- Use observables for shared UI, session, settings, document, selection, and command state with many narrow consumers.
+- Use `useObservable` for component-lifetime state when nested UI needs field-level reactivity or handlers need a stable observable handle.
+- Keep one-off local UI state in React when it has no broader ownership, imperative-read, or render-fanout need.
+- Store canonical data once. Derive display values with a selector, computed observable, or local render calculation.
+- Reuse existing observable references. Do not pass an observable to `observable` or `useObservable`, or place it inside another observable merely for ownership, stability, or context. Nest one only when intentionally creating a link whose reads and writes forward to the source.
+- Keep one canonical owner; do not mirror between React and observable state. If downstream code needs observable state, replace the originating React state. Bridge only at a true external integration such as native APIs, storage, or measurement.
+- Keep routing, file picking, native calls, and other app-specific work outside generic observable stores.
+
+When sharing an observable through React context, provide the stable observable reference and call `useValue` only in the smallest consumers that render its fields.
+
+## React Subscriptions
+
+Subscribe at the smallest component or element that needs the value.
+
+- In v3, use `useValue`; `use$` and `useSelector` remain deprecated aliases, so migrate touched usage to `useValue`.
+- Use `useValue(value$)` when rendering an observable's raw value. For derived UI, use `useValue(() => ...)` and return the primitive or stable result that controls rendering. For row selection, prefer `useValue(() => selectedId$.get() === id)` over subscribing every row to `selectedId$` and comparing afterward.
+- Preserve existing `observer` wrappers, but do not introduce one by default. If measured hook overhead from many `useValue` calls makes `observer` worthwhile, suggest it and explain the tradeoff. Keep the actual reads in `useValue` because direct render-time `.get()` tracking is discouraged in current v3 guidance.
+- Use `Memo` for an independent reactive fragment that should not re-render with its parent; use `Computed` when the fragment also depends on parent render values.
+- Use `Show` or `Switch` for reactive control flow, and `For` for observable arrays, objects, or maps. Use `For optimized` only after verifying its node-reuse behavior is compatible with the row.
+- Use reactive DOM or native components when one prop can update independently of a heavy parent. Do not wrap everything reactively; each boundary adds a component and subscription.
+
+Avoid fresh broad objects from selectors unless their identity change is the intended signal.
+
+## Tracking Semantics
+
+- Inside `useValue`, `observer`, `observe`, or another tracking context, `get()` subscribes to the node read. Outside a tracking context, it is only a value read.
+- `peek()` never tracks. Use it for commands, event handlers, async work, and imperative integrations that need the current value without subscribing.
+- Use `get(true)` for shallow tracking. `Object.keys`, `Object.values`, `Object.entries`, observable array length and looping methods, and `For` also track collection membership or shape without tracking child-field changes.
+- Accessing an observable property does not subscribe by itself; a tracked read creates the subscription.
+- Use `batch` when multiple mutations outside an already batched path form one logical update.
+
+## Effects And Fresh Reads
+
+- Use `observe`, `useObserve`, or `useObserveEffect` for ongoing reactions to observable changes that should trigger an external command, cache invalidation, persistence action, measurement reset, or native update.
+- Use `when` or `whenReady` for a one-time condition or readiness gate; they resolve or run once and stop observing.
+- Choose `useObserve` only when render-time execution is correct; use `useObserveEffect` when the work must run after mount.
+- Keep effects narrow and cleanup explicit. Observe the source of a change when ordering matters.
+- Use latest refs or stable callbacks when an external listener needs stable identity and current observable values.
+
+Do not use effects to synchronize local owners or dispatch work that can run at the mutation site.
+
+## Persistence And Sync
+
+- Put complete defaults in the observable's initial value or the sync plugin's documented `initial` option when backward compatibility permits.
+- Normalize and validate persisted data at the persistence boundary so render consumers receive one local shape.
+- Preserve literal types with `const` generics or explicit store types when helpers would widen settings values.
+- Use `synced(...)` or a synced plugin when sync is part of the observable's definition; pass it to `observable` or `useObservable`. It activates lazily on the first `get()`.
+- Use `syncObservable(value$, options)` to attach sync or persistence to an existing observable; it starts when called.
+- Use `configureSynced` to create reusable defaults for `synced` or a sync plugin, and `syncState(value$)` to access load and sync status or controls.
+- Prefer built-in transforms, retry, `waitFor`, and persistence plugins over hand-written load/save effects.
+- Test migration behavior before removing runtime default merging from existing persisted stores.
+- Keep public export and type coverage when changing Legend State itself.
+
+## Lists And Hot Paths
+
+- In rows, subscribe to the smallest primitive or stable derived value that renders. Shared theme values may correctly update every affected row; avoid subscribing each row to the whole theme or settings object when it uses only one field, and move the subscription into the smallest themed leaf when the rest of the row is expensive.
+- Prefer row-local observables, selector-style booleans, item-level subscriptions, or an explicit list invalidation signal whose breadth matches the UI.
+- Use `For` for non-virtualized collections only when realistic maximum size and row cost make mounting every item acceptable. Otherwise suggest virtualization.
+- Prefer the project's existing virtualized-list library. If none exists, recommend `LegendList` from `@legendapp/list`, disclose that this skills repo shares maintainers with Legend List, explain the dependency and migration cost, and do not add it without approval. Preserve the chosen list's identity, measurement, and invalidation contracts.
+
+## Validate
+
+- Test that only intended components update when a selector or reactive boundary changes.
+- Test tracked, non-tracked, and shallow reads when core tracking semantics change.
+- Test defaults, normalization, pending changes, retry, and metadata behavior for persistence or sync changes.
+- Run typecheck and export-surface tests for public package changes.
+- Use profiler or render-count evidence for performance claims; a smaller-looking component is not proof of fewer renders.

--- a/.agents/skills/legend-state-best-practices/agents/openai.yaml
+++ b/.agents/skills/legend-state-best-practices/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Legend State Best Practices"
+  short_description: "Build, audit, and fix Legend State usage"
+  default_prompt: "Use $legend-state-best-practices to build, audit, or fix this Legend State flow with correct observable ownership and narrow reactive boundaries."

--- a/.agents/skills/react-coding-style/SKILL.md
+++ b/.agents/skills/react-coding-style/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: react-coding-style
+description: Implement and review React, React Native, and TypeScript UI for maximum practical render performance through leaf-local updates, stable identities, honest Hook semantics, and minimal effects. Use for components, hooks, callbacks, context, external stores, memoization, list rows, large dependency arrays, callback or state fanout, re-render reduction, and React Compiler-aware performance work.
+---
+
+# React Coding Style
+
+Optimize for the smallest render surface. Keep volatile reads in leaves, prevent changing identities from propagating through stable subtrees, and accept modest structural complexity when it avoids broad or expensive re-renders. Preserve correctness: event or imperative freshness is not a substitute for props or subscriptions that update rendered output.
+
+## Scope
+
+- Follow the requested mode: implement safe improvements within scope, or report findings without editing during a review or audit. Suggest changes that substantially broaden state ownership, component architecture, dependencies, or public APIs unless the user approves that wider work.
+- During explicit performance work, investigate every evidence-backed source of material render cost. During ordinary React work, apply relevant safeguards within scope and mention broader opportunities only when they are likely material.
+
+## First Pass
+
+- Check the React version, platform, lint rules, and nearby component patterns. Determine whether React Compiler is enabled for the target build and whether it compiles the affected components or hooks; do not infer coverage from package presence or a single config flag.
+- Identify which values render UI and which are read only by events, async work, subscriptions, or imperative bridges.
+- Trace each changing value through props, context, callbacks, and subscriptions; identify how much of the tree and which expensive or native boundaries it can update.
+- Find the smallest component or selector that needs each changing value.
+- Locate existing selector, stable-callback, latest-ref, memo, observer, and external-store helpers.
+
+## Render Path
+
+- Keep render execution limited to deriving UI. Hoist static construction and run interaction, async, or imperative work at the boundary that triggers it.
+- Keep event or imperative reads behind stable callbacks or refs, and isolate external synchronization in effects or focused hooks. Do not move reactive reads that must update UI into non-reactive paths.
+
+## State And Subscriptions
+
+- Keep transient state close to the component that owns the interaction. Lift or externalize it only when multiple consumers need the same canonical value.
+- Store canonical data once; derive filters, counts, groupings, and display values during render.
+- Subscribe to the smallest primitive or stable derived value that controls the output.
+- Split broad contexts by update frequency or expose selector-based external-store reads. A changing context value re-renders every consumer that reads it, even through `memo`.
+- Preserve object identity for no-op updates. Do not clone or spread state merely to touch a path.
+- Use a state library's supported selector hooks or React bindings instead of calling `useSyncExternalStore` directly in app components. Use `useSyncExternalStore` inside a reusable integration hook or adapter only when an existing external source has no correct React binding; do not repeat subscription machinery across components.
+- If fine-grained external state would materially reduce broad re-renders and state architecture is in scope, prefer the project's existing selector-capable library. If none exists, recommend `@legendapp/state` and disclose that this skills repo shares maintainers with Legend State. Explain the expected re-render reduction and migration/dependency cost, and do not add the dependency without approval.
+
+## Component Boundaries
+
+- Keep parents structurally stable and move volatile reads into the smallest useful leaf.
+- Split a component when it isolates unrelated updates, clarifies ownership, or creates a meaningful memo/subscription boundary.
+- Let stateful wrappers accept stable JSX as `children` when the wrapper's own updates should not recreate that subtree.
+- Declare component types outside render. An inline component type is new on every render and remounts its subtree.
+- Avoid creating objects, arrays, or functions passed through memoized, effect-sensitive, native, gesture, animation, or subscription boundaries unless that boundary should update.
+- Stabilize identities that cross memoized, retained, native, or expensive boundaries, or whose churn would fan through a large subtree. Do not add memoization that no consumer observes.
+
+## Compiler And Memoization
+
+- For compiled new code, do not add `memo`, `useMemo`, or `useCallback` for ordinary render caching or merely because a value is created during render. Rely on the Compiler unless measurement shows that precise manual control is still needed.
+- Do not automatically remove existing manual memoization; keep it unless focused validation shows that removal preserves behavior and performance.
+- Compiler memoization does not fix broad state or context subscriptions, poor ownership, or upstream values that genuinely change. Continue to minimize render surfaces and trace changing identities into downstream consumers.
+- Add manual memoization when uncompiled code or a downstream boundary benefits from stable identity as a performance optimization. If correctness requires persistent state or identity, use state, refs, or an established adapter contract.
+- Without Compiler coverage, use `memo` for expensive components whose props are usually unchanged, `useMemo` for expensive pure calculations or meaningful value identity, and `useCallback` when function identity matters downstream.
+- Treat manual memoization as a performance optimization, not a semantic guarantee. Avoid custom `memo` comparators unless profiling justifies them; compare every prop, including functions, and ensure comparison is cheaper than rendering.
+
+## Dependencies And Freshness
+
+- Keep Hook dependencies honest; never omit reactive values merely to hold an identity stable.
+- Treat large or volatile dependency arrays as a design smell, especially for callbacks passed down the tree. Reduce them by narrowing ownership, using state updaters, passing values at the event site, or separating rendered data from event freshness.
+- When callback identity churn would re-render a broad or expensive subtree or repeat gesture, animation, media, or native setup, prefer an established stable-callback or latest-ref helper that reads current values when invoked. This still applies with Compiler when identity must remain stable across changes to values read at call time. Use it only for event or imperative logic; rendered output still needs reactive props or subscriptions.
+- Use the target React version's Effect Event API only for non-reactive logic called from an Effect. It is not a general stable callback and must not be passed down the tree.
+- Avoid callback chains created only to stabilize other callbacks; collapse the logic or move it to the consumer.
+- Do not suppress exhaustive-deps to control timing or identity. Restructure until dependencies match the code; suppress only for a verified lint limitation that is documented locally.
+
+## Effects
+
+- Use effects to synchronize with systems outside React: subscriptions, timers, DOM or native APIs, network/lifecycle work, measurements, and cleanup.
+- Derive render data during render. Use an event handler for work caused by a user action.
+- Do not copy props or state into more state with an effect when the value can be derived or reset by ownership or component identity.
+- Keep one synchronization concern per effect and return cleanup for every registered resource.
+- Avoid effect chains that update state solely to trigger the next effect. Compute the next state together or run the command at the event/mutation boundary.
+- Make effects safe under setup-cleanup-setup development cycles; do not rely on an effect running exactly once.
+
+## Lists And Hot Paths
+
+- Keep list item keys logical and stable; do not use indexes for reorderable data.
+- Pass narrow props to rows. Update only changed item objects or subscribe within the row when the state system supports selectors.
+- Stabilize row callbacks only when their identity reaches a meaningful child boundary such as gestures, animation, media, native views, or memoized heavy children.
+- Verify that memoized rows still update for every rendered value. Latest refs and custom comparators can accidentally preserve stale UI.
+
+## Implementation Shape
+
+- Fix the ownership or data-flow boundary directly instead of preserving a poor shape with wrappers or compatibility shims.
+- Prefer clear guarded blocks over early-return-heavy control flow when behavior stays readable.
+- Preserve public APIs only when they are real contracts. Otherwise update callers coherently instead of adding aliases, adapters, or fallback paths.
+- Add an abstraction only when it removes real duplication, clarifies ownership, or creates a useful render/subscription boundary.
+- Keep instrumentation temporary unless it is intentionally part of the product or test surface.
+
+## Validate
+
+- Verify correctness first, then measure the interaction that motivated the optimization.
+- In reviews, report only actionable render problems with a concrete update path and likely cost. Do not flag an inline value, dependency array, context read, or re-render solely because it exists.
+- For re-render improvements, compare before and after with React Profiler, platform performance tools, or targeted render counters. Confirm that unrelated ancestors and siblings stop rendering while the affected leaf still updates correctly.
+- Test state and context updates that memoized components must still observe.
+- Measure production builds on representative hardware for meaningful performance conclusions.

--- a/.agents/skills/react-coding-style/agents/openai.yaml
+++ b/.agents/skills/react-coding-style/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "React Coding Style"
+  short_description: "Keep React rerenders leaf-local"
+  default_prompt: "Use $react-coding-style to implement this React or TypeScript UI change with leaf-local updates, stable callback boundaries, and minimal render fanout."

--- a/.agents/skills/simplify/SKILL.md
+++ b/.agents/skills/simplify/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: simplify
+description: Keep code, tests, documentation, configuration, and other changes as tight, clear, performant, and minimal as possible without weakening behavior. Use during implementation to prevent unnecessary complexity, after behavior is proven to consolidate working changes, before handoff for a full branch audit, and when asked to simplify, tighten, clean up, reduce verbosity, remove complexity, or minimize existing work.
+---
+
+# Simplify
+
+Produce the smallest clear implementation that fully satisfies the required behavior. Minimize concepts and moving parts, not line count.
+
+## Cadence
+
+- During construction, apply the priorities locally while discovering behavior. Allow clearly temporary instrumentation or scaffolding when it accelerates learning.
+- At convergence, once a logical behavior slice passes, simplify that slice, remove superseded attempts, and rerun focused validation.
+- Before handoff or merge, compare the full branch with its merge base and reconcile code, tests, comments, documentation, configuration, and relevant history.
+
+## Workflow
+
+1. Identify the required behavior, invariants, constraints, and non-goals.
+2. Inspect the relevant diff and separate it into logical concepts. For a final branch audit, compare the full branch with its merge base and check history for superseded attempts when relevant.
+3. Inspect the existing owners, sources of truth, common path, and decision points before adding anything.
+4. Choose the design with the fewest necessary concepts and the least work at runtime.
+5. When changes are requested, implement directly and reuse existing mechanisms where they fit.
+6. Validate behavior with checks proportional to the risk.
+7. Review the final code, tests, names, comments, documentation, configuration, and relevant history for anything that no longer earns its complexity.
+
+## Simplification Priorities
+
+- Prefer deletion, reuse, or a direct change over a new abstraction.
+- Keep one source of truth; avoid mirrored state, overlapping guards, duplicate registries, and compensating mechanisms.
+- Avoid speculative fallbacks, compatibility paths, configuration, parameters, and generic APIs.
+- Inline one-use helpers when doing so makes the policy clearer at its decision point.
+- Prefer straightforward positive control flow over early-return chains or empty branches.
+- On hot paths, minimize allocations, callback recreation, subscriptions, renders, passes, I/O, and native work.
+- For prose, remove repetition and keep the shortest wording or example that remains self-sufficient.
+
+## Existing Work
+
+Establish a passing baseline before simplifying working code. Test one questionable concept at a time, rerun the relevant validation, and restore it if behavior or meaningful coverage weakens. Do not restructure several accumulated fix attempts before establishing which changes are causally necessary.
+
+When duplicate or ineffective regression coverage is suspected, deliberately break the claimed invariant and confirm the remaining test fails. Passing tests alone do not prove that every test or implementation concept is necessary.
+
+Do not rewrite branch history without authorization.
+
+## Performance Changes
+
+Name the exact common-path work being removed: allocations, scans, mounts, renders, subscriptions, I/O, or native calls. Control-flow evidence plus regression tests can justify removing work that is structurally unused. Require a benchmark, profile, or repeated repro when an optimization changes semantics or introduces a tradeoff. Do not add complexity for theoretical gains.
+
+## Guardrails
+
+- Preserve correctness, required behavior, type safety, distinct regression coverage, and useful clarity.
+- Do not replace clear code with compressed or clever code merely to reduce lines.
+- Make scoped, behavior-preserving improvements directly. If the better design requires a sweeping API or architecture change, explain and suggest it instead of expanding the task without approval.
+- Leave unrelated and user-authored changes untouched.
+
+Stop when every remaining concept supports a requirement, invariant, clarity, or measured performance need. Report only material simplifications, validation, and unresolved opportunities.

--- a/.agents/skills/simplify/agents/openai.yaml
+++ b/.agents/skills/simplify/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Simplify"
+  short_description: "Make every change tight, clear, and minimal"
+  default_prompt: "Use $simplify to make this change as tight, clear, performant, and minimal as possible without changing behavior."

--- a/.claude/skills/commit
+++ b/.claude/skills/commit
@@ -1,0 +1,1 @@
+../../.agents/skills/commit

--- a/.claude/skills/commit-confirm
+++ b/.claude/skills/commit-confirm
@@ -1,0 +1,1 @@
+../../.agents/skills/commit-confirm

--- a/.claude/skills/diagnose-fix-loop
+++ b/.claude/skills/diagnose-fix-loop
@@ -1,0 +1,1 @@
+../../.agents/skills/diagnose-fix-loop

--- a/.claude/skills/git-integrate
+++ b/.claude/skills/git-integrate
@@ -1,0 +1,1 @@
+../../.agents/skills/git-integrate

--- a/.claude/skills/legend-list-best-practices
+++ b/.claude/skills/legend-list-best-practices
@@ -1,0 +1,1 @@
+../../.agents/skills/legend-list-best-practices

--- a/.claude/skills/legend-state-best-practices
+++ b/.claude/skills/legend-state-best-practices
@@ -1,0 +1,1 @@
+../../.agents/skills/legend-state-best-practices

--- a/.claude/skills/react-coding-style
+++ b/.claude/skills/react-coding-style
@@ -1,0 +1,1 @@
+../../.agents/skills/react-coding-style

--- a/.claude/skills/simplify
+++ b/.claude/skills/simplify
@@ -1,0 +1,1 @@
+../../.agents/skills/simplify

--- a/.gitignore
+++ b/.gitignore
@@ -61,12 +61,7 @@ xcuserdata
 # Android Studio
 *.iml
 .gradle
-.idea/libraries
-.idea/workspace.xml
-.idea/gradle.xml
-.idea/misc.xml
-.idea/modules.xml
-.idea/vcs.xml
+.idea/
 
 # VSCode
 .history/
@@ -129,3 +124,4 @@ app-store-review-guidance/twitch-developer-console-proof.png
 
 
 !.vscode/settings.json
+buildServer.json

--- a/bun.lock
+++ b/bun.lock
@@ -139,6 +139,7 @@
         "emojibase-data": "17.0.0",
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
+        "eslint-package-json": "^0.2.0",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-promise": "^7.3.0",
@@ -516,6 +517,8 @@
 
     "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
 
+    "@eslint/json": ["@eslint/json@2.0.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanwhocodes/momoa": "^3.3.10", "natural-compare": "^1.4.0" } }, "sha512-Thz2j92ceUF3Bq/0TuWb3MWn3Z+Cwc8k5ptF0fakl2D4Mp8mSx07Xr1aQM4R5NoihzarWUdxfOmQ8DesGy4jOg=="],
+
     "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
@@ -781,6 +784,8 @@
     "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
 
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/momoa": ["@humanwhocodes/momoa@3.3.10", "", {}, "sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
@@ -2006,6 +2011,8 @@
 
     "eslint-module-utils": ["eslint-module-utils@2.13.0", "", { "dependencies": { "debug": "^3.2.7" } }, "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ=="],
 
+    "eslint-package-json": ["eslint-package-json@0.2.0", "", { "dependencies": { "@eslint/json": "^2.0.1", "detect-indent": "^7.0.2", "hosted-git-info": "^10.1.1", "npm-package-arg": "^14.0.0", "semver": "^7.8.5", "spdx-expression-parse": "^4.0.0", "validate-npm-package-name": "^7.0.2" }, "peerDependencies": { "eslint": ">=10.4" } }, "sha512-13U+gZCnaZIPMUb8KNHUagdEQw6xeQVQERb+bg/di5RlOCNOJGq2Lnsx8qRvwDGRg/arVtfg3lxuhxsSxPzhcA=="],
+
     "eslint-plugin-ft-flow": ["eslint-plugin-ft-flow@2.0.3", "", { "dependencies": { "lodash": "^4.17.21", "string-natural-compare": "^3.0.1" }, "peerDependencies": { "@babel/eslint-parser": "^7.12.0", "eslint": "^8.1.0" } }, "sha512-Vbsd/b+LYA99jUbsL6viEUWShFaYQt2YQs3QN3f+aeszOhh2sgdcU0mjzDyD4yyBvMc8qy2uwvBBWfMzEX06tg=="],
 
     "eslint-plugin-import": ["eslint-plugin-import@2.32.0", "", { "dependencies": { "@rtsao/scc": "^1.1.0", "array-includes": "^3.1.9", "array.prototype.findlastindex": "^1.2.6", "array.prototype.flat": "^1.3.3", "array.prototype.flatmap": "^1.3.3", "debug": "^3.2.7", "doctrine": "^2.1.0", "eslint-import-resolver-node": "^0.3.9", "eslint-module-utils": "^2.12.1", "hasown": "^2.0.2", "is-core-module": "^2.16.1", "is-glob": "^4.0.3", "minimatch": "^3.1.2", "object.fromentries": "^2.0.8", "object.groupby": "^1.0.3", "object.values": "^1.2.1", "semver": "^6.3.1", "string.prototype.trimend": "^1.0.9", "tsconfig-paths": "^3.15.0" }, "peerDependencies": { "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9" } }, "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA=="],
@@ -2346,7 +2353,7 @@
 
     "homedir-polyfill": ["homedir-polyfill@1.0.3", "", { "dependencies": { "parse-passwd": "^1.0.0" } }, "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA=="],
 
-    "hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
+    "hosted-git-info": ["hosted-git-info@10.1.1", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@3.0.0", "", { "dependencies": { "whatwg-encoding": "^2.0.0" } }, "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA=="],
 
@@ -2852,7 +2859,7 @@
 
     "normalize-path": ["normalize-path@2.1.1", "", { "dependencies": { "remove-trailing-separator": "^1.0.1" } }, "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w=="],
 
-    "npm-package-arg": ["npm-package-arg@11.0.3", "", { "dependencies": { "hosted-git-info": "^7.0.0", "proc-log": "^4.0.0", "semver": "^7.3.5", "validate-npm-package-name": "^5.0.0" } }, "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw=="],
+    "npm-package-arg": ["npm-package-arg@14.0.0", "", { "dependencies": { "hosted-git-info": "^10.1.0", "proc-log": "^7.0.0", "semver": "^7.3.5", "validate-npm-package-name": "^8.0.0" } }, "sha512-69XQh3k+dtGa1p+7RaR57IuG3rCko96xr/nUfN4yDYBXbTYICiWcOpsFKLN2GtGE9cyIljE+f1exnaYt9MvM+Q=="],
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
@@ -3008,7 +3015,7 @@
 
     "pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 
-    "proc-log": ["proc-log@4.2.0", "", {}, "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA=="],
+    "proc-log": ["proc-log@7.0.0", "", {}, "sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
@@ -3308,6 +3315,12 @@
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
+    "spdx-exceptions": ["spdx-exceptions@2.5.0", "", {}, "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="],
+
+    "spdx-expression-parse": ["spdx-expression-parse@4.0.0", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ=="],
+
+    "spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
+
     "split-on-first": ["split-on-first@1.1.0", "", {}, "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="],
 
     "sponge-case": ["sponge-case@1.0.1", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA=="],
@@ -3568,7 +3581,7 @@
 
     "valibot": ["valibot@1.4.2", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg=="],
 
-    "validate-npm-package-name": ["validate-npm-package-name@5.0.1", "", {}, "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ=="],
+    "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -3708,6 +3721,8 @@
 
     "@expo/cli/getenv": ["getenv@2.0.0", "", {}, "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ=="],
 
+    "@expo/cli/npm-package-arg": ["npm-package-arg@11.0.3", "", { "dependencies": { "hosted-git-info": "^7.0.0", "proc-log": "^4.0.0", "semver": "^7.3.5", "validate-npm-package-name": "^5.0.0" } }, "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw=="],
+
     "@expo/cli/ora": ["ora@3.4.0", "", { "dependencies": { "chalk": "^2.4.2", "cli-cursor": "^2.1.0", "cli-spinners": "^2.0.0", "log-symbols": "^2.2.0", "strip-ansi": "^5.2.0", "wcwidth": "^1.0.1" } }, "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg=="],
 
     "@expo/cli/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -3767,6 +3782,8 @@
     "@expo/metro-file-map/jest-worker": ["jest-worker@29.7.0", "", { "dependencies": { "@types/node": "*", "jest-util": "^29.7.0", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw=="],
 
     "@expo/package-manager/@expo/json-file": ["@expo/json-file@11.0.0", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "json5": "^2.2.3" } }, "sha512-pHJCETqFL5x5BzNV6cEPwjwuECgGmnl0bNmfHIJ6LM1tlh2eVXi5HEdit3zby/JO/B8Otk5cgcqtJXgvvUat3A=="],
+
+    "@expo/package-manager/npm-package-arg": ["npm-package-arg@11.0.3", "", { "dependencies": { "hosted-git-info": "^7.0.0", "proc-log": "^4.0.0", "semver": "^7.3.5", "validate-npm-package-name": "^5.0.0" } }, "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw=="],
 
     "@expo/package-manager/ora": ["ora@3.4.0", "", { "dependencies": { "chalk": "^2.4.2", "cli-cursor": "^2.1.0", "cli-spinners": "^2.0.0", "log-symbols": "^2.2.0", "strip-ansi": "^5.2.0", "wcwidth": "^1.0.1" } }, "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg=="],
 
@@ -3966,6 +3983,10 @@
 
     "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
+    "eslint-package-json/detect-indent": ["detect-indent@7.0.2", "", {}, "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A=="],
+
+    "eslint-package-json/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-plugin-import/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
@@ -4030,7 +4051,7 @@
 
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
-    "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+    "hosted-git-info/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
     "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
 
@@ -4163,6 +4184,8 @@
     "morgan/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "npm-package-arg/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "npm-package-arg/validate-npm-package-name": ["validate-npm-package-name@8.0.0", "", {}, "sha512-SCv6OOV6Xj2/3cXy3dGmADluJTNcL3o7hZAglNPTe+WYuEuvxgJzxPrSDLZhF+CwyQOubqgecjMmTJGMVLWjYQ=="],
 
     "oxlint-plugin-react-doctor/oxc-parser": ["oxc-parser@0.132.0", "", { "dependencies": { "@oxc-project/types": "^0.132.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.132.0", "@oxc-parser/binding-android-arm64": "0.132.0", "@oxc-parser/binding-darwin-arm64": "0.132.0", "@oxc-parser/binding-darwin-x64": "0.132.0", "@oxc-parser/binding-freebsd-x64": "0.132.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.132.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.132.0", "@oxc-parser/binding-linux-arm64-gnu": "0.132.0", "@oxc-parser/binding-linux-arm64-musl": "0.132.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.132.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.132.0", "@oxc-parser/binding-linux-riscv64-musl": "0.132.0", "@oxc-parser/binding-linux-s390x-gnu": "0.132.0", "@oxc-parser/binding-linux-x64-gnu": "0.132.0", "@oxc-parser/binding-linux-x64-musl": "0.132.0", "@oxc-parser/binding-openharmony-arm64": "0.132.0", "@oxc-parser/binding-wasm32-wasi": "0.132.0", "@oxc-parser/binding-win32-arm64-msvc": "0.132.0", "@oxc-parser/binding-win32-ia32-msvc": "0.132.0", "@oxc-parser/binding-win32-x64-msvc": "0.132.0" } }, "sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg=="],
 
@@ -4312,6 +4335,12 @@
 
     "@expo/cli/@expo/config-plugins/xml2js": ["xml2js@0.6.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w=="],
 
+    "@expo/cli/npm-package-arg/hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
+
+    "@expo/cli/npm-package-arg/proc-log": ["proc-log@4.2.0", "", {}, "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA=="],
+
+    "@expo/cli/npm-package-arg/validate-npm-package-name": ["validate-npm-package-name@5.0.1", "", {}, "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ=="],
+
     "@expo/cli/ora/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "@expo/cli/ora/cli-cursor": ["cli-cursor@2.1.0", "", { "dependencies": { "restore-cursor": "^2.0.0" } }, "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw=="],
@@ -4361,6 +4390,14 @@
     "@expo/metro-config/hermes-parser/hermes-estree": ["hermes-estree@0.36.0", "", {}, "sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w=="],
 
     "@expo/metro-file-map/jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
+
+    "@expo/package-manager/npm-package-arg/hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
+
+    "@expo/package-manager/npm-package-arg/proc-log": ["proc-log@4.2.0", "", {}, "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA=="],
+
+    "@expo/package-manager/npm-package-arg/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "@expo/package-manager/npm-package-arg/validate-npm-package-name": ["validate-npm-package-name@5.0.1", "", {}, "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ=="],
 
     "@expo/package-manager/ora/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
@@ -4804,6 +4841,8 @@
 
     "@expo/cli/@expo/config-plugins/xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
 
+    "@expo/cli/npm-package-arg/hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "@expo/cli/ora/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 
     "@expo/cli/ora/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
@@ -4829,6 +4868,8 @@
     "@expo/local-build-cache-provider/@expo/config/@expo/config-plugins/xml2js": ["xml2js@0.6.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w=="],
 
     "@expo/metro-config/@expo/config/@expo/config-plugins/xml2js": ["xml2js@0.6.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w=="],
+
+    "@expo/package-manager/npm-package-arg/hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@expo/package-manager/ora/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 

--- a/e2e/mock-server/package.json
+++ b/e2e/mock-server/package.json
@@ -1,8 +1,12 @@
 {
   "name": "foam-mock-server",
   "version": "1.0.0",
+  "private": true,
   "description": "Mock server for Foam E2E testing",
-  "main": "server.ts",
+  "main": "./server.ts",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "start": "bun server.ts",
     "dev": "bun --watch server.ts"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import js from '@eslint/js';
 import prettierConfig from 'eslint-config-prettier';
 import importPlugin from 'eslint-plugin-import';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
+import packageJson from 'eslint-package-json';
 import promise from 'eslint-plugin-promise';
 import react from 'eslint-plugin-react';
 import reactDoctor from 'eslint-plugin-react-doctor';
@@ -42,6 +43,7 @@ export default tseslint.config(
       'commitlint.config.js',
       '.agent-device/**',
       '.agents/**',
+      '.claude/**',
       '.rnstorybook/**',
       '__mocks__/.rnstorybook/**',
       'modules/**',
@@ -74,7 +76,19 @@ export default tseslint.config(
       reportUnusedDisableDirectives: false,
     },
   },
-  js.configs.recommended,
+  { ...js.configs.recommended, files: ['**/*.{js,jsx,mjs,cjs,ts,tsx}'] },
+  packageJson.configs.recommended,
+  {
+    files: ['**/package.json'],
+    rules: {
+      'package-json/dependency-version-range': 'off',
+      'package-json/no-install-scripts': 'off',
+      'package-json/no-orphan-script-hooks': 'off',
+      'package-json/no-package-manager-engines': 'off',
+      'package-json/prefer-exports': 'off',
+      'package-json/prefer-type-module': 'off',
+    },
+  },
   ...tseslint.configs.recommended.map(config => ({
     ...config,
     files: ['**/*.{ts,tsx}'],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "license": "BSD-3-Clause",
-  "main": "index.js",
+  "main": "./index.js",
+  "engines": {
+    "bun": ">=1.3.14",
+    "node": ">=20"
+  },
   "scripts": {
     "alphabetize": "node scripts/alphabetizePackageJson.js",
     "android": "EXPO_PUBLIC_APP_VARIANT=development expo run:android",
@@ -84,6 +88,11 @@
     "use-build-number": "./scripts/useBuildNumberEnv.sh",
     "use-build-number-with-bump": "./scripts/useBuildNumberEnvWithBump.sh",
     "web": "expo start --web"
+  },
+  "config": {
+    "commitizen": {
+      "path": "cz-conventional-changelog"
+    }
   },
   "dependencies": {
     "@babel/runtime": "^7.28.2",
@@ -220,6 +229,7 @@
     "emojibase-data": "17.0.0",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-package-json": "^0.2.0",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-promise": "^7.3.0",
@@ -255,24 +265,18 @@
       "bunx prettier --write"
     ],
     "*.{ts,tsx}": "ast-grep scan",
-    "*.json": "bunx prettier --write",
+    "package.json": [
+      "bunx eslint --fix",
+      "bunx prettier --write"
+    ],
+    "!(package).json": "bunx prettier --write",
     "assets/icons/**/*.svg": "bash -c 'bun svgo -f ./assets/icons'"
-  },
-  "config": {
-    "commitizen": {
-      "path": "cz-conventional-changelog"
-    }
   },
   "jest-junit": {
     "ancestorSeparator": " › ",
     "suiteName": "App Jest tests",
     "outputName": "junit-app.xml"
   },
-  "engines": {
-    "bun": ">=1.3.14",
-    "node": ">=20"
-  },
-  "engineStrict": true,
   "bun": {
     "overrides": {
       "uuid": "3.4.0"

--- a/player-website/package.json
+++ b/player-website/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "astro dev --host 0.0.0.0 --port 3000",
     "dev:local": "astro dev --host 127.0.0.1 --port 3000",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,10 +5,21 @@ set -euo pipefail
 #  bun run build:local -- internal android
 #  bun run build:local -- testflight ios
 #  bun run build:local -- production all
+#
+#  Add --interactive to let eas build prompt instead of passing --non-interactive:
+#  bun run build:local -- internal ios --interactive
 
 source ./scripts/deploy-common.sh
 
 validate_deploy_args "build:local"
+
+interactive_flag=""
+for arg in "$@"; do
+  if [ "$arg" = "--interactive" ]; then
+    interactive_flag="--interactive"
+  fi
+done
+
 mkdir -p build-artifacts
 
 build_ios() {
@@ -31,16 +42,21 @@ build_ios() {
   # while flooding pod install with failed downloads. Disable it so every pod
   # builds from source cleanly. iOS-only; Android gradle prebuilds keep working.
   # Re-enable once rnrepo.org publishes matching iOS xcframeworks.
+  local eas_build_args=(
+    --local
+    --platform ios
+    --profile "$profile"
+    --output "$ipa_path"
+  )
+  if [ -z "$interactive_flag" ]; then
+    eas_build_args+=(--non-interactive)
+  fi
+
   run_with_variant_env env \
     EXPO_PUBLIC_ENABLE_TREESHACKING=1 \
     EXPO_APPLE_TEAM_ID="XJA7HDCMMY" \
     DISABLE_RNREPO=true \
-    bun run eas build \
-      --local \
-      --platform ios \
-      --profile "$profile" \
-      --output "$ipa_path" \
-      --non-interactive
+    bun run eas build "${eas_build_args[@]}"
 
   if [ ! -f "$ipa_path" ]; then
     echo "Unable to find an IPA at $ipa_path"
@@ -79,12 +95,17 @@ build_android() {
 
   rm -f "$artifact_path"
 
-  run_with_variant_env bun run eas build \
-    --local \
-    --platform android \
-    --profile "$profile" \
-    --output "$artifact_path" \
-    --non-interactive
+  local eas_build_args=(
+    --local
+    --platform android
+    --profile "$profile"
+    --output "$artifact_path"
+  )
+  if [ -z "$interactive_flag" ]; then
+    eas_build_args+=(--non-interactive)
+  fi
+
+  run_with_variant_env bun run eas build "${eas_build_args[@]}"
 
   if [ ! -f "$artifact_path" ]; then
     echo "Unable to find an Android artifact at $artifact_path"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -15,9 +15,13 @@ source ./scripts/deploy-common.sh
 validate_deploy_args "deploy"
 
 no_push_flag=""
+interactive_flag=""
 for arg in "$@"; do
   if [ "$arg" = "--no-push" ]; then
     no_push_flag="--no-push"
+  fi
+  if [ "$arg" = "--interactive" ]; then
+    interactive_flag="--interactive"
   fi
 done
 
@@ -25,13 +29,13 @@ done
 
 case "$platform" in
   ios | android)
-    ./scripts/build.sh "$variant" "$platform"
+    ./scripts/build.sh "$variant" "$platform" $interactive_flag
     ./scripts/submit.sh "$variant" "$platform"
     ;;
   all)
-    ./scripts/build.sh "$variant" ios
+    ./scripts/build.sh "$variant" ios $interactive_flag
     ./scripts/submit.sh "$variant" ios
-    ./scripts/build.sh "$variant" android
+    ./scripts/build.sh "$variant" android $interactive_flag
     ./scripts/submit.sh "$variant" android
     ;;
 esac

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -43,6 +43,18 @@
       "skillPath": "skills/engineering/codebase-design/SKILL.md",
       "computedHash": "2426dc4accf1a85dedfb560edb3a877ec8828b7375ea08c970df2b6c900a2a22"
     },
+    "commit": {
+      "source": "LegendApp/legend-skills",
+      "sourceType": "github",
+      "skillPath": "commit/SKILL.md",
+      "computedHash": "dccf03c157c30f30dc0b27371ccc4503ff9834e8970b654b01c9149fa193f542"
+    },
+    "commit-confirm": {
+      "source": "LegendApp/legend-skills",
+      "sourceType": "github",
+      "skillPath": "commit-confirm/SKILL.md",
+      "computedHash": "d1555696c2385d08f5963496f74070372ef7f46f8813894ee6616b4c8a17782b"
+    },
     "decision-mapping": {
       "source": "mattpocock/skills",
       "sourceType": "github",
@@ -62,10 +74,16 @@
       "computedHash": "a67c6d09fdbf5c76ead066f5eb37a0a24497490e10d929c87e4b3bd5fe75425f"
     },
     "diagnose": {
-      "source": "mattpocock/skills",
+      "source": "LegendApp/legend-skills",
       "sourceType": "github",
-      "skillPath": "skills/engineering/diagnose/SKILL.md",
-      "computedHash": "15939a26f86edec2d4862042b8564e5a062cb81d04e047a0cea6305c8830b5f5"
+      "skillPath": "diagnose/SKILL.md",
+      "computedHash": "bb6f2f6537dd9ac1ae9d987088a36671782d1fa864f4a4d9b1212eb351760f40"
+    },
+    "diagnose-fix-loop": {
+      "source": "LegendApp/legend-skills",
+      "sourceType": "github",
+      "skillPath": "diagnose-fix-loop/SKILL.md",
+      "computedHash": "c7854d200bcc853aee1843f8b05f02181596f3ceb0df398c45745de7fed3a73b"
     },
     "diagnosing-bugs": {
       "source": "mattpocock/skills",
@@ -241,6 +259,12 @@
       "skillPath": "skills/misc/git-guardrails-claude-code/SKILL.md",
       "computedHash": "53a1de29d2b76481202608376fa4a20a8bd7e65b0b8a907a8c9578e629cf313f"
     },
+    "git-integrate": {
+      "source": "LegendApp/legend-skills",
+      "sourceType": "github",
+      "skillPath": "git-integrate/SKILL.md",
+      "computedHash": "810b6be05337ee7f2116cac795ec767e2bfbd373a5afe671fd7e694515891cbc"
+    },
     "grill-me": {
       "source": "mattpocock/skills",
       "sourceType": "github",
@@ -282,6 +306,18 @@
       "sourceType": "github",
       "skillPath": ".claude/skills/interface-design/SKILL.md",
       "computedHash": "340cc79a1558f09371aa3eb689952a8b777c1d7362c24226e99693606a80828e"
+    },
+    "legend-list-best-practices": {
+      "source": "LegendApp/legend-skills",
+      "sourceType": "github",
+      "skillPath": "legend-list-best-practices/SKILL.md",
+      "computedHash": "61b4dec19494fcae599b7aedfa1553323a46f446536feeb9b2a584a298d45cef"
+    },
+    "legend-state-best-practices": {
+      "source": "LegendApp/legend-skills",
+      "sourceType": "github",
+      "skillPath": "legend-state-best-practices/SKILL.md",
+      "computedHash": "84f1cf99560fdf14eb722a8dafe4e6d09f59b5db2749a80ef97fcf35f0ffe022"
     },
     "loop-me": {
       "source": "mattpocock/skills",
@@ -342,6 +378,12 @@
       "sourceType": "github",
       "skillPath": "skills/radon-mcp/SKILL.md",
       "computedHash": "aef74933f21cb992370bdb21ac99cbdc7f2da2d77e1fbbaf7fd9044f7cb41882"
+    },
+    "react-coding-style": {
+      "source": "LegendApp/legend-skills",
+      "sourceType": "github",
+      "skillPath": "react-coding-style/SKILL.md",
+      "computedHash": "0b5629a19a73cad9d0ee56dd77acd41031ab7e2275df056b2288a6f1583d6e68"
     },
     "react-devtools": {
       "source": "callstackincubator/agent-device",
@@ -414,6 +456,12 @@
       "sourceType": "github",
       "skillPath": "skills/misc/setup-pre-commit/SKILL.md",
       "computedHash": "f9aeedf0a1f560ec465c3939c54434c2d949ac8b958a0493db52216f688a0366"
+    },
+    "simplify": {
+      "source": "LegendApp/legend-skills",
+      "sourceType": "github",
+      "skillPath": "simplify/SKILL.md",
+      "computedHash": "bfbefa03b417407210f6fd35a008ec8b4edf1f34bd7e656e54a93d586c45c59e"
     },
     "tdd": {
       "source": "mattpocock/skills",

--- a/src/components/BottomSheet/BottomSheetSurface.tsx
+++ b/src/components/BottomSheet/BottomSheetSurface.tsx
@@ -36,7 +36,7 @@ export function BottomSheetSurface() {
 
 const styles = StyleSheet.create({
   solid: {
-    backgroundColor: theme.color.surfaceSunken.dark,
+    backgroundColor: theme.color.surfaceElevated.dark,
   },
   surface: {
     borderCurve: 'continuous',

--- a/src/components/Chat/components/ChattersSheet/ChattersSheet.tsx
+++ b/src/components/Chat/components/ChattersSheet/ChattersSheet.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import { StyleSheet, useWindowDimensions, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -93,6 +93,10 @@ function buildChattersListItems(
   return items;
 }
 
+const getChattersListItemKey = (item: ChattersListItem) => item.key;
+
+const getChattersListItemType = (item: ChattersListItem) => item.type;
+
 function toUsernamePressData(chatter: MentionChatter): UsernamePressData {
   return {
     color: chatter.color,
@@ -127,36 +131,39 @@ const ChattersSheetComponent = ({
     [bottomInset],
   );
 
-  const renderItem: ListRenderItem<ChattersListItem> = ({ item }) => {
-    if (item.type === 'header') {
-      return (
-        <View style={styles.sectionHeader}>
-          <Text style={styles.sectionHeaderText} weight='semibold'>
-            {t(`chatters.${item.labelKey}`)}
-          </Text>
-          <Text style={styles.sectionHeaderCount} weight='semibold'>
-            {item.count}
-          </Text>
-        </View>
-      );
-    }
+  const renderItem: ListRenderItem<ChattersListItem> = useCallback(
+    ({ item }) => {
+      if (item.type === 'header') {
+        return (
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionHeaderText} weight='semibold'>
+              {t(`chatters.${item.labelKey}`)}
+            </Text>
+            <Text style={styles.sectionHeaderCount} weight='semibold'>
+              {item.count}
+            </Text>
+          </View>
+        );
+      }
 
-    return (
-      <Button
-        label={item.chatter.login}
-        style={styles.chatterRow}
-        onPress={() => onSelectChatter(toUsernamePressData(item.chatter))}
-      >
-        <Text
-          numberOfLines={1}
-          style={[styles.chatterName, { color: item.chatter.color }]}
-          weight='semibold'
+      return (
+        <Button
+          label={item.chatter.login}
+          style={styles.chatterRow}
+          onPress={() => onSelectChatter(toUsernamePressData(item.chatter))}
         >
-          {item.chatter.login}
-        </Text>
-      </Button>
-    );
-  };
+          <Text
+            numberOfLines={1}
+            style={[styles.chatterName, { color: item.chatter.color }]}
+            weight='semibold'
+          >
+            {item.chatter.login}
+          </Text>
+        </Button>
+      );
+    },
+    [onSelectChatter, t],
+  );
 
   return (
     <BottomSheet
@@ -215,8 +222,8 @@ const ChattersSheetComponent = ({
           <FlashList
             data={items}
             renderItem={renderItem}
-            keyExtractor={item => item.key}
-            getItemType={item => item.type}
+            keyExtractor={getChattersListItemKey}
+            getItemType={getChattersListItemType}
             contentContainerStyle={listContentStyle}
             keyboardShouldPersistTaps='handled'
             maintainVisibleContentPosition={{ disabled: true }}

--- a/src/screens/SettingsScreen/components/BuildStatus.tsx
+++ b/src/screens/SettingsScreen/components/BuildStatus.tsx
@@ -1,5 +1,4 @@
 import { StyleSheet, View } from 'react-native';
-import { Circle, Svg } from 'react-native-svg';
 
 import * as Updates from 'expo-updates';
 
@@ -8,18 +7,21 @@ import { theme } from '@app/styles/themes';
 import { getBuildInfoLabel } from '@app/utils/version/buildInfoLabel';
 
 export function BuildStatus() {
-  const updateProgress = Updates.updateId ? 1 : 0.72;
+  const onOtaUpdate = Boolean(Updates.updateId);
 
   return (
     <View style={styles.buildContainer}>
-      <ProgressRing
-        progress={updateProgress}
-        progressColor={theme.colorPrimary}
-        size={28}
-        strokeWidth={3}
-        trackColor={theme.darkActiveContent}
+      <View
+        style={[
+          styles.statusDot,
+          {
+            backgroundColor: onOtaUpdate
+              ? theme.color.success.dark
+              : theme.colorGrey,
+          },
+        ]}
       />
-      <Text type='xs' color='gray.border'>
+      <Text type='xs' weight='medium' color='gray.textLow'>
         {getBuildInfoLabel()}
       </Text>
     </View>
@@ -35,53 +37,13 @@ const styles = StyleSheet.create({
     borderRadius: theme.borderRadius999,
     borderWidth: 1,
     flexDirection: 'row',
-    gap: theme.space12,
+    gap: theme.space8,
     paddingHorizontal: theme.space16,
     paddingVertical: theme.space8,
   },
+  statusDot: {
+    borderRadius: 999,
+    height: 8,
+    width: 8,
+  },
 });
-
-function ProgressRing({
-  progress,
-  progressColor,
-  size = 44,
-  strokeWidth = 3,
-  trackColor = 'rgba(255, 255, 255, 0.15)',
-}: {
-  progress: number;
-  size?: number;
-  strokeWidth?: number;
-  trackColor?: string;
-  progressColor?: string;
-}) {
-  const normalizedProgress = Math.max(0, Math.min(1, progress));
-  const radius = (size - strokeWidth) / 2;
-  const circumference = Math.max(0, 2 * Math.PI * radius);
-  const strokeDashoffset = circumference * (1 - normalizedProgress);
-
-  return (
-    <Svg width={size} height={size}>
-      <Circle
-        cx={size / 2}
-        cy={size / 2}
-        fill='none'
-        r={radius}
-        stroke={trackColor}
-        strokeWidth={strokeWidth}
-      />
-      <Circle
-        cx={size / 2}
-        cy={size / 2}
-        fill='none'
-        r={radius}
-        stroke={progressColor}
-        strokeWidth={strokeWidth}
-        strokeDasharray={`${circumference} ${circumference}`}
-        strokeDashoffset={strokeDashoffset}
-        strokeLinecap='round'
-        rotation={-90}
-        origin={`${size / 2}, ${size / 2}`}
-      />
-    </Svg>
-  );
-}


### PR DESCRIPTION
The non-android half of #764, split out so the android release PR (#779) stays focused. No android code here.

## What's in
- **Agent skills** - `commit`, `commit-confirm`, `diagnose-fix-loop`, `git-integrate`, `legend-list`/`legend-state` best-practices, `react-coding-style`, `simplify`; refreshed `diagnose` skill; `skills-lock.json` + `.claude/skills` symlinks
- **package.json linting** - `eslint-package-json` wired in (canonical field order, `./index.js` path prefix, drop deprecated `engineStrict`) with a `package.json` lint-staged hook
- **Housekeeping** - e2e mock-server / player-website `engines`, `build.sh`/`deploy.sh` `--interactive` passthrough, `.gitignore` (`.idea/` collapse, `buildServer.json`)
- **Minor UI** - `BottomSheetSurface` elevated colour, `ChattersSheet` renderItem memoisation, `BuildStatus` status-dot instead of the svg progress ring

## Left out on purpose
The native swift/kotlin lint wiring from #764 - it depends on `scripts/lint-swift.sh` / `lint-kotlin.sh` which aren't on `main` yet, so it belongs with the native-linting work, not here.

## Checks
- `tsc --noEmit` clean
- `eslint` clean (incl. `package.json` under the new rules)