### PR TITLE
ci: block merge commits on pr branches

### DIFF
--- a/.github/workflows/enforce-rebase.yml
+++ b/.github/workflows/enforce-rebase.yml
@@ -1,0 +1,61 @@
+name: Enforce rebase
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+permissions:
+  contents: read
+jobs:
+  no-merge-commits:
+    name: No merge commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: 🚫 Reject merge commits
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
+          merges=$(git rev-list --min-parents=2 "origin/${BASE_REF}..${HEAD_SHA}")
+
+          if [ -z "$merges" ]; then
+            echo "Branch is linear on top of ${BASE_REF}."
+            echo "✅ No merge commits - branch is linear on top of \`${BASE_REF}\`." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "### ❌ Merge commits found"
+            echo
+            echo "This branch was updated with \`git merge\` instead of \`git rebase\`. We keep a linear history, so merge commits are not allowed on a PR branch - including merges of \`${BASE_REF}\` into the branch."
+            echo
+            echo "| commit | author | subject |"
+            echo "| --- | --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          while read -r sha; do
+            git show -s --format='| `%h` | %an | %s |' "$sha" >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Merge commit $(git show -s --format='%h %s' "$sha")"
+          done <<< "$merges"
+
+          {
+            echo
+            echo "Drop them by rebasing:"
+            echo
+            echo '```sh'
+            echo "git fetch origin ${BASE_REF}"
+            echo "git rebase origin/${BASE_REF}"
+            echo "git push --force-with-lease"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit 1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,41 @@
+base="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || echo origin/main)"
+base_branch="${base#origin/}"
+
+git rev-parse --verify --quiet "$base" >/dev/null || exit 0
+
+status=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  case "$local_sha" in
+    *[!0]*) ;;
+    *) continue ;;
+  esac
+
+  if [ "$remote_ref" = "refs/heads/$base_branch" ]; then
+    continue
+  fi
+
+  merges="$(git rev-list --min-parents=2 "$base..$local_sha")"
+  [ -n "$merges" ] || continue
+
+  status=1
+
+  echo "" >&2
+  echo "❌ $local_ref contains merge commits on top of $base:" >&2
+  echo "" >&2
+  git log --no-walk --format='   %h %an - %s' $merges >&2
+  echo "" >&2
+  echo "   We keep a linear history. Update your branch with a rebase:" >&2
+  echo "" >&2
+  echo "     git fetch origin $base_branch" >&2
+  echo "     git rebase $base" >&2
+  echo "     git push --force-with-lease" >&2
+  echo "" >&2
+done
+
+if [ "$status" -ne 0 ]; then
+  echo "   Push blocked. Use 'git push --no-verify' to override." >&2
+  echo "" >&2
+fi
+
+exit "$status"


### PR DESCRIPTION
# Why

We want a linear history on PR branches. Right now nothing stops someone updating their branch with `git merge main`, which drags merge commits into the PR and makes the diff and `git log` harder to read.

# How

Two layers, both checking the same thing - any commit with 2+ parents in `origin/<base>..HEAD`:

- `.github/workflows/enforce-rebase.yml` - runs on PR open/reopen/push, checks out the head SHA with full history, and fails with an error annotation per offending commit plus a step summary listing them and the rebase commands to fix it. It rejects any merge commit on the branch, not just `main` into the branch, since merging a sibling branch in breaks linearity the same way.
- `.husky/pre-push` - same check locally so you find out before CI does. Skips branch deletions and pushes to the base branch itself, and `git push --no-verify` still overrides.

Note the workflow only reports until **No merge commits** is marked as a required status check on `main` in branch protection settings.

# Test Plan

Ran both against a throwaway repo with a real `origin`:

- branch with `Merge branch 'main' into feat` - workflow logic lists the commit, hook exits 1 and prints the rebase instructions
- same branch after `git rebase origin/main` - both pass
- push to `main` and branch deletion (all-zero local SHA) - hook skips
- hook re-run under `sh -e`, which is how husky's shim invokes it, to confirm the skip branches don't trip `set -e`

The workflow YAML parses, and this PR is itself the live test of it.
