### PR TITLE
fix: android player freeze, android chat long-press, ios emote sheet hang

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -100,3 +100,4 @@ bun.lockb
 !.env
 
 profile-*.json
+playstore-service-account.json

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ buildServer.json
 
 # unit tests
 junit-app.xml
+
+playstore-service-account.json

--- a/patches/expo-image@57.0.0.patch
+++ b/patches/expo-image@57.0.0.patch
@@ -1,3 +1,46 @@
+diff --git a/ios/AnimatedImage.swift b/ios/AnimatedImage.swift
+index 350c9e4d90680baf8370e49b3529f6e45781244e..fd438254be1cfd1b4c057a426fa95c9c20943824 100644
+--- a/ios/AnimatedImage.swift
++++ b/ios/AnimatedImage.swift
+@@ -8,16 +8,20 @@ internal import SDWebImage
+ final class AnimatedImage: SDAnimatedImage {
+   var frames: [SDImageFrame]?
+ 
++  var hasMultipleFrames: Bool {
++    return animatedImageFrameCount > 1
++  }
++
+   // MARK: - UIImage
+ 
+   override var images: [UIImage]? {
+-    preloadAllFrames()
+-    return frames?.map({ $0.image })
++    return nil
+   }
+ 
+   override var duration: TimeInterval {
+-    preloadAllFrames()
+-    return frames?.reduce(0, { $0 + $1.duration }) ?? 0.0
++    return (0..<animatedImageFrameCount).reduce(0.0) { total, index in
++      return total + animatedImageDuration(at: index)
++    }
+   }
+ 
+   // MARK: - SDAnimatedImage
+diff --git a/ios/Image.swift b/ios/Image.swift
+index 5c92efa2ec1ca32fc4c49b0e30f3f809259508f3..2c2dd898a9b5721ac16738640a06d80ebf259190 100644
+--- a/ios/Image.swift
++++ b/ios/Image.swift
+@@ -8,6 +8,9 @@ internal final class Image: SharedRef<UIImage> {
+   }
+ 
+   var isAnimated: Bool {
++    if let animatedImage = ref as? AnimatedImage {
++      return animatedImage.hasMultipleFrames
++    }
+     return !(ref.images?.isEmpty ?? true)
+   }
+ 
 diff --git a/ios/ImageView.swift b/ios/ImageView.swift
 index cccedd7adf7328b18bb61333c3fe2473c79e72cd..8917134a516b206eda2bead68bbe151d8d3efc16 100644
 --- a/ios/ImageView.swift

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintLayerBackground.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintLayerBackground.tsx
@@ -72,6 +72,7 @@ export function PaintLayerBackground({
             layer.repeat,
           )}
           source={{ uri: layer.image_url }}
+          useAppleWebpCodec={false}
           style={styles.fill}
         />
       </View>

--- a/src/components/Chat/components/ChatMessage/RichChatMessageBody.tsx
+++ b/src/components/Chat/components/ChatMessage/RichChatMessageBody.tsx
@@ -130,6 +130,7 @@ export function RichChatMessageContainer({
     bodyVariant,
     clearRowLongPressTimer,
     compact,
+    handleRowTouchMove,
     customHighlightColor,
     isAlternatingRow,
     isAppSystemSender,
@@ -150,7 +151,7 @@ export function RichChatMessageContainer({
       testID='chat-message'
       onTouchCancel={clearRowLongPressTimer}
       onTouchEnd={clearRowLongPressTimer}
-      onTouchMove={clearRowLongPressTimer}
+      onTouchMove={handleRowTouchMove}
       onTouchStart={startRowLongPressTimer}
       style={[
         styles.chatContainer,

--- a/src/components/Chat/components/ChatMessage/__tests__/RichChatMessage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/__tests__/RichChatMessage.test.tsx
@@ -76,13 +76,24 @@ const createMockMessage = (
   };
 };
 
-function fireMessageLongPress(element: ReactTestInstance) {
+const touchAt = (pageX: number, pageY: number) => ({
+  nativeEvent: { pageX, pageY },
+});
+
+function fireMessageLongPress(
+  element: ReactTestInstance,
+  options: { driftDp?: number } = {},
+) {
+  const { driftDp = 0 } = options;
   jest.useFakeTimers();
-  fireEvent(element, 'touchStart');
+  fireEvent(element, 'touchStart', touchAt(100, 100));
+  if (driftDp > 0) {
+    fireEvent(element, 'touchMove', touchAt(100 + driftDp, 100));
+  }
   act(() => {
     jest.advanceTimersByTime(MESSAGE_LONG_PRESS_DELAY_MS);
   });
-  fireEvent(element, 'touchEnd');
+  fireEvent(element, 'touchEnd', touchAt(100 + driftDp, 100));
   jest.useRealTimers();
 }
 
@@ -179,6 +190,34 @@ describe('RichChatMessage', () => {
   });
 
   describe('Long Press Reply', () => {
+    test('survives the touch jitter android reports while a finger rests', () => {
+      const message = createMockMessage([
+        { type: 'text', content: 'Hello world!' },
+      ]);
+
+      const { getByTestId } = render(
+        <RichChatMessage {...message} onReply={mockOnReply} />,
+      );
+
+      fireMessageLongPress(getByTestId('chat-message'), { driftDp: 4 });
+
+      expect(mockOnReply).toHaveBeenCalledTimes(1);
+    });
+
+    test('cancels once the finger drifts past the tolerance', () => {
+      const message = createMockMessage([
+        { type: 'text', content: 'Hello world!' },
+      ]);
+
+      const { getByTestId } = render(
+        <RichChatMessage {...message} onReply={mockOnReply} />,
+      );
+
+      fireMessageLongPress(getByTestId('chat-message'), { driftDp: 40 });
+
+      expect(mockOnReply).not.toHaveBeenCalled();
+    });
+
     test('should call onReply when message is long pressed (regular messages)', () => {
       const message = createMockMessage([
         { type: 'text', content: 'Hello world!' },

--- a/src/components/Chat/components/ChatMessage/useRichChatMessage.ts
+++ b/src/components/Chat/components/ChatMessage/useRichChatMessage.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { GestureResponderEvent } from 'react-native';
 
 import { useMappingHelper } from '@shopify/flash-list';
 
@@ -25,6 +26,8 @@ import type {
 } from './RichChatMessage.types';
 
 export const MESSAGE_LONG_PRESS_DELAY_MS = 650;
+
+const LONG_PRESS_MOVE_TOLERANCE_DP = 10;
 
 export function useRichChatMessage<
   TNoticeType extends NoticeVariants,
@@ -124,6 +127,7 @@ export function useRichChatMessage<
   // the single row-level long-press timer can open the emote sheet without a
   // Pressable per emote (busy rows would mount hundreds of them).
   const pressedEmotePartRef = useRef<EmotePressData | null>(null);
+  const rowTouchOriginRef = useRef<{ x: number; y: number } | null>(null);
 
   useEffect(() => {
     return () => {
@@ -167,7 +171,23 @@ export function useRichChatMessage<
 
   const clearRowLongPressTimer = () => {
     pressedEmotePartRef.current = null;
+    rowTouchOriginRef.current = null;
     stopRowLongPressTimer();
+  };
+
+  const handleRowTouchMove = (event: GestureResponderEvent) => {
+    const origin = rowTouchOriginRef.current;
+    if (!origin) {
+      return;
+    }
+
+    const { pageX, pageY } = event.nativeEvent;
+    if (
+      Math.abs(pageX - origin.x) > LONG_PRESS_MOVE_TOLERANCE_DP ||
+      Math.abs(pageY - origin.y) > LONG_PRESS_MOVE_TOLERANCE_DP
+    ) {
+      clearRowLongPressTimer();
+    }
   };
 
   useEffect(
@@ -286,10 +306,14 @@ export function useRichChatMessage<
     });
   };
 
-  const startRowLongPressTimer = () => {
+  const startRowLongPressTimer = (event: GestureResponderEvent) => {
     // Only stop the timer here: the pressed emote (if any) was just recorded
     // by the emote's own onTouchStart, which bubbles before the row's.
     stopRowLongPressTimer();
+    rowTouchOriginRef.current = {
+      x: event.nativeEvent.pageX,
+      y: event.nativeEvent.pageY,
+    };
     rowLongPressTimerRef.current = setTimeout(() => {
       rowLongPressTimerRef.current = null;
       const pressedEmotePart = pressedEmotePartRef.current;
@@ -335,6 +359,7 @@ export function useRichChatMessage<
     canJumpToReplyTarget,
     clearRowLongPressTimer,
     closeEmoteActionSheet,
+    handleRowTouchMove,
     compact,
     customHighlightColor: customHighlight?.color,
     disableEmoteAnimations,

--- a/src/components/Chat/components/UserCardHeader.tsx
+++ b/src/components/Chat/components/UserCardHeader.tsx
@@ -101,6 +101,7 @@ export function UserCardHeader({
             <View style={styles.chip}>
               <Image
                 source={{ uri: sevenTvBadge.url }}
+                useAppleWebpCodec={false}
                 style={styles.badgeImage}
               />
               <Text style={styles.chipText} numberOfLines={1}>

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -52,6 +52,7 @@ export const Image = function Image({
   onLoadEnd,
   onLoadStart,
   style,
+  useAppleWebpCodec = false,
   ...props
 }: ImageProps) {
   const url = getSourceUrl(source);
@@ -161,7 +162,7 @@ export const Image = function Image({
          * needless teardown of the native image.
          */
         recyclingKey={recyclingKey ?? url ?? undefined}
-        useAppleWebpCodec
+        useAppleWebpCodec={useAppleWebpCodec}
         placeholderContentFit={placeholderContentFit ?? 'cover'}
         onLoad={handleLoad}
         onError={handleError}

--- a/src/components/StreamPlayer/StreamPlayerWebView.tsx
+++ b/src/components/StreamPlayer/StreamPlayerWebView.tsx
@@ -135,9 +135,7 @@ export const StreamPlayerWebView = memo(function StreamPlayerWebView({
       allowsInlineMediaPlayback
       allowsAirPlayForMediaPlayback={false}
       allowsPictureInPictureMediaPlayback={PIP_ENABLED}
-      androidLayerType='hardware'
       cacheEnabled
-      cacheMode='LOAD_CACHE_ELSE_NETWORK'
       domStorageEnabled
       javaScriptEnabled
       javaScriptCanOpenWindowsAutomatically

--- a/src/lib/expo-image/__tests__/resolveUseAppleWebpCodec.test.ts
+++ b/src/lib/expo-image/__tests__/resolveUseAppleWebpCodec.test.ts
@@ -1,0 +1,22 @@
+import { resolveUseAppleWebpCodec } from '@app/lib/expo-image/resolveUseAppleWebpCodec';
+
+test('keeps known-animated urls on libwebp', () => {
+  expect(resolveUseAppleWebpCodec('animated')).toBe(false);
+  expect(
+    resolveUseAppleWebpCodec('animated', { preferAppleCodecForStatic: true }),
+  ).toBe(false);
+});
+
+test('keeps urls of unknown kind on libwebp', () => {
+  expect(resolveUseAppleWebpCodec(null)).toBe(false);
+  expect(
+    resolveUseAppleWebpCodec(null, { preferAppleCodecForStatic: true }),
+  ).toBe(false);
+});
+
+test('opts into the apple codec only for proven-static urls', () => {
+  expect(
+    resolveUseAppleWebpCodec('static', { preferAppleCodecForStatic: true }),
+  ).toBe(true);
+  expect(resolveUseAppleWebpCodec('static')).toBe(false);
+});

--- a/src/lib/expo-image/resolveUseAppleWebpCodec.ts
+++ b/src/lib/expo-image/resolveUseAppleWebpCodec.ts
@@ -6,19 +6,12 @@ type EmoteUrlKind = EmoteUrlDescriptor['kind'];
  * expo-image's Apple WebP codec is faster and lighter but plays animated WebP
  * at the wrong framerate (see expo-image docs on `useAppleWebpCodec`). Force
  * the standards-compliant libwebp path for known-animated urls so chat emotes
- * and picker previews play at full FPS; leave static/unknown urls on the fast
- * Apple codec when `preferAppleCodecForStatic` is set, otherwise expo-image's
- * default.
+ * and picker previews play at full FPS; only opt into the Apple codec for urls
+ * we can prove are static.
  */
 export function resolveUseAppleWebpCodec(
   urlKind: EmoteUrlKind,
   options?: { preferAppleCodecForStatic?: boolean },
-): boolean | undefined {
-  if (urlKind === 'animated') {
-    return false;
-  }
-  if (options?.preferAppleCodecForStatic) {
-    return true;
-  }
-  return undefined;
+): boolean {
+  return urlKind === 'static' && options?.preferAppleCodecForStatic === true;
 }


### PR DESCRIPTION
# Why

Three field bugs, plus a guard.

**iOS emote sheet freezes.** Sentry `FOAM-TV-MOBILE-W` is a fatal App Hang still firing on 1.0.5 build 311. The main-thread stack is unambiguous:

```
CA::Transaction::commit -> CA::Layer::prepare_commit
  -> -[CAKeyframeAnimation CA_prepareRenderValue] -> CA::Render::prepare_image
  -> IIOImageProviderInfo::CopyImageBlockSetWithOptions
  -> WebPReadPlugin::decodeAnimatedWebP -> WebPAnimDecoderGetNext -> VP8Decode
```

That is animated WebP being rasterised on the main thread inside the CoreAnimation commit. The earlier accessibility-snapshot diagnosis was wrong (Seer still repeats it).

**Android player plays a frame or two then freezes.** Audio keeps going, picture stops.

**Android chat can't open emote details.** The message long-press was also dead.

# How

**Images.** expo-image's `AnimatedImage` overrides `SDAnimatedImage.images`, which stock SDWebImage deliberately returns nil for. Because it is non-nil, `SDAnimatedImageView.m:195` hands a `UIAnimatedImage` to `UIImageView`, which installs its own `CAKeyframeAnimation` on top of SDWebImage's off-thread player. With the Apple/ImageIO webp coder those frames are lazy `CGImage`s (`SDImageIOAnimatedCoder.m:713` decodes with `lazyDecode:YES`), so `CA_prepareRenderValue` rasterises all of them on the main thread. The emote sheet commits ~100 cells in one transaction, hence multi-second blocks.

The patch makes `images` return nil so animation is left entirely to `SDAnimatedImagePlayer`, and sums `duration` from the coder rather than preloading frames. `Image.isAnimated` backed `ImageRef.isAnimated`, which `cache-service.ts:320` and `ChatInlineImage.tsx:248` use as the unknown-url-kind fallback, so it now asks the coder's frame count first.

Side effect worth knowing: `SDAnimatedImageView.stopAnimating` only pauses its own player and never calls super, so while `images` was non-nil UIKit kept keyframe-animating regardless. `autoplay={false}`, the emote sheet's 24-concurrent animation budget and the scroll-pause were all no-ops on iOS. They work now.

The JS half stops handing possibly-animated webp to the Apple codec at all, since only that half is OTA-shippable. The `Image` wrapper hardcoded `useAppleWebpCodec`, the resolver returned `true`/`undefined` for unknown url kinds (and `undefined` falls through to expo-image's native default of `true`), and `PaintLayerBackground` / `UserCardHeader` use expo-image directly. Paints matter most there: `pickBestPaintLayerImage` prefers animated webp and they render once per painted username.

**Player.** `androidLayerType='hardware'` renders the whole WebView into one offscreen texture that is only redrawn on invalidation, so continuously-updating inline video stops propagating after the first composited frames. The WebView is GPU-composited under `LAYER_TYPE_NONE` anyway. Also dropped `cacheMode='LOAD_CACHE_ELSE_NETWORK'`, which serves expired resources to a live player and fights `cacheEnabled` (both write `settings.cacheMode`, last prop applied wins; `cacheEnabled` already sets `LOAD_DEFAULT`).

Both are android-only props added in #605, months before the app shipped on android in #779, so they were tuned against iOS which ignores them.

This is invisible to telemetry, which is why Sentry looked clean: the page's `<video>` stays healthy, so `stream.player.load` spans report `ok` on Android (5 ok, 0 error) and the `currentTime`-based stall detector never fires. 43 `stream.player.start` vs 1 `stream.player.load_failed` over 14 days.

**Chat.** The row cancelled its 650ms long-press timer on *any* `onTouchMove`. Android emits `ACTION_MOVE` continuously from touch jitter while a finger rests, so the timer never survived. Now cancels only past 10dp of drift.

# Test Plan

Automated: 318 suites / 9833 tests, `ts:check`, `lint`, `format:check`, `lint:ast-grep`, `test:ast-grep` all pass locally.

- Two new `RichChatMessage` tests cover both sides of the tolerance. Verified they fail when the tolerance is set to 0, so they are real regression tests.
- New `resolveUseAppleWebpCodec` tests pin the static-only rule.
- `xcodebuild -workspace ios/Foamdev.xcworkspace -scheme ExpoImage -sdk iphonesimulator` succeeds, and the patch re-applies cleanly after `rm -rf node_modules/expo-image && bun install`.

Not yet verified on device - all three fixes are reasoned from platform behaviour, so they need a smoke test before release:

- **Android player**: open a live channel, confirm video keeps rendering past the first seconds.
- **Android chat**: press and hold an emote, confirm the detail sheet opens; same for a plain message.
- **iOS emote sheet**: open the picker on a channel with many animated emotes and confirm no hang. Also worth watching that the animation budget now visibly caps concurrent animations, since it was previously inert.

The expo-image change is a native patch, so it needs a native rebuild before the next OTA.

## Follow-up, not in this PR

Android `eas submit` fails with `The service account is missing the necessary permissions`, naming `firebase-adminsdk-fbsvc@expo-notifications-eas` - the EAS-server-stored Android key is the Firebase push key, which has no Play Console permissions. The fix is to upload `foam-android-testtrack@foam-456217` to EAS credentials so local and CI both work; pointing `eas.json` at a gitignored local key would have fixed only local, since CI's submit step never provisions that file. This PR only adds the ignore entries so such a key cannot be committed.
