### PR TITLE
fix(ci): bump react-doctor action to a release with pinned transitive actions

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -20,11 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Run React Doctor
-        uses: millionco/react-doctor@b612664043a9be414166e3c6a69b355e39a8dcf4 # v1.1.1
+        uses: millionco/react-doctor@01820bb4fd4d0a4aebcd8df2b2a143a098649cb2 # v2.2.8
         with:
-          fail-on: error
-          annotations: true
-          # 0.7.5/0.7.6 exit 0 without writing the JSON report on ubuntu
-          # runners, failing the job (millionco/react-doctor#1183). Pinned to
-          # the last good release; bump once a fixed stable version ships.
-          version: 0.7.4
+          blocking: error
+          commit-status: false


### PR DESCRIPTION
# Why

Every PR has been failing at job setup with:

> Error: The actions actions/setup-node@v5 and actions/github-script@v8 are not allowed in luke-h1/foam because all actions must be pinned to a full-length commit SHA.

`millionco/react-doctor@v1.1.1` is a composite action, and its own steps referenced `actions/setup-node@v5` and `actions/github-script@v8` by tag. The SHA-pinning policy applies transitively, so the job died before running anything. Nothing in this repo was unpinned - I swept every action reference in `.github/workflows` and `.github/actions` against its upstream manifest and react-doctor was the only offender.

# How

Bumped the action to v2.2.8, which pins its transitive actions. That release renamed some inputs:

- `fail-on: error` -> `blocking: error`
- `annotations` is gone, replaced by `review-comments` (default on)
- `scope` now defaults to `changed`, so only issues the PR introduces are reported

Also dropped the `version: 0.7.4` pin - that was a workaround for millionco/react-doctor#1183, which is closed, so the action's default resolves the current release again. Set `commit-status: false` since this workflow only runs on `pull_request`, where the check itself already reports the result - keeps the token at `contents: read` + `pull-requests: write` rather than needing `statuses: write`.

# Test Plan

- Verified `01820bb4fd4d0a4aebcd8df2b2a143a098649cb2` dereferences from the `v2.2.8` annotated tag on `millionco/react-doctor`.
- Read `action.yml` at that SHA: `actions/setup-node`, `actions/cache`, `actions/github-script` are all full-SHA pinned.
- Swept all 22 third-party action refs in this repo for unpinned transitive `uses:` - react-doctor was the only one.
- React Doctor on this PR is the real test: it should get past setup and complete.
