### PR TITLE
fix(perf): only configure the expo-image cache on ios

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,40 +15,47 @@ if (__DEV__ && !process.env.EXPO_PUBLIC_REACT_PERF_TRACKS) {
   delete console.timeStamp;
 }
 
-// Bound expo-image's in-memory decoded cache. By default both tiers are
-// unbounded (maxMemoryCost/maxDiskSize: 0); under sustained chat raids the
-// decoded working set grew until iOS jettisoned the app (std::bad_alloc /
-// WatchdogTermination in busy channels like caedrel). `maxMemoryCost` is in
-// BYTES (SDWebImage: "the bytes size held in memory"), so a flat 2GB let the
-// cache grow to ~2GB of decoded emote bitmaps on top of the video WebView and
-// JS heap. Scale it to the device instead: ~12% of physical RAM, clamped to
-// [96MB, 384MB], so smaller phones cap tighter and no device parks gigabytes of
-// decoded images. NSCache still self-purges under OS memory pressure.
-try {
-  const MIN_MEMORY_CACHE_BYTES = 96 * 1024 * 1024;
-  const MAX_MEMORY_CACHE_BYTES = 384 * 1024 * 1024;
-  let totalMemoryBytes = 0;
+// Bound expo-image's in-memory decoded cache. iOS only: `configureCache` is
+// declared `@platform ios` and has no counterpart in expo-image's Android
+// module, so calling it there just throws into the catch below. Android needs
+// no equivalent — Glide's default MemorySizeCalculator already scales the
+// memory cache and bitmap pool to the device's memory class, whereas
+// SDWebImage defaults both tiers to unbounded (maxMemoryCost/maxDiskSize: 0).
+// Under sustained chat raids that unbounded working set grew until iOS
+// jettisoned the app (std::bad_alloc / WatchdogTermination in busy channels
+// like caedrel). `maxMemoryCost` is in BYTES (SDWebImage: "the bytes size held
+// in memory"), so a flat 2GB let the cache grow to ~2GB of decoded emote
+// bitmaps on top of the video WebView and JS heap. Scale it to the device
+// instead: ~12% of physical RAM, clamped to [96MB, 384MB], so smaller phones
+// cap tighter and no device parks gigabytes of decoded images. NSCache still
+// self-purges under OS memory pressure.
+if (process.env.EXPO_OS === 'ios') {
   try {
-    const deviceInfo = require('react-native-device-info');
-    const DeviceInfo = deviceInfo.default ?? deviceInfo;
-    totalMemoryBytes = DeviceInfo.getTotalMemorySync?.() ?? 0;
+    const MIN_MEMORY_CACHE_BYTES = 96 * 1024 * 1024;
+    const MAX_MEMORY_CACHE_BYTES = 384 * 1024 * 1024;
+    let totalMemoryBytes = 0;
+    try {
+      const deviceInfo = require('react-native-device-info');
+      const DeviceInfo = deviceInfo.default ?? deviceInfo;
+      totalMemoryBytes = DeviceInfo.getTotalMemorySync?.() ?? 0;
+    } catch {
+      // device-info unavailable — fall through to the fixed ceiling below.
+    }
+    const scaled =
+      totalMemoryBytes > 0
+        ? Math.floor(totalMemoryBytes * 0.12)
+        : MAX_MEMORY_CACHE_BYTES;
+    const maxMemoryCost = Math.max(
+      MIN_MEMORY_CACHE_BYTES,
+      Math.min(MAX_MEMORY_CACHE_BYTES, scaled),
+    );
+    require('expo-image').Image.configureCache({
+      maxMemoryCost,
+      maxDiskSize: 512 * 1024 * 1024,
+    });
   } catch {
-    // device-info unavailable — fall through to the fixed ceiling below.
+    // expo-image unavailable — cache stays default.
   }
-  const scaled =
-    totalMemoryBytes > 0
-      ? Math.floor(totalMemoryBytes * 0.12)
-      : MAX_MEMORY_CACHE_BYTES;
-  const maxMemoryCost = Math.max(
-    MIN_MEMORY_CACHE_BYTES,
-    Math.min(MAX_MEMORY_CACHE_BYTES, scaled),
-  );
-  require('expo-image').Image.configureCache({
-    maxMemoryCost,
-    maxDiskSize: 512 * 1024 * 1024,
-  });
-} catch {
-  // expo-image unavailable (e.g. web) — cache stays default.
 }
 
 require('expo-router/entry');


### PR DESCRIPTION
Found while investigating the emote picker hang (#788).

`index.js` calls `Image.configureCache({ maxMemoryCost, maxDiskSize })` unconditionally, but that API is iOS-only:

- `expo-image/src/Image.types.ts:855` declares `ImageCacheConfig` `@platform ios`
- `ExpoImageModule.kt` exposes `clearMemoryCache` / `clearDiskCache` / `prefetch` but no `configureCache`

So on Android the call threw straight into the surrounding catch on every launch, silently. The block also reads as if it bounds both platforms when it only ever bounded iOS.

Android needs no equivalent - `ExpoImageAppGlideModule.applyOptions` only sets the log level, leaving Glide's default `MemorySizeCalculator`, which already scales the memory cache and bitmap pool to the device's memory class. That is unlike SDWebImage, which defaults both tiers to unbounded and was the actual bug this block was written for.

Gates the call to iOS and corrects the comment. No behaviour change on iOS.

Fingerprint is unchanged with and without this diff (`97e5d5b43fa0b1ec415b4fbf7e1a0ead129890d7`), so it is OTA-shippable.

Full suite 9795 passing, eslint and prettier clean.