### PR TITLE
fix(chat): cap concurrent emote picker animations

### DIFF
--- a/src/components/Chat/components/EmoteSheet/EmoteCell.tsx
+++ b/src/components/Chat/components/EmoteSheet/EmoteCell.tsx
@@ -11,6 +11,7 @@ import { describeEmoteUrl } from '@app/utils/emote/describeEmoteUrl';
 import { emoteSheetStyles as styles } from './emoteSheetStyles';
 import type { EmotePickerItem } from './emoteSheetTypes';
 import { getEmotePickerDisplayUrl } from './util/emotePickerDisplayUrl';
+import { emoteSheetAnimationBudget } from './util/emoteSheetAnimationBudget';
 import { emoteSheetScrollActivity } from './util/emoteSheetScrollActivity';
 
 function EmoteCellComponent({
@@ -30,19 +31,33 @@ function EmoteCellComponent({
     [displayUrl],
   );
 
+  const hasAnimationSlotRef = useRef(false);
+
   useEffect(() => {
     if (typeof item === 'string') {
       return undefined;
     }
-    if (emoteSheetScrollActivity.isActive()) {
-      runAnimationCommand(imageRef.current, 'stopAnimating');
-    }
-    return emoteSheetScrollActivity.subscribe(active => {
+
+    const sync = () => {
+      const shouldAnimate =
+        hasAnimationSlotRef.current && !emoteSheetScrollActivity.isActive();
       runAnimationCommand(
         imageRef.current,
-        active ? 'stopAnimating' : 'startAnimating',
+        shouldAnimate ? 'startAnimating' : 'stopAnimating',
       );
+    };
+
+    const releaseSlot = emoteSheetAnimationBudget.acquire(granted => {
+      hasAnimationSlotRef.current = granted;
+      sync();
     });
+    const unsubscribeScroll = emoteSheetScrollActivity.subscribe(sync);
+
+    return () => {
+      unsubscribeScroll();
+      releaseSlot();
+      hasAnimationSlotRef.current = false;
+    };
   }, [item]);
 
   if (typeof item === 'string') {
@@ -77,7 +92,7 @@ function EmoteCellComponent({
         useAppleWebpCodec={resolveUseAppleWebpCodec(urlKind, {
           preferAppleCodecForStatic: true,
         })}
-        autoplay={!emoteSheetScrollActivity.isActive()}
+        autoplay={false}
         priority='low'
         transition={0}
         recyclingKey={item.id}

--- a/src/components/Chat/components/EmoteSheet/EmoteSheet.tsx
+++ b/src/components/Chat/components/EmoteSheet/EmoteSheet.tsx
@@ -154,7 +154,7 @@ export function EmoteSheet({
                         (sheet.filteredSets.length > 1 ? 0 : bottomInset),
                     },
                   ]}
-                  drawDistance={(sheet.cellSize + 4) * 8}
+                  drawDistance={(sheet.cellSize + 4) * 3}
                   showsVerticalScrollIndicator
                   nestedScrollEnabled
                   indicatorStyle='white' // todo - once we have light theme, adjust this

--- a/src/components/Chat/components/EmoteSheet/__tests__/EmoteCell.test.tsx
+++ b/src/components/Chat/components/EmoteSheet/__tests__/EmoteCell.test.tsx
@@ -1,6 +1,7 @@
 import { act, render } from '@testing-library/react-native';
 
 import { EmoteCell } from '../EmoteCell';
+import { emoteSheetAnimationBudget } from '../util/emoteSheetAnimationBudget';
 import { emoteSheetScrollActivity } from '../util/emoteSheetScrollActivity';
 import { createMenuEmote } from './__fixtures__/emoteMenuData.fixture';
 
@@ -24,11 +25,13 @@ describe('EmoteCell animation pause', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     emoteSheetScrollActivity.reset();
+    emoteSheetAnimationBudget.reset();
     mockStartAnimating.mockClear();
     mockStopAnimating.mockClear();
   });
   afterEach(() => {
     emoteSheetScrollActivity.reset();
+    emoteSheetAnimationBudget.reset();
     jest.useRealTimers();
   });
 
@@ -39,6 +42,9 @@ describe('EmoteCell animation pause', () => {
         item={createMenuEmote('a', 'a', '7TV Global')}
       />,
     );
+
+    expect(mockStartAnimating).toHaveBeenCalledTimes(1);
+    mockStartAnimating.mockClear();
 
     act(() => emoteSheetScrollActivity.poke());
     expect(mockStopAnimating).toHaveBeenCalledTimes(1);
@@ -59,5 +65,24 @@ describe('EmoteCell animation pause', () => {
     );
 
     expect(mockStopAnimating).toHaveBeenCalledTimes(1);
+  });
+
+  test('leaves cells past the animation cap on their first frame', () => {
+    const held: (() => void)[] = [];
+    for (let i = 0; i < 24; i += 1) {
+      held.push(emoteSheetAnimationBudget.acquire(() => undefined));
+    }
+    mockStartAnimating.mockClear();
+
+    render(
+      <EmoteCell
+        cellSize={40}
+        item={createMenuEmote('c', 'c', '7TV Global')}
+      />,
+    );
+
+    expect(mockStartAnimating).not.toHaveBeenCalled();
+
+    held.forEach(release => release());
   });
 });

--- a/src/components/Chat/components/EmoteSheet/useEmoteSheet.tsx
+++ b/src/components/Chat/components/EmoteSheet/useEmoteSheet.tsx
@@ -28,6 +28,7 @@ import type { SanitisedEmote } from '@app/types/emote';
 import { EmoteRow } from './EmoteRow';
 import type { EmotePickerItem } from './emoteSheetTypes';
 import { SetHeader } from './SetHeader';
+import { emoteSheetAnimationBudget } from './util/emoteSheetAnimationBudget';
 import { emoteSheetScrollActivity } from './util/emoteSheetScrollActivity';
 import { prefetchEmotePickerImages } from './util/prefetchEmotePickerImages';
 
@@ -255,6 +256,7 @@ export function useEmoteSheet({
   const handleDismiss = useCallback(() => {
     setSearchQuery('');
     emoteSheetScrollActivity.reset();
+    emoteSheetAnimationBudget.reset();
     onDismiss();
   }, [onDismiss]);
 

--- a/src/components/Chat/components/EmoteSheet/util/__tests__/emoteSheetAnimationBudget.test.ts
+++ b/src/components/Chat/components/EmoteSheet/util/__tests__/emoteSheetAnimationBudget.test.ts
@@ -48,3 +48,18 @@ test('reset clears every slot so a reopened sheet starts from zero', () => {
 
   expect(afterReset).toEqual([true]);
 });
+
+test('releasing a slot after reset does not raise the cap', () => {
+  const budget = createAnimationBudget(1);
+  const afterReset: boolean[] = [];
+
+  const releaseBeforeReset = budget.acquire(() => undefined);
+  budget.reset();
+  // The dismissed sheet's cell unmounts after reset and releases its old slot.
+  releaseBeforeReset();
+
+  budget.acquire(value => afterReset.push(value));
+  budget.acquire(value => afterReset.push(value));
+
+  expect(afterReset).toEqual([true]);
+});

--- a/src/components/Chat/components/EmoteSheet/util/__tests__/emoteSheetAnimationBudget.test.ts
+++ b/src/components/Chat/components/EmoteSheet/util/__tests__/emoteSheetAnimationBudget.test.ts
@@ -1,0 +1,50 @@
+import { createAnimationBudget } from '../emoteSheetAnimationBudget';
+
+test('grants animation to cells up to the cap', () => {
+  const budget = createAnimationBudget(2);
+  const granted: boolean[] = [];
+
+  budget.acquire(value => granted.push(value));
+  budget.acquire(value => granted.push(value));
+  budget.acquire(value => granted.push(value));
+
+  expect(granted).toEqual([true, true]);
+});
+
+test('promotes a waiting cell when a granted cell is released', () => {
+  const budget = createAnimationBudget(1);
+  const third: boolean[] = [];
+
+  const releaseFirst = budget.acquire(() => undefined);
+  budget.acquire(value => third.push(value));
+
+  expect(third).toEqual([]);
+
+  releaseFirst();
+
+  expect(third).toEqual([true]);
+});
+
+test('releasing an ungranted cell does not free a slot', () => {
+  const budget = createAnimationBudget(1);
+  const late: boolean[] = [];
+
+  budget.acquire(() => undefined);
+  const releaseWaiting = budget.acquire(() => undefined);
+
+  releaseWaiting();
+  budget.acquire(value => late.push(value));
+
+  expect(late).toEqual([]);
+});
+
+test('reset clears every slot so a reopened sheet starts from zero', () => {
+  const budget = createAnimationBudget(1);
+  const afterReset: boolean[] = [];
+
+  budget.acquire(() => undefined);
+  budget.reset();
+  budget.acquire(value => afterReset.push(value));
+
+  expect(afterReset).toEqual([true]);
+});

--- a/src/components/Chat/components/EmoteSheet/util/emoteSheetAnimationBudget.ts
+++ b/src/components/Chat/components/EmoteSheet/util/emoteSheetAnimationBudget.ts
@@ -1,0 +1,69 @@
+type AnimationBudgetListener = (granted: boolean) => void;
+
+/**
+ * Caps how many picker cells may animate at once.
+ *
+ * Every mounted cell autoplaying meant a reopened sheet committed ~100 animated
+ * WebP layers in a single CoreAnimation transaction, decoding all of them on the
+ * main thread (Sentry FOAM-TV-MOBILE-W, 3.8-4.6s fully-blocked hang). Cells
+ * beyond the cap hold their first frame instead.
+ */
+const MAX_CONCURRENT_ANIMATED = 24;
+
+interface AnimationSlot {
+  granted: boolean;
+  listener: AnimationBudgetListener;
+}
+
+export interface EmoteSheetAnimationBudget {
+  acquire: (listener: AnimationBudgetListener) => () => void;
+  reset: () => void;
+}
+
+export function createAnimationBudget(
+  maxConcurrent: number = MAX_CONCURRENT_ANIMATED,
+): EmoteSheetAnimationBudget {
+  const slots = new Set<AnimationSlot>();
+  let grantedCount = 0;
+
+  function grant(slot: AnimationSlot): void {
+    if (slot.granted || grantedCount >= maxConcurrent) {
+      return;
+    }
+    slot.granted = true;
+    grantedCount += 1;
+    slot.listener(true);
+  }
+
+  function promoteWaiting(): void {
+    for (const slot of slots) {
+      if (grantedCount >= maxConcurrent) {
+        return;
+      }
+      grant(slot);
+    }
+  }
+
+  return {
+    acquire(listener: AnimationBudgetListener): () => void {
+      const slot: AnimationSlot = { granted: false, listener };
+      slots.add(slot);
+      grant(slot);
+
+      return () => {
+        slots.delete(slot);
+        if (slot.granted) {
+          slot.granted = false;
+          grantedCount -= 1;
+          promoteWaiting();
+        }
+      };
+    },
+    reset(): void {
+      slots.clear();
+      grantedCount = 0;
+    },
+  };
+}
+
+export const emoteSheetAnimationBudget = createAnimationBudget();

--- a/src/components/Chat/components/EmoteSheet/util/emoteSheetAnimationBudget.ts
+++ b/src/components/Chat/components/EmoteSheet/util/emoteSheetAnimationBudget.ts
@@ -60,6 +60,12 @@ export function createAnimationBudget(
       };
     },
     reset(): void {
+      // Cells unmount after the sheet dismisses, so their release closures still
+      // hold these slots. Clearing `granted` first stops those late releases
+      // from decrementing `grantedCount` below zero and doubling the cap.
+      for (const slot of slots) {
+        slot.granted = false;
+      }
       slots.clear();
       grantedCount = 0;
     },


### PR DESCRIPTION
Reopening the emote picker froze the app. Root cause is in Sentry: [FOAM-TV-MOBILE-W](https://foam-tv.sentry.io/issues/FOAM-TV-MOBILE-W), 7 events in production, main thread fully blocked 3.8-4.6s with `view_names: ["RCTFabricModalHostViewController"]` (the sheet's modal):

```
CA::Transaction::commit -> CA::Layer::prepare_commit
  -> -[CAKeyframeAnimation CA_prepareRenderValue]
  -> CA::Render::prepare_image -> CA::Render::copy_image
  -> WebPReadPlugin::decodeAnimatedWebP -> WebPAnimDecoderGetNext -> VP8Decode
```

Synchronous animated-WebP decode inside the CoreAnimation commit.

`EmoteCell` set `autoplay={!emoteSheetScrollActivity.isActive()}`. Nothing is scrolling when the sheet opens, so every mounted cell autoplayed - at 6 columns with 8 rows of `drawDistance` that's ~100 animated emotes. First open they arrive over the network so the decodes spread out; on reopen everything is cached and they all decode in one commit. Chat already gates this on row visibility (`ChatInlineImage.tsx:289`); the picker never got the same treatment.

Changes:
- New `emoteSheetAnimationBudget` grants animation to at most 24 cells at a time, FIFO, promoting waiters as cells recycle. Cells past the cap hold their first frame.
- `EmoteCell` no longer autoplays; it drives `startAnimating`/`stopAnimating` explicitly from the budget plus the existing scroll-pause signal.
- `drawDistance` cut from 8 rows to 3 to shrink the mounted set.
- Budget resets on dismiss so a reopened sheet starts from zero.

Note: Seer's blurb on that issue attributes the hang to accessibility frame calculation. The stack doesn't support that - every frame between the CA commit and the leaf is image decode.

Not device-verified. The mechanism and the stack agree, but I have not reproduced the hang on a device before/after.

Tests: new unit tests for the budget (cap, promotion on release, reset) and an `EmoteCell` test asserting cells past the cap stay on their first frame. Full suite 9800 passing, tsc clean, eslint/prettier clean.