### PR TITLE
fix(security): restrict https auth callbacks to foam-app.com on native

### DIFF
--- a/src/navigators/__tests__/authLinking.test.ts
+++ b/src/navigators/__tests__/authLinking.test.ts
@@ -55,3 +55,28 @@ describe('authLinking magic-link sign in', () => {
     expect(response.params.refresh_token).toBe('magic-refresh-token');
   });
 });
+
+describe('authLinking native callback host restriction', () => {
+  const tokenQuery =
+    'access_token=injected-token&token_type=bearer&expires_in=14400';
+
+  test('accepts foam-app.com auth and proxy callbacks that carry a token', () => {
+    expect(isAuthCallbackUrl(`https://foam-app.com/auth?${tokenQuery}`)).toBe(
+      true,
+    );
+    expect(
+      isAuthCallbackUrl(
+        `https://auth-staging.foam-app.com/proxy?${tokenQuery}`,
+      ),
+    ).toBe(true);
+  });
+
+  test('rejects a token-bearing https /auth link from any other host', () => {
+    expect(isAuthCallbackUrl(`https://twitch.tv/auth?${tokenQuery}`)).toBe(
+      false,
+    );
+    expect(isAuthCallbackUrl(`https://evil.example/auth?${tokenQuery}`)).toBe(
+      false,
+    );
+  });
+});

--- a/src/navigators/authLinking.ts
+++ b/src/navigators/authLinking.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import type { AuthSessionResult } from 'expo-auth-session';
 
 import {
@@ -16,9 +18,9 @@ export type LoginWithTwitchFn = (
 
 const AUTH_CALLBACK_PATTERNS = [
   /^foam(-[a-z0-9]+)?:\/\//,
-  /^https?:\/\/[^/]+\/auth(?:[?#/]|$)/,
   /^https?:\/\/([^/]+\.)?foam-app\.com\/auth/,
   /^https?:\/\/([^/]+\.)?foam-app\.com\/proxy/,
+  ...(Platform.OS === 'web' ? [/^https?:\/\/[^/]+\/auth(?:[?#/]|$)/] : []),
 ];
 
 export function isAuthCallbackUrl(url: string | null): boolean {


### PR DESCRIPTION
# Why

Found during the adversarial review of the android release, #779. Not android-specific, so it's on its own branch off main.

AUTH_CALLBACK_PATTERNS matched any https://<host>/auth?access_token=... URL, and completeAuthWithCallbackUrl logs the user in with whatever token that URL carries. On native the app only ever receives auth callbacks through the foam:// scheme or the foam-app.com proxy - useTwitchSignIn returns to foam://auth and the redirect uri is auth-staging.foam-app.com/proxy. So the any-host /auth pattern had no legitimate use on native and was a token-injection surface: a crafted https://twitch.tv/auth?access_token=ATTACKER link would be accepted, and twitch.tv is a registered android intent host.

# How

Keep the any-host /auth wildcard on web only, where the callback lands on the app's own origin. On native, callbacks have to be foam://, foam-app.com/auth or foam-app.com/proxy. Every real native and web flow still works.

Added tests: twitch.tv/auth and evil.example/auth are rejected on native, foam-app.com callbacks still pass.

# Not fixed here

foam://auth?access_token=... is still an injection vector, since any app can invoke the custom scheme. Closing it needs state/nonce binding, and that has to account for the App Review magic link, which is server-issued with no client nonce - a naive state check would break login. Leaving it as a separate follow-up.

# Test Plan

- tsc and eslint clean.
- 16 auth tests pass (authLinking, RouterEffects, native-intent).
