### PR TITLE
fix(ci): give android a per-variant google services file

### DIFF
--- a/.github/actions/load-native-deploy-secrets/action.yml
+++ b/.github/actions/load-native-deploy-secrets/action.yml
@@ -35,5 +35,7 @@ runs:
         FOAM_AWS_FINGERPRINT_BUCKET_NAME: op://ci-cd/foam-mobile-${{ inputs.variant == 'production' && 'production' || 'staging' }}/FOAM_AWS_FINGERPRINT_BUCKET_NAME
         GOOGLE_SERVICES_IOS_PROD_BS4: op://ci-cd/foam-mobile-${{ inputs.variant == 'production' && 'production' || 'staging' }}/GOOGLE_SERVICES_IOS_PROD_BS4
         GOOGLE_SERVICES_ANDROID_PROD_BS4: op://ci-cd/foam-mobile-${{ inputs.variant == 'production' && 'production' || 'staging' }}/GOOGLE_SERVICES_ANDROID_PROD_BS4
+        GOOGLE_SERVICES_ANDROID_INTERNAL_BS4: op://ci-cd/foam-mobile-${{ inputs.variant == 'production' && 'production' || 'staging' }}/GOOGLE_SERVICES_ANDROID_INTERNAL_BS4
+        GOOGLE_SERVICES_ANDROID_TESTFLIGHT_BS4: op://ci-cd/foam-mobile-${{ inputs.variant == 'production' && 'production' || 'staging' }}/GOOGLE_SERVICES_ANDROID_TESTFLIGHT_BS4
         SLACK_WEBHOOK_URL: op://ci-cd/foam-mobile-${{ inputs.variant == 'production' && 'production' || 'staging' }}/SLACK_WEBHOOK_URL
         OP_ENV_FILE: '.env'

--- a/.github/actions/write-google-service-files/action.yml
+++ b/.github/actions/write-google-service-files/action.yml
@@ -16,10 +16,9 @@ runs:
       run: |
         set -euo pipefail
 
-        if [ -z "${GOOGLE_SERVICES_ANDROID_PROD_BS4:-}" ]; then
-          echo "Error: GOOGLE_SERVICES_ANDROID_PROD_BS4 is not set"
-          exit 1
-        fi
+        # iOS shares one plist across variants; Android needs its own file per
+        # variant because google-services.json only matches the package names
+        # it was exported with, and Gradle hard-fails on a missing client.
         if [ -z "${GOOGLE_SERVICES_IOS_PROD_BS4:-}" ]; then
           echo "Error: GOOGLE_SERVICES_IOS_PROD_BS4 is not set"
           exit 1
@@ -29,14 +28,20 @@ runs:
           production)
             ios_file="GoogleService-Info-prod.plist"
             android_file="google-services-prod.json"
+            android_secret_name="GOOGLE_SERVICES_ANDROID_PROD_BS4"
+            android_secret="${GOOGLE_SERVICES_ANDROID_PROD_BS4:-}"
             ;;
           internal)
             ios_file="GoogleService-Info-internal.plist"
             android_file="google-services-internal.json"
+            android_secret_name="GOOGLE_SERVICES_ANDROID_INTERNAL_BS4"
+            android_secret="${GOOGLE_SERVICES_ANDROID_INTERNAL_BS4:-}"
             ;;
           testflight)
             ios_file="GoogleService-Info-testflight.plist"
             android_file="google-services-testflight.json"
+            android_secret_name="GOOGLE_SERVICES_ANDROID_TESTFLIGHT_BS4"
+            android_secret="${GOOGLE_SERVICES_ANDROID_TESTFLIGHT_BS4:-}"
             ;;
           *)
             echo "Error: unsupported Google services variant '$VARIANT'"
@@ -44,8 +49,13 @@ runs:
             ;;
         esac
 
-        echo "Decoding Android Google Services JSON to $android_file..."
-        echo "$GOOGLE_SERVICES_ANDROID_PROD_BS4" | base64 -d > "$android_file"
+        if [ -z "$android_secret" ]; then
+          echo "Error: $android_secret_name is not set"
+          exit 1
+        fi
+
+        echo "Decoding $android_secret_name to $android_file..."
+        echo "$android_secret" | base64 -d > "$android_file"
 
         echo "Decoding iOS Google Services plist to $ios_file..."
         echo "$GOOGLE_SERVICES_IOS_PROD_BS4" | base64 -d > "$ios_file"

--- a/.github/actions/write-google-service-files/action.yml
+++ b/.github/actions/write-google-service-files/action.yml
@@ -56,3 +56,12 @@ runs:
         fi
 
         echo "Google service files written for $VARIANT"
+
+    # Both variants read one pair of secrets, so a file that is valid for one
+    # variant is silently wrong for another. Gradle only catches the Android
+    # half, and only after the whole native build has run.
+    - name: Verify Google service files match the variant
+      shell: bash
+      env:
+        VARIANT: ${{ inputs.variant }}
+      run: bunx tsx scripts/workflows/verify-google-service-files-cli.ts --variant "$VARIANT"

--- a/app.config.ts
+++ b/app.config.ts
@@ -19,7 +19,7 @@ export type Variant =
   'development' | 'internal' | 'testflight' | 'e2e' | 'production';
 
 // https://docs.expo.dev/tutorial/eas/multiple-app-variants
-const VARIANT_CONFIG: Record<Variant, AppVariantConfig> = {
+export const VARIANT_CONFIG: Record<Variant, AppVariantConfig> = {
   development: {
     name: 'Foam (dev)',
     icon: './assets/splash/splash-image-production.png',

--- a/scripts/workflows/verify-google-service-files-cli.ts
+++ b/scripts/workflows/verify-google-service-files-cli.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { VARIANT_CONFIG } from '../../app.config';
+import { getRequiredArg } from './github-actions';
+import {
+  getBuildVariant,
+  verifyGoogleServiceFiles,
+} from './verifyGoogleServiceFiles';
+
+function main(): void {
+  const variant = getBuildVariant(
+    getRequiredArg(process.argv.slice(2), 'variant'),
+  );
+  const config = VARIANT_CONFIG[variant];
+
+  const read = (file: string) => {
+    try {
+      return readFileSync(resolve(process.cwd(), file), 'utf8');
+    } catch {
+      throw new Error(`${file} was not written for variant ${variant}`);
+    }
+  };
+
+  const problems = verifyGoogleServiceFiles({
+    variant,
+    androidContents: read(config.androidGoogleServicesFile),
+    iosContents: read(config.iosGoogleServicesFile),
+  });
+
+  problems.forEach(({ severity, file, message }) => {
+    console.error(`::${severity}::${file} ${message}`);
+  });
+
+  if (problems.some(({ severity }) => severity === 'error')) {
+    process.exit(1);
+  }
+
+  process.stdout.write(
+    `Google service files checked against ${config.androidPackageName} and ${config.iosBundleIdentifier}`,
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`::error::${message}`);
+  process.exit(1);
+}

--- a/scripts/workflows/verifyGoogleServiceFiles.ts
+++ b/scripts/workflows/verifyGoogleServiceFiles.ts
@@ -1,0 +1,107 @@
+import { type Variant, VARIANT_CONFIG } from '../../app.config';
+
+export type GoogleServiceFileProblem = {
+  severity: 'error' | 'warning';
+  file: string;
+  message: string;
+};
+
+type AndroidGoogleServices = {
+  client?: {
+    client_info?: {
+      android_client_info?: {
+        package_name?: string;
+      };
+    };
+  }[];
+};
+
+export function isBuildVariant(value: string): value is Variant {
+  return Object.prototype.hasOwnProperty.call(VARIANT_CONFIG, value);
+}
+
+export function getBuildVariant(value: string): Variant {
+  if (!isBuildVariant(value)) {
+    throw new Error(
+      `Unsupported variant: ${value}. Expected one of ${Object.keys(VARIANT_CONFIG).join(', ')}`,
+    );
+  }
+
+  return value;
+}
+
+export function androidPackageNames(contents: string): string[] {
+  const parsed = JSON.parse(contents) as AndroidGoogleServices;
+
+  return (parsed.client ?? []).flatMap(
+    client => client.client_info?.android_client_info?.package_name ?? [],
+  );
+}
+
+/**
+ * Reads `BUNDLE_ID` out of a GoogleService-Info plist. Firebase writes a flat
+ * `<key>`/`<string>` pair, so this does not need a plist parser.
+ */
+export function plistBundleId(contents: string): string | undefined {
+  return /<key>BUNDLE_ID<\/key>\s*<string>([^<]*)<\/string>/.exec(
+    contents,
+  )?.[1];
+}
+
+/**
+ * Every variant decodes the same pair of secrets, so a file that is right for
+ * one is silently wrong for another.
+ *
+ * A missing Android client is an error because Gradle fails on it anyway, just
+ * 15 minutes later in `processReleaseGoogleServices`. A mismatched iOS bundle
+ * id is only a warning: nothing fails on it today, so blocking the deploy
+ * would be a new failure rather than an earlier one.
+ */
+export function verifyGoogleServiceFiles({
+  variant,
+  androidContents,
+  iosContents,
+}: {
+  variant: Variant;
+  androidContents: string;
+  iosContents: string;
+}): GoogleServiceFileProblem[] {
+  const config = VARIANT_CONFIG[variant];
+  const problems: GoogleServiceFileProblem[] = [];
+
+  let packageNames: string[] | undefined;
+  try {
+    packageNames = androidPackageNames(androidContents);
+  } catch {
+    problems.push({
+      severity: 'error',
+      file: config.androidGoogleServicesFile,
+      message: 'is not valid JSON. Check the secret holds base64 of the file.',
+    });
+  }
+
+  if (packageNames && !packageNames.includes(config.androidPackageName)) {
+    problems.push({
+      severity: 'error',
+      file: config.androidGoogleServicesFile,
+      message: `has no client for '${config.androidPackageName}'. It has ${packageNames.map(name => `'${name}'`).join(', ') || 'no clients'}. Add the app in Firebase and re-upload the file to the variant's secret.`,
+    });
+  }
+
+  const bundleId = plistBundleId(iosContents);
+  if (bundleId === undefined) {
+    problems.push({
+      severity: 'error',
+      file: config.iosGoogleServicesFile,
+      message: 'has no BUNDLE_ID. Check the secret holds base64 of the plist.',
+    });
+  } else if (bundleId !== config.iosBundleIdentifier) {
+    problems.push({
+      severity: 'warning',
+      file: config.iosGoogleServicesFile,
+      message: `is for '${bundleId}', but this variant builds '${config.iosBundleIdentifier}'. Firebase does not fail the build on this, so the app reports to the wrong project.`,
+    });
+  }
+
+  return problems;
+}

--- a/scripts/workflows/verifyGoogleServiceFiles.ts
+++ b/scripts/workflows/verifyGoogleServiceFiles.ts
@@ -49,13 +49,12 @@ export function plistBundleId(contents: string): string | undefined {
 }
 
 /**
- * Every variant decodes the same pair of secrets, so a file that is right for
- * one is silently wrong for another.
+ * Android takes a per-variant file, so the wrong secret means Gradle dies in
+ * `processReleaseGoogleServices` - but only after the whole native build has
+ * run. Checking here turns that into a one-second failure naming the package.
  *
- * A missing Android client is an error because Gradle fails on it anyway, just
- * 15 minutes later in `processReleaseGoogleServices`. A mismatched iOS bundle
- * id is only a warning: nothing fails on it today, so blocking the deploy
- * would be a new failure rather than an earlier one.
+ * iOS deliberately shares one plist across variants, so its BUNDLE_ID is not
+ * expected to match the variant being built and is only checked for presence.
  */
 export function verifyGoogleServiceFiles({
   variant,
@@ -88,18 +87,11 @@ export function verifyGoogleServiceFiles({
     });
   }
 
-  const bundleId = plistBundleId(iosContents);
-  if (bundleId === undefined) {
+  if (plistBundleId(iosContents) === undefined) {
     problems.push({
       severity: 'error',
       file: config.iosGoogleServicesFile,
       message: 'has no BUNDLE_ID. Check the secret holds base64 of the plist.',
-    });
-  } else if (bundleId !== config.iosBundleIdentifier) {
-    problems.push({
-      severity: 'warning',
-      file: config.iosGoogleServicesFile,
-      message: `is for '${bundleId}', but this variant builds '${config.iosBundleIdentifier}'. Firebase does not fail the build on this, so the app reports to the wrong project.`,
     });
   }
 

--- a/test/workflows.test.ts
+++ b/test/workflows.test.ts
@@ -60,6 +60,13 @@ import {
   sentrySizeAnalysisBuildConfigurationFor,
   variantLabel,
 } from '../scripts/workflows/variant';
+import {
+  androidPackageNames,
+  getBuildVariant,
+  type GoogleServiceFileProblem,
+  plistBundleId,
+  verifyGoogleServiceFiles,
+} from '../scripts/workflows/verifyGoogleServiceFiles';
 
 function createMemoryCopier(remotes: string[] = []): {
   copier: S3Copier;
@@ -791,6 +798,96 @@ describe('s3Cache', () => {
         rmSync(dir, { recursive: true, force: true });
       }
     });
+  });
+});
+
+describe('verifyGoogleServiceFiles', () => {
+  const androidFileFor = (...packageNames: string[]) =>
+    JSON.stringify({
+      client: packageNames.map(packageName => ({
+        client_info: { android_client_info: { package_name: packageName } },
+      })),
+    });
+
+  const iosFileFor = (bundleId: string) =>
+    `<plist><dict><key>BUNDLE_ID</key><string>${bundleId}</string></dict></plist>`;
+
+  test('reads the package names out of a Firebase android file', () => {
+    expect(
+      androidPackageNames(androidFileFor('com.lhowsam.foam_tv', 'other')),
+    ).toEqual(['com.lhowsam.foam_tv', 'other']);
+  });
+
+  test('reads the bundle id out of a GoogleService-Info plist', () => {
+    expect(plistBundleId(iosFileFor('foam-tv'))).toEqual('foam-tv');
+  });
+
+  test('accepts files that match the variant', () => {
+    expect(
+      verifyGoogleServiceFiles({
+        variant: 'production',
+        androidContents: androidFileFor('com.lhowsam.foam_tv'),
+        iosContents: iosFileFor('foam-tv'),
+      }),
+    ).toEqual([]);
+  });
+
+  /**
+   * The failure this check exists for: Gradle's processReleaseGoogleServices
+   * dies on it, but only after the whole native build has run.
+   */
+  test('errors when the android file has no client for the variant', () => {
+    const [problem] = verifyGoogleServiceFiles({
+      variant: 'production',
+      androidContents: androidFileFor('com.lhowsam.foam.internal'),
+      iosContents: iosFileFor('foam-tv'),
+    });
+
+    expect(problem).toEqual<GoogleServiceFileProblem>({
+      severity: 'error',
+      file: './google-services-prod.json',
+      message:
+        "has no client for 'com.lhowsam.foam_tv'. It has 'com.lhowsam.foam.internal'. Add the app in Firebase and re-upload the file to the variant's secret.",
+    });
+  });
+
+  test('errors when the android file is not valid JSON', () => {
+    const [problem] = verifyGoogleServiceFiles({
+      variant: 'production',
+      androidContents: 'not json',
+      iosContents: iosFileFor('foam-tv'),
+    });
+
+    expect(problem?.severity).toEqual('error');
+  });
+
+  test('warns rather than errors when the ios bundle id does not match', () => {
+    const [problem] = verifyGoogleServiceFiles({
+      variant: 'internal',
+      androidContents: androidFileFor('com.lhowsam.foam.internal'),
+      iosContents: iosFileFor('foam-tv'),
+    });
+
+    expect(problem).toEqual<GoogleServiceFileProblem>({
+      severity: 'warning',
+      file: './GoogleService-Info-internal.plist',
+      message:
+        "is for 'foam-tv', but this variant builds 'foam-tv-internal'. Firebase does not fail the build on this, so the app reports to the wrong project.",
+    });
+  });
+
+  test('errors when the plist has no bundle id at all', () => {
+    const [problem] = verifyGoogleServiceFiles({
+      variant: 'production',
+      androidContents: androidFileFor('com.lhowsam.foam_tv'),
+      iosContents: '<plist><dict></dict></plist>',
+    });
+
+    expect(problem?.severity).toEqual('error');
+  });
+
+  test('rejects a variant the app config does not define', () => {
+    expect(() => getBuildVariant('nope')).toThrow('Unsupported variant: nope');
   });
 });
 

--- a/test/workflows.test.ts
+++ b/test/workflows.test.ts
@@ -861,19 +861,18 @@ describe('verifyGoogleServiceFiles', () => {
     expect(problem?.severity).toEqual('error');
   });
 
-  test('warns rather than errors when the ios bundle id does not match', () => {
-    const [problem] = verifyGoogleServiceFiles({
-      variant: 'internal',
-      androidContents: androidFileFor('com.lhowsam.foam.internal'),
-      iosContents: iosFileFor('foam-tv'),
-    });
-
-    expect(problem).toEqual<GoogleServiceFileProblem>({
-      severity: 'warning',
-      file: './GoogleService-Info-internal.plist',
-      message:
-        "is for 'foam-tv', but this variant builds 'foam-tv-internal'. Firebase does not fail the build on this, so the app reports to the wrong project.",
-    });
+  /**
+   * One plist is shared across variants on purpose, so its BUNDLE_ID belongs
+   * to whichever variant it was exported for and must not be flagged.
+   */
+  test('accepts an ios plist whose bundle id is another variant', () => {
+    expect(
+      verifyGoogleServiceFiles({
+        variant: 'internal',
+        androidContents: androidFileFor('com.lhowsam.foam.internal'),
+        iosContents: iosFileFor('com.lhowsam.foam'),
+      }),
+    ).toEqual([]);
   });
 
   test('errors when the plist has no bundle id at all', () => {


### PR DESCRIPTION
# Why

The production Android deploy ([run 30363702276](https://github.com/luke-h1/foam/actions/runs/30363702276)) failed 15 minutes into the native build:

```
Execution failed for task ':app:processReleaseGoogleServices'.
> No matching client found for package name 'com.lhowsam.foam_tv' in android/app/google-services.json
```

`write-google-service-files` decoded `GOOGLE_SERVICES_ANDROID_PROD_BS4` for **every** variant and only varied the filename it wrote it to. So internal and testflight Android builds were getting production's `google-services.json`. That holds up only while one file happens to carry every package we build, and production's copy predated the `com.lhowsam.foam_tv` Firebase app - it had `com.lhowsam.foam`, `.dev` and `.preview` and nothing else.

`GOOGLE_SERVICES_ANDROID_INTERNAL_BS4` and `GOOGLE_SERVICES_ANDROID_TESTFLIGHT_BS4` were already in the 1Password item, already carrying the right clients. Nothing read them.

# How

Android takes a per-variant secret; iOS keeps the single shared plist, which is deliberate - one Firebase iOS app across variants.

- `write-google-service-files` selects the Android secret by variant and errors naming the specific secret if it is unset.
- `load-native-deploy-secrets` loads the internal and testflight Android secrets alongside the production one.
- A verify step after the decode checks the decoded Android file actually contains a client for the package being built. Gradle fails on this anyway, so it is the same failure a second in with the package name in the message rather than buried in a native build log.
- Expected packages and filenames both come from `app.config.ts`'s `VARIANT_CONFIG` (now exported), so the check cannot drift from what the build uses.

The iOS plist is only checked for having a `BUNDLE_ID` at all, not for matching the variant, since sharing it is intentional.

## 1Password

`op://ci-cd/foam-mobile-production/GOOGLE_SERVICES_ANDROID_PROD_BS4` has been updated with the current Firebase export for `foam-a434d` (`firebase apps:sdkconfig ANDROID`), which registers all six Android apps including `com.lhowsam.foam_tv`. Verified by reading it back and decoding. The previous value is preserved locally in case a rollback is wanted.

That alone unblocks the deploy - this PR is what stops it recurring silently.

# Test Plan

Reproduced the original failure by putting the internal-era file where production expects it:

```
::error::./google-services-prod.json has no client for 'com.lhowsam.foam_tv'. It has
'com.lhowsam.foam', 'com.lhowsam.foam.dev', 'com.lhowsam.foam.internal',
'com.lhowsam.foam.preview'. Add the app in Firebase and re-upload the file to the
variant's secret.
[exit=1]
```

Then ran the updated selection logic against the **real** 1Password secrets, decoding each variant's file and checking it carries that variant's package:

```
production -> google-services-prod.json       : OK com.lhowsam.foam_tv
internal   -> google-services-internal.json   : OK com.lhowsam.foam.internal
testflight -> google-services-testflight.json : OK com.lhowsam.foam.testflight
```

Nine unit tests in `test/workflows.test.ts` cover the parsers, the matching case, the missing-client error, malformed input, a plist with no `BUNDLE_ID`, an unknown variant, and that a shared plist belonging to another variant is accepted rather than flagged.

317 suites / 9828 tests passing, `tsc --noEmit` clean, prettier clean, both action YAMLs parse. `scripts/workflows/` is eslint-ignored in this repo, so the new files are covered by prettier and tsc only.

# Note

The staging item's `GOOGLE_SERVICES_ANDROID_PROD_BS4` is now unread - internal and testflight resolve their own secrets. Worth deleting once this lands so it cannot go stale unnoticed the same way.
