### PR TITLE
perf(chat): stop mention autocomplete rebuilding a collator per comparison

### DIFF
--- a/src/components/Chat/components/ChatComposer/hooks/useUserSuggestions.ts
+++ b/src/components/Chat/components/ChatComposer/hooks/useUserSuggestions.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useDeferredValue, useEffect, useMemo } from 'react';
 
 import { useSelector } from '@legendapp/state/react';
 
@@ -30,6 +30,11 @@ export function useUserSuggestions({
 }: UseUserSuggestionsProps) {
   const mentionLoginRevision = useSelector(chatStore$.mentionLoginRevision);
   const cleanSearch = searchTerm.slice(1).toLowerCase().trim();
+  /**
+   * The search scans both mention indexes, so it trails the keystroke rather
+   * than sharing a frame with the character the composer is echoing.
+   */
+  const deferredSearch = useDeferredValue(cleanSearch);
 
   useEffect(() => {
     if (!enabled || cleanSearch.length < 2) {
@@ -40,16 +45,16 @@ export function useUserSuggestions({
   }, [cleanSearch, enabled]);
 
   const filteredUsers = useMemo(() => {
-    if (!enabled || !searchTerm.trim() || cleanSearch.length < 1) {
+    if (!enabled || deferredSearch.length < 1) {
       return [];
     }
 
     return searchMentionChatters(
-      cleanSearch,
+      deferredSearch,
       maxSuggestions,
       mentionLoginRevision,
     ).map(toChatUser);
-  }, [cleanSearch, enabled, maxSuggestions, mentionLoginRevision, searchTerm]);
+  }, [deferredSearch, enabled, maxSuggestions, mentionLoginRevision]);
 
   return {
     filteredUsers,

--- a/src/components/Chat/components/ChatComposer/hooks/useUserSuggestions.ts
+++ b/src/components/Chat/components/ChatComposer/hooks/useUserSuggestions.ts
@@ -35,6 +35,11 @@ export function useUserSuggestions({
    * than sharing a frame with the character the composer is echoing.
    */
   const deferredSearch = useDeferredValue(cleanSearch);
+  /**
+   * Deferring delays the search, not the clear - the deferred value still holds
+   * the previous mention for a render after the query empties.
+   */
+  const hasSearch = cleanSearch.length > 0;
 
   useEffect(() => {
     if (!enabled || cleanSearch.length < 2) {
@@ -45,7 +50,7 @@ export function useUserSuggestions({
   }, [cleanSearch, enabled]);
 
   const filteredUsers = useMemo(() => {
-    if (!enabled || deferredSearch.length < 1) {
+    if (!enabled || !hasSearch || deferredSearch.length < 1) {
       return [];
     }
 
@@ -54,7 +59,13 @@ export function useUserSuggestions({
       maxSuggestions,
       mentionLoginRevision,
     ).map(toChatUser);
-  }, [deferredSearch, enabled, maxSuggestions, mentionLoginRevision]);
+  }, [
+    deferredSearch,
+    enabled,
+    hasSearch,
+    maxSuggestions,
+    mentionLoginRevision,
+  ]);
 
   return {
     filteredUsers,

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameSkia.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameSkia.tsx
@@ -296,6 +296,7 @@ export function PaintedUsernameSkia({
       return;
     }
     if (!retainPaintBitmaps(bitmaps)) {
+      // react-doctor-disable-next-line react-hooks-js/set-state-in-effect -- recovery branch, not a cascade: it only runs when disposal beat this retain, and the entry cannot be re-derived before render because retaining during render would leak on a discarded one
       setRebuildToken(token => token + 1);
       return;
     }

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameSkia.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameSkia.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useMemo } from 'react';
+import { type ReactNode, useEffect, useMemo } from 'react';
 import { PixelRatio } from 'react-native';
 
 import {
@@ -14,6 +14,10 @@ import { Text } from '@app/components/ui/Text/Text';
 import { theme } from '@app/styles/themes';
 import type { PaintData } from '@app/types/seventv/cosmetics';
 
+import {
+  releasePaintBitmaps,
+  retainPaintBitmaps,
+} from './util/paintBitmapCacheLifecycle';
 import { useSharedPaintAnimationFrame } from './util/sharedPaintAnimationFrames';
 import {
   getPaintBitmaps,
@@ -269,6 +273,19 @@ export function PaintedUsernameSkia({
         : null,
     [fontProvider, username, paint, fallbackColor, fontSize, pixelRatio],
   );
+
+  /**
+   * Pins the entry's textures for as long as this canvas draws them, so an LRU
+   * eviction or a memory-warning clear cannot dispose a bitmap that is on
+   * screen.
+   */
+  useEffect(() => {
+    if (!bitmaps) {
+      return;
+    }
+    retainPaintBitmaps(bitmaps);
+    return () => releasePaintBitmaps(bitmaps);
+  }, [bitmaps]);
 
   if (!bitmaps) {
     return (

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameSkia.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameSkia.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useMemo } from 'react';
+import { type ReactNode, useLayoutEffect, useMemo, useState } from 'react';
 import { PixelRatio } from 'react-native';
 
 import {
@@ -257,6 +257,7 @@ export function PaintedUsernameSkia({
 }: PaintedUsernameSkiaProps) {
   const fontProvider = useSkiaPaintFontProvider();
   const pixelRatio = PixelRatio.get();
+  const [rebuildToken, setRebuildToken] = useState(0);
 
   const bitmaps = useMemo(
     () =>
@@ -271,19 +272,33 @@ export function PaintedUsernameSkia({
             fontFamily: 'Montserrat',
           })
         : null,
-    [fontProvider, username, paint, fallbackColor, fontSize, pixelRatio],
+    // rebuildToken re-reads the cache after a lost retain; see below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      fontProvider,
+      username,
+      paint,
+      fallbackColor,
+      fontSize,
+      pixelRatio,
+      rebuildToken,
+    ],
   );
 
   /**
-   * Pins the entry's textures for as long as this canvas draws them, so an LRU
-   * eviction or a memory-warning clear cannot dispose a bitmap that is on
-   * screen.
+   * Pins the textures while this canvas draws them, so an eviction or a
+   * memory-warning clear cannot dispose a bitmap that is on screen. Layout
+   * effect so the retain lands in the same commit as the render that read the
+   * entry; if disposal still won the race, rebuild rather than draw a dead one.
    */
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!bitmaps) {
       return;
     }
-    retainPaintBitmaps(bitmaps);
+    if (!retainPaintBitmaps(bitmaps)) {
+      setRebuildToken(token => token + 1);
+      return;
+    }
     return () => releasePaintBitmaps(bitmaps);
   }, [bitmaps]);
 

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/paintBitmapCacheLifecycle.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/paintBitmapCacheLifecycle.test.ts
@@ -10,11 +10,9 @@ import {
 
 interface FakeEntry extends DisposablePaintBitmaps {
   staticImage: { dispose: jest.Mock };
-  maskImage: { dispose: jest.Mock } | null;
-  strokeImage: { dispose: jest.Mock } | null;
-  layerSlots: (
-    { kind: 'baked'; image: { dispose: jest.Mock } } | { kind: 'url' }
-  )[];
+  maskImage: { dispose: jest.Mock };
+  strokeImage: { dispose: jest.Mock };
+  layerSlots: { kind: 'baked'; image: { dispose: jest.Mock } }[];
 }
 
 function createEntry({ bakedLayers = 0 }: { bakedLayers?: number } = {}) {
@@ -32,10 +30,10 @@ function createEntry({ bakedLayers = 0 }: { bakedLayers?: number } = {}) {
 function disposeCallCounts(entry: FakeEntry) {
   return {
     staticImage: entry.staticImage.dispose.mock.calls.length,
-    maskImage: entry.maskImage?.dispose.mock.calls.length ?? 0,
-    strokeImage: entry.strokeImage?.dispose.mock.calls.length ?? 0,
-    bakedLayers: entry.layerSlots.map(slot =>
-      slot.kind === 'baked' ? slot.image.dispose.mock.calls.length : 0,
+    maskImage: entry.maskImage.dispose.mock.calls.length,
+    strokeImage: entry.strokeImage.dispose.mock.calls.length,
+    bakedLayers: entry.layerSlots.map(
+      slot => slot.image.dispose.mock.calls.length,
     ),
   };
 }
@@ -204,6 +202,37 @@ describe('paintBitmapCacheLifecycle', () => {
       strokeImage: 1,
       bakedLayers: [],
     });
+  });
+
+  test('refuses a retain on an entry whose textures are already gone', () => {
+    const disposed = createEntry();
+    cachePaintBitmaps('disposed', disposed);
+
+    clearPaintBitmapCache();
+    flushFrames();
+
+    // The canvas lost the race: its commit landed after disposal ran, so it
+    // must rebuild rather than draw a dead texture.
+    expect(retainPaintBitmaps(disposed)).toBe(false);
+
+    // A refused retain must not resurrect the entry into the retain table, or
+    // a later release would dispose it a second time.
+    releasePaintBitmaps(disposed);
+    expect(disposeCallCounts(disposed)).toEqual({
+      staticImage: 1,
+      maskImage: 1,
+      strokeImage: 1,
+      bakedLayers: [],
+    });
+  });
+
+  test('accepts a retain on a live entry', () => {
+    const live = createEntry();
+    cachePaintBitmaps('live', live);
+
+    expect(retainPaintBitmaps(live)).toBe(true);
+
+    releasePaintBitmaps(live);
   });
 
   test('a canvas that mounts after eviction keeps the entry alive', () => {

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/paintBitmapCacheLifecycle.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/paintBitmapCacheLifecycle.test.ts
@@ -1,0 +1,237 @@
+import {
+  cachePaintBitmaps,
+  clearPaintBitmapCache,
+  type DisposablePaintBitmaps,
+  getCachedPaintBitmaps,
+  MAX_CACHED_PAINT_BITMAPS,
+  releasePaintBitmaps,
+  retainPaintBitmaps,
+} from '../paintBitmapCacheLifecycle';
+
+interface FakeEntry extends DisposablePaintBitmaps {
+  staticImage: { dispose: jest.Mock };
+  maskImage: { dispose: jest.Mock } | null;
+  strokeImage: { dispose: jest.Mock } | null;
+  layerSlots: (
+    { kind: 'baked'; image: { dispose: jest.Mock } } | { kind: 'url' }
+  )[];
+}
+
+function createEntry({ bakedLayers = 0 }: { bakedLayers?: number } = {}) {
+  return {
+    staticImage: { dispose: jest.fn() },
+    maskImage: { dispose: jest.fn() },
+    strokeImage: { dispose: jest.fn() },
+    layerSlots: Array.from({ length: bakedLayers }, () => ({
+      kind: 'baked' as const,
+      image: { dispose: jest.fn() },
+    })),
+  } satisfies FakeEntry;
+}
+
+function disposeCallCounts(entry: FakeEntry) {
+  return {
+    staticImage: entry.staticImage.dispose.mock.calls.length,
+    maskImage: entry.maskImage?.dispose.mock.calls.length ?? 0,
+    strokeImage: entry.strokeImage?.dispose.mock.calls.length ?? 0,
+    bakedLayers: entry.layerSlots.map(slot =>
+      slot.kind === 'baked' ? slot.image.dispose.mock.calls.length : 0,
+    ),
+  };
+}
+
+let frameCallbacks: FrameRequestCallback[] = [];
+
+/**
+ * Disposal is deferred two frames, so drain twice.
+ */
+function flushFrames(): void {
+  for (let frame = 0; frame < 2; frame += 1) {
+    const pending = frameCallbacks;
+    frameCallbacks = [];
+    pending.forEach(callback => callback(0));
+  }
+}
+
+beforeEach(() => {
+  frameCallbacks = [];
+  jest
+    .spyOn(globalThis, 'requestAnimationFrame')
+    .mockImplementation(callback => frameCallbacks.push(callback));
+});
+
+afterEach(() => {
+  clearPaintBitmapCache();
+  flushFrames();
+  jest.restoreAllMocks();
+});
+
+describe('paintBitmapCacheLifecycle', () => {
+  test('disposes every texture an evicted entry owns', () => {
+    const evicted = createEntry({ bakedLayers: 2 });
+    cachePaintBitmaps('evicted', evicted);
+
+    for (let index = 0; index < MAX_CACHED_PAINT_BITMAPS; index += 1) {
+      cachePaintBitmaps(`filler-${index}`, createEntry());
+    }
+    flushFrames();
+
+    expect(disposeCallCounts(evicted)).toEqual({
+      staticImage: 1,
+      maskImage: 1,
+      strokeImage: 1,
+      bakedLayers: [1, 1],
+    });
+  });
+
+  test('does not dispose an entry a mounted canvas still retains', () => {
+    const retained = createEntry({ bakedLayers: 1 });
+    cachePaintBitmaps('retained', retained);
+    retainPaintBitmaps(retained);
+
+    for (let index = 0; index < MAX_CACHED_PAINT_BITMAPS; index += 1) {
+      cachePaintBitmaps(`filler-${index}`, createEntry());
+    }
+    flushFrames();
+
+    expect(disposeCallCounts(retained)).toEqual({
+      staticImage: 0,
+      maskImage: 0,
+      strokeImage: 0,
+      bakedLayers: [0],
+    });
+  });
+
+  test('disposes a retained entry once the last canvas releases it', () => {
+    const retained = createEntry({ bakedLayers: 1 });
+    cachePaintBitmaps('retained', retained);
+    retainPaintBitmaps(retained);
+    retainPaintBitmaps(retained);
+
+    for (let index = 0; index < MAX_CACHED_PAINT_BITMAPS; index += 1) {
+      cachePaintBitmaps(`filler-${index}`, createEntry());
+    }
+    flushFrames();
+
+    releasePaintBitmaps(retained);
+
+    expect(disposeCallCounts(retained)).toEqual({
+      staticImage: 0,
+      maskImage: 0,
+      strokeImage: 0,
+      bakedLayers: [0],
+    });
+
+    releasePaintBitmaps(retained);
+
+    expect(disposeCallCounts(retained)).toEqual({
+      staticImage: 1,
+      maskImage: 1,
+      strokeImage: 1,
+      bakedLayers: [1],
+    });
+  });
+
+  test('leaves a released entry alone while it is still cached', () => {
+    const cached = createEntry();
+    cachePaintBitmaps('cached', cached);
+
+    retainPaintBitmaps(cached);
+    releasePaintBitmaps(cached);
+    flushFrames();
+
+    expect(disposeCallCounts(cached)).toEqual({
+      staticImage: 0,
+      maskImage: 0,
+      strokeImage: 0,
+      bakedLayers: [],
+    });
+    expect(getCachedPaintBitmaps('cached')).toBe(cached);
+  });
+
+  test('a cache hit refreshes recency so the entry survives eviction', () => {
+    const hit = createEntry();
+    cachePaintBitmaps('hit', hit);
+    cachePaintBitmaps('cold', createEntry());
+
+    expect(getCachedPaintBitmaps('hit')).toBe(hit);
+
+    for (let index = 0; index < MAX_CACHED_PAINT_BITMAPS - 1; index += 1) {
+      cachePaintBitmaps(`filler-${index}`, createEntry());
+    }
+    flushFrames();
+
+    expect(getCachedPaintBitmaps('cold')).toBeUndefined();
+    expect(getCachedPaintBitmaps('hit')).toBe(hit);
+  });
+
+  test('clearing disposes cached entries and drops them from the cache', () => {
+    const cleared = createEntry({ bakedLayers: 1 });
+    cachePaintBitmaps('cleared', cleared);
+
+    clearPaintBitmapCache();
+    flushFrames();
+
+    expect(disposeCallCounts(cleared)).toEqual({
+      staticImage: 1,
+      maskImage: 1,
+      strokeImage: 1,
+      bakedLayers: [1],
+    });
+    expect(getCachedPaintBitmaps('cleared')).toBeUndefined();
+  });
+
+  test('clearing spares an on-screen entry until it is released', () => {
+    const onScreen = createEntry();
+    cachePaintBitmaps('on-screen', onScreen);
+    retainPaintBitmaps(onScreen);
+
+    clearPaintBitmapCache();
+    flushFrames();
+
+    expect(disposeCallCounts(onScreen)).toEqual({
+      staticImage: 0,
+      maskImage: 0,
+      strokeImage: 0,
+      bakedLayers: [],
+    });
+
+    releasePaintBitmaps(onScreen);
+
+    expect(disposeCallCounts(onScreen)).toEqual({
+      staticImage: 1,
+      maskImage: 1,
+      strokeImage: 1,
+      bakedLayers: [],
+    });
+  });
+
+  test('a canvas that mounts after eviction keeps the entry alive', () => {
+    const evicted = createEntry();
+    cachePaintBitmaps('evicted', evicted);
+
+    for (let index = 0; index < MAX_CACHED_PAINT_BITMAPS; index += 1) {
+      cachePaintBitmaps(`filler-${index}`, createEntry());
+    }
+
+    // The retaining effect lands before the deferred flush runs.
+    retainPaintBitmaps(evicted);
+    flushFrames();
+
+    expect(disposeCallCounts(evicted)).toEqual({
+      staticImage: 0,
+      maskImage: 0,
+      strokeImage: 0,
+      bakedLayers: [],
+    });
+
+    releasePaintBitmaps(evicted);
+
+    expect(disposeCallCounts(evicted)).toEqual({
+      staticImage: 1,
+      maskImage: 1,
+      strokeImage: 1,
+      bakedLayers: [],
+    });
+  });
+});

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintBitmapCacheLifecycle.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintBitmapCacheLifecycle.ts
@@ -21,10 +21,8 @@ export interface DisposablePaintBitmaps {
 }
 
 /**
- * Bounded LRU over cache *entries*, not textures: each entry owns a foundation
- * bitmap plus an optional mask, stroke, and one baked bitmap per gradient run
- * that stacks above a URL layer. 7TV serves a few hundred paints in total, so
- * 256 entries covers a chat session's working set.
+ * Caps entries, not textures - one entry owns a foundation bitmap plus an
+ * optional mask, stroke, and a baked bitmap per gradient run above a URL layer.
  */
 export const MAX_CACHED_PAINT_BITMAPS = 256;
 
@@ -37,17 +35,22 @@ const cache = new Map<string, DisposablePaintBitmaps>();
 const retainCounts = new Map<DisposablePaintBitmaps, number>();
 
 /**
- * Evicted, not yet freed. Disposal is deferred two frames because
- * `PaintedUsernameSkia` retains in a passive effect, asynchronously after the
- * render that read the entry — freeing on eviction can race that effect and
- * hand an already-disposed texture to a canvas that is about to mount. By the
- * next frame the retain has landed, so an absent count reliably means nothing
- * is drawing it.
+ * Evicted, not yet freed. `PaintedUsernameSkia` retains in a layout effect, so
+ * the retain lands in the same commit as the render that read the entry — but
+ * a concurrent render can be interrupted between the two, so disposal is still
+ * deferred two frames rather than running on eviction.
  */
 const pendingDisposal = new Set<DisposablePaintBitmaps>();
 let disposalFlushScheduled = false;
 
+/**
+ * Lets a retain that lost the race above find out its textures are gone,
+ * rather than handing a dead entry to a canvas.
+ */
+const disposedEntries = new WeakSet<DisposablePaintBitmaps>();
+
 function disposeTextures(entry: DisposablePaintBitmaps): void {
+  disposedEntries.add(entry);
   entry.staticImage.dispose();
   entry.maskImage?.dispose();
   entry.strokeImage?.dispose();
@@ -103,18 +106,28 @@ export function cachePaintBitmaps(
   entry: DisposablePaintBitmaps,
 ): void {
   if (cache.size >= MAX_CACHED_PAINT_BITMAPS) {
-    const oldestKey = cache.keys().next().value;
-    const oldest = oldestKey === undefined ? undefined : cache.get(oldestKey);
-    if (oldestKey !== undefined && oldest !== undefined) {
+    const oldest = cache.entries().next().value;
+    if (oldest) {
+      const [oldestKey, oldestEntry] = oldest;
       cache.delete(oldestKey);
-      scheduleDisposal(oldest);
+      scheduleDisposal(oldestEntry);
     }
   }
   cache.set(key, entry);
 }
 
-export function retainPaintBitmaps(entry: DisposablePaintBitmaps): void {
+/**
+ * Pins an entry's textures for as long as a canvas draws them. Returns false if
+ * the entry was disposed before this retain landed — the caller must rebuild
+ * rather than draw it, which keeps the eviction race recoverable instead of
+ * putting a dead texture on screen.
+ */
+export function retainPaintBitmaps(entry: DisposablePaintBitmaps): boolean {
+  if (disposedEntries.has(entry)) {
+    return false;
+  }
   retainCounts.set(entry, (retainCounts.get(entry) ?? 0) + 1);
+  return true;
 }
 
 export function releasePaintBitmaps(entry: DisposablePaintBitmaps): void {

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintBitmapCacheLifecycle.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintBitmapCacheLifecycle.ts
@@ -3,13 +3,139 @@
  * importing the Skia rasterizer (keeps web / non-skia bundles free of that
  * dependency). Values are `PaintBitmaps` from the rasterizer.
  */
-export const MAX_CACHED_PAINT_BITMAPS = 256;
 
-export const paintBitmapCache = new Map<string, unknown>();
+interface DisposableTexture {
+  dispose(): void;
+}
 
 /**
- * Drop cached paint bitmaps (session reset / clear image cache).
+ * The disposable surface of `PaintBitmaps`. Declared structurally so this
+ * module never reaches for Skia, while a renamed or retyped field in the
+ * rasterizer still fails the typecheck at the `cachePaintBitmaps` call.
+ */
+export interface DisposablePaintBitmaps {
+  staticImage: DisposableTexture;
+  maskImage: DisposableTexture | null;
+  strokeImage: DisposableTexture | null;
+  layerSlots: ({ kind: 'baked'; image: DisposableTexture } | { kind: 'url' })[];
+}
+
+/**
+ * Bounded LRU over cache *entries*, not textures: each entry owns a foundation
+ * bitmap plus an optional mask, stroke, and one baked bitmap per gradient run
+ * that stacks above a URL layer. 7TV serves a few hundred paints in total, so
+ * 256 entries covers a chat session's working set.
+ */
+export const MAX_CACHED_PAINT_BITMAPS = 256;
+
+const cache = new Map<string, DisposablePaintBitmaps>();
+
+/**
+ * Retain counts for entries a mounted canvas is still drawing. Eviction only
+ * unlinks an entry from the cache; the last release frees its textures.
+ */
+const retainCounts = new Map<DisposablePaintBitmaps, number>();
+
+/**
+ * Evicted, not yet freed. Disposal is deferred two frames because
+ * `PaintedUsernameSkia` retains in a passive effect, asynchronously after the
+ * render that read the entry — freeing on eviction can race that effect and
+ * hand an already-disposed texture to a canvas that is about to mount. By the
+ * next frame the retain has landed, so an absent count reliably means nothing
+ * is drawing it.
+ */
+const pendingDisposal = new Set<DisposablePaintBitmaps>();
+let disposalFlushScheduled = false;
+
+function disposeTextures(entry: DisposablePaintBitmaps): void {
+  entry.staticImage.dispose();
+  entry.maskImage?.dispose();
+  entry.strokeImage?.dispose();
+  for (const slot of entry.layerSlots) {
+    if (slot.kind === 'baked') {
+      slot.image.dispose();
+    }
+  }
+}
+
+function flushPendingDisposal(): void {
+  disposalFlushScheduled = false;
+  for (const entry of [...pendingDisposal]) {
+    if (retainCounts.has(entry)) {
+      // A canvas mounted onto this entry after it was evicted; the matching
+      // release frees it instead.
+      continue;
+    }
+    pendingDisposal.delete(entry);
+    disposeTextures(entry);
+  }
+}
+
+function scheduleDisposal(entry: DisposablePaintBitmaps): void {
+  pendingDisposal.add(entry);
+  if (disposalFlushScheduled) {
+    return;
+  }
+  disposalFlushScheduled = true;
+  requestAnimationFrame(() => {
+    requestAnimationFrame(flushPendingDisposal);
+  });
+}
+
+/**
+ * Map iteration order is insertion order, so re-inserting on a hit keeps
+ * eviction least-recently-used rather than first-inserted.
+ */
+export function getCachedPaintBitmaps(
+  key: string,
+): DisposablePaintBitmaps | undefined {
+  const entry = cache.get(key);
+  if (entry === undefined) {
+    return undefined;
+  }
+  cache.delete(key);
+  cache.set(key, entry);
+  return entry;
+}
+
+export function cachePaintBitmaps(
+  key: string,
+  entry: DisposablePaintBitmaps,
+): void {
+  if (cache.size >= MAX_CACHED_PAINT_BITMAPS) {
+    const oldestKey = cache.keys().next().value;
+    const oldest = oldestKey === undefined ? undefined : cache.get(oldestKey);
+    if (oldestKey !== undefined && oldest !== undefined) {
+      cache.delete(oldestKey);
+      scheduleDisposal(oldest);
+    }
+  }
+  cache.set(key, entry);
+}
+
+export function retainPaintBitmaps(entry: DisposablePaintBitmaps): void {
+  retainCounts.set(entry, (retainCounts.get(entry) ?? 0) + 1);
+}
+
+export function releasePaintBitmaps(entry: DisposablePaintBitmaps): void {
+  const remaining = (retainCounts.get(entry) ?? 0) - 1;
+  if (remaining > 0) {
+    retainCounts.set(entry, remaining);
+    return;
+  }
+  retainCounts.delete(entry);
+  if (pendingDisposal.delete(entry)) {
+    disposeTextures(entry);
+  }
+}
+
+/**
+ * Drop cached paint bitmaps (session reset / clear image cache / memory
+ * warning). Entries still on screen are freed by their last release.
  */
 export function clearPaintBitmapCache(): void {
-  paintBitmapCache.clear();
+  for (const entry of cache.values()) {
+    scheduleDisposal(entry);
+  }
+  cache.clear();
 }

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/skiaPaintedUsernameRasterizer.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/skiaPaintedUsernameRasterizer.ts
@@ -27,9 +27,9 @@ import type {
 import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
 
 import {
+  cachePaintBitmaps,
   clearPaintBitmapCache,
-  MAX_CACHED_PAINT_BITMAPS,
-  paintBitmapCache,
+  getCachedPaintBitmaps,
 } from './paintBitmapCacheLifecycle';
 import { getPaintDropShadows } from './paintLayer/getPaintDropShadows';
 import { getPaintLayers } from './paintLayer/getPaintLayers';
@@ -751,11 +751,6 @@ function buildPaintLayerSlots(
   return { layerSlots, imageLayers };
 }
 
-/**
- * Bounded LRU: caps the cache at ~256 paint bitmaps (paint x user x fontSize
- * x pixelRatio). 7TV serves a few hundred paints in total; 256 covers the
- * working set of a chat session without letting the map grow unbounded.
- */
 export { clearPaintBitmapCache };
 
 let memoryWarningSubscribed = false;
@@ -800,14 +795,8 @@ export function getPaintBitmaps(
 ): PaintBitmaps | null {
   subscribeToMemoryWarnings();
   const key = paintBitmapCacheKey(opts);
-  const cached = paintBitmapCache.get(key) as PaintBitmaps | undefined;
+  const cached = getCachedPaintBitmaps(key) as PaintBitmaps | undefined;
   if (cached) {
-    /**
-     * Map iteration order is insertion order, so re-inserting on hit keeps
-     * eviction least-recently-used rather than first-inserted.
-     */
-    paintBitmapCache.delete(key);
-    paintBitmapCache.set(key, cached);
     return cached;
   }
 
@@ -899,12 +888,6 @@ export function getPaintBitmaps(
     },
   };
 
-  if (paintBitmapCache.size >= MAX_CACHED_PAINT_BITMAPS) {
-    const oldest = paintBitmapCache.keys().next().value;
-    if (oldest !== undefined) {
-      paintBitmapCache.delete(oldest);
-    }
-  }
-  paintBitmapCache.set(key, bitmaps);
+  cachePaintBitmaps(key, bitmaps);
   return bitmaps;
 }

--- a/src/components/Chat/hooks/__tests__/useChatMessages.test.ts
+++ b/src/components/Chat/hooks/__tests__/useChatMessages.test.ts
@@ -435,6 +435,89 @@ describe('useChatMessages', () => {
     });
   });
 
+  describe('Flush timer transitions', () => {
+    test('arms a fresh timer for a message arriving after a flush', () => {
+      const { result } = renderHook(() => useChatMessages(defaultOptions));
+
+      act(() => {
+        result.current.handleNewMessage(createMockMessage('1'));
+      });
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      expect(mockAddMessages).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        result.current.handleNewMessage(createMockMessage('2'));
+      });
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      expect(mockAddMessages).toHaveBeenCalledTimes(2);
+      expect(getLastFlushedMessages().map(m => m.message_id)).toEqual(['2']);
+    });
+
+    test('keeps the timer armed for a message queued while publishing', () => {
+      let hasQueued = false;
+      const { result } = renderHook(() =>
+        useChatMessages({
+          ...defaultOptions,
+          finalizeMessageForCommit: (message: BufferedMessage) => {
+            // Feeds a message back in mid-flush, which arms a timer while the
+            // flush that cleared the handle is still running.
+            if (!hasQueued) {
+              hasQueued = true;
+              result.current.handleNewMessage(createMockMessage('2'));
+            }
+            return message;
+          },
+        }),
+      );
+
+      act(() => {
+        result.current.handleNewMessage(createMockMessage('1'));
+      });
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      expect(getLastFlushedMessages().map(m => m.message_id)).toEqual(['1']);
+      expect(result.current.getBufferSize()).toBe(1);
+
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      expect(getLastFlushedMessages().map(m => m.message_id)).toEqual(['2']);
+      expect(result.current.getBufferSize()).toBe(0);
+    });
+
+    test('does not drain the same message twice across consecutive flushes', () => {
+      const { result } = renderHook(() => useChatMessages(defaultOptions));
+
+      act(() => {
+        result.current.handleNewMessage(createMockMessage('1'));
+      });
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+
+      const flushedIds = mockAddMessages.mock.calls.flatMap(([messages]) =>
+        (Array.isArray(messages) ? messages : [])
+          .filter(
+            (message): message is ChatMessageType<never> => message != null,
+          )
+          .map(message => message.message_id),
+      );
+      expect(flushedIds).toEqual(['1']);
+    });
+  });
+
   describe('Cleanup', () => {
     test('should clear flush timer on cleanup', () => {
       const { result } = renderHook(() => useChatMessages(defaultOptions));

--- a/src/components/Chat/hooks/useChatMessages.ts
+++ b/src/components/Chat/hooks/useChatMessages.ts
@@ -94,7 +94,20 @@ export const useChatMessages = (options: UseChatMessagesOptions) => {
   });
 
   const flushBuffer = useCallback(() => {
-    flushTimerRef.current = null;
+    if (isFlushingRef.current) {
+      // Re-entered from inside a flush, because publishing fed a message
+      // straight back in. The drain already under way covers it, so leave any
+      // armed timer alone rather than dropping its handle.
+      return;
+    }
+
+    // Clearing (not just forgetting) matters on the direct-call path: a timer
+    // armed for this same flush would otherwise stay pending and re-run it.
+    if (flushTimerRef.current) {
+      clearTimeout(flushTimerRef.current);
+      flushTimerRef.current = null;
+    }
+
     const buffer = bufferRef.current;
 
     if (buffer.size() === 0) {
@@ -102,9 +115,6 @@ export const useChatMessages = (options: UseChatMessagesOptions) => {
         onUnreadIncrement(pendingUnreadCountRef.current);
         pendingUnreadCountRef.current = 0;
       }
-      return;
-    }
-    if (isFlushingRef.current) {
       return;
     }
     if (!isAtBottomRef.current && isUserActivelyScrolling?.()) {

--- a/src/hooks/useChannelPoll.ts
+++ b/src/hooks/useChannelPoll.ts
@@ -127,9 +127,7 @@ export function useChannelPoll(channelId?: string) {
           onProgress,
         ),
         TwitchWsService.unsubscribeFromEvent('channel.poll.end', onEnd),
-      ]).finally(() => {
-        TwitchWsService.disconnect();
-      });
+      ]);
     };
   }, [canSubscribe, channelId]);
 

--- a/src/hooks/useChannelPrediction.ts
+++ b/src/hooks/useChannelPrediction.ts
@@ -154,9 +154,7 @@ export function useChannelPrediction(channelId?: string) {
         ),
         TwitchWsService.unsubscribeFromEvent('channel.prediction.lock', onLock),
         TwitchWsService.unsubscribeFromEvent('channel.prediction.end', onEnd),
-      ]).finally(() => {
-        TwitchWsService.disconnect();
-      });
+      ]);
     };
   }, [canSubscribe, channelId]);
 

--- a/src/hooks/ws/__tests__/manageSubscribers.test.ts
+++ b/src/hooks/ws/__tests__/manageSubscribers.test.ts
@@ -1,0 +1,46 @@
+import {
+  addSubscriber,
+  hasSubscriber,
+  hasSubscribers,
+  removeSubscriber,
+} from '../manage-subscribers';
+import type { Subscriber } from '../types';
+
+function createSubscriber(): Subscriber {
+  return {
+    setLastMessage: jest.fn(),
+    setReadyState: jest.fn(),
+    optionsRef: { current: {} },
+    reconnectCount: { current: 0 },
+    reconnect: { current: jest.fn() },
+  };
+}
+
+describe('hasSubscriber', () => {
+  test('reports a registered subscriber', () => {
+    const subscriber = createSubscriber();
+    addSubscriber('wss://registered.test', subscriber);
+
+    expect(hasSubscriber('wss://registered.test', subscriber)).toBe(true);
+  });
+
+  test('reports a removed subscriber as gone', () => {
+    const subscriber = createSubscriber();
+    addSubscriber('wss://removed.test', subscriber);
+    removeSubscriber('wss://removed.test', subscriber);
+
+    expect(hasSubscriber('wss://removed.test', subscriber)).toBe(false);
+    expect(hasSubscribers('wss://removed.test')).toBe(false);
+  });
+
+  test('does not confuse subscribers across urls', () => {
+    const subscriber = createSubscriber();
+    addSubscriber('wss://a.test', subscriber);
+
+    expect(hasSubscriber('wss://b.test', subscriber)).toBe(false);
+  });
+
+  test('returns false for a url nothing ever subscribed to', () => {
+    expect(hasSubscriber('wss://unknown.test', createSubscriber())).toBe(false);
+  });
+});

--- a/src/hooks/ws/attachListener.ts
+++ b/src/hooks/ws/attachListener.ts
@@ -48,7 +48,24 @@ export function attachListeners(
   const { setLastMessage, setReadyState } = setters;
 
   let interval: ReturnType<typeof setInterval>;
-  let reconnectTimeout: ReturnType<typeof setTimeout>;
+  let reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  /**
+   * A socket error is normally followed by a close, and both arm a reconnect.
+   * Without clearing first the second assignment orphans the first timer, so
+   * two reconnects race and open two sockets.
+   */
+  function scheduleReconnect(attempt: number, baseInterval: number): void {
+    if (reconnectTimeout) {
+      clearTimeout(reconnectTimeout);
+    }
+    const delay = getReconnectDelayWithJitter(attempt, baseInterval);
+    reconnectTimeout = setTimeout(() => {
+      reconnectTimeout = undefined;
+      reconnectCount.current += 1;
+      reconnect();
+    }, delay);
+  }
 
   if (optionsRef.current.fromSocketIO) {
     interval = setupSocketPing(instance);
@@ -86,14 +103,7 @@ export function attachListeners(
         optionsRef.current.reconnectInterval ?? DEFAULT_RECONNECT_INTERVAL_MS;
 
       if (reconnectCount.current < reconnectAttempts) {
-        const delay = getReconnectDelayWithJitter(
-          reconnectCount.current,
-          baseInterval,
-        );
-        reconnectTimeout = setTimeout(() => {
-          reconnectCount.current += 1;
-          reconnect();
-        }, delay);
+        scheduleReconnect(reconnectCount.current, baseInterval);
       } else {
         optionsRef.current.onReconnectStop?.(reconnectAttempts);
         logger.main.error(
@@ -113,14 +123,7 @@ export function attachListeners(
         optionsRef.current.reconnectInterval ?? DEFAULT_RECONNECT_INTERVAL_MS;
 
       if (reconnectCount.current < reconnectAttempts) {
-        const delay = getReconnectDelayWithJitter(
-          reconnectCount.current,
-          baseInterval,
-        );
-        reconnectTimeout = setTimeout(() => {
-          reconnectCount.current += 1;
-          reconnect();
-        }, delay);
+        scheduleReconnect(reconnectCount.current, baseInterval);
       } else {
         optionsRef.current.onReconnectStop?.(reconnectAttempts);
         logger.main.error(

--- a/src/hooks/ws/attachedSharedListeners.ts
+++ b/src/hooks/ws/attachedSharedListeners.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_RECONNECT_LIMIT,
   ReadyState,
 } from './constants';
-import { getSubscribers } from './manage-subscribers';
+import { getSubscribers, hasSubscriber } from './manage-subscribers';
 import { sharedWebSockets, type WebSocketEventMap } from './types';
 
 export const attachSharedListeners = (instance: WebSocket, url: string) => {
@@ -63,7 +63,7 @@ export const attachSharedListeners = (instance: WebSocket, url: string) => {
             setTimeout(() => {
               // The subscriber can unmount during backoff; reconnecting then
               // would reopen a socket nobody is listening on.
-              if (!getSubscribers(url).includes(subscriber)) {
+              if (!hasSubscriber(url, subscriber)) {
                 return;
               }
               subscriber.reconnect.current();

--- a/src/hooks/ws/attachedSharedListeners.ts
+++ b/src/hooks/ws/attachedSharedListeners.ts
@@ -61,6 +61,11 @@ export const attachSharedListeners = (instance: WebSocket, url: string) => {
             const backoffMultiplier = Math.min(1.5 ** attempt, 8);
             const delay = Math.round(baseInterval * backoffMultiplier);
             setTimeout(() => {
+              // The subscriber can unmount during backoff; reconnecting then
+              // would reopen a socket nobody is listening on.
+              if (!getSubscribers(url).includes(subscriber)) {
+                return;
+              }
               subscriber.reconnect.current();
             }, delay);
           }

--- a/src/hooks/ws/manage-subscribers.ts
+++ b/src/hooks/ws/manage-subscribers.ts
@@ -14,6 +14,10 @@ export const hasSubscribers = (url: string): boolean => {
   return !!subscribers[url] && subscribers[url].size > 0;
 };
 
+export const hasSubscriber = (url: string, subscriber: Subscriber): boolean => {
+  return subscribers[url]?.has(subscriber) ?? false;
+};
+
 export const addSubscriber = (url: string, subscriber: Subscriber): void => {
   if (!subscribers[url]) {
     subscribers[url] = new Set<Subscriber>();

--- a/src/services/__tests__/__fixtures__/twitchWsService.fixture.ts
+++ b/src/services/__tests__/__fixtures__/twitchWsService.fixture.ts
@@ -2,10 +2,26 @@ import TwitchWsService from '@app/services/twitch-ws-service';
 
 type EventCallback = (data: unknown) => void;
 
+/**
+ * Only the surface the service touches on its socket, so tests can install a
+ * fake without standing up a whole `WebSocket`.
+ */
+type TestSocket = {
+  close: (code?: number, reason?: string) => void;
+  readyState: number;
+};
+
 export type TwitchWsTestState = {
+  /**
+   * Private on the service; reached for so a test can arm the backoff reconnect
+   * without faking a keepalive lapse over the wire.
+   */
+  attemptReconnect: () => void;
   activeSubscriptions: Map<string, string>;
   eventCallbacks: Map<string, EventCallback[]>;
-  instance: WebSocket | null;
+  instance: TestSocket | null;
+  isReconnecting: boolean;
+  reconnectTimer: ReturnType<typeof setTimeout> | null;
   sessionId: string;
   subscriptionConfigs: Map<
     string,
@@ -22,6 +38,19 @@ export function resetTwitchWsTestState(state: TwitchWsTestState) {
   state.activeSubscriptions = new Map();
   state.eventCallbacks = new Map();
   state.instance = null;
+  state.isReconnecting = false;
+  state.reconnectTimer = null;
   state.sessionId = 'session-id';
   state.subscriptionConfigs = new Map();
+}
+
+/**
+ * Stands in for the WebSocket the service opens, so tests can assert whether a
+ * teardown actually closed the socket.
+ */
+export function createFakeSocket() {
+  return {
+    close: jest.fn(),
+    readyState: 1,
+  } satisfies TestSocket;
 }

--- a/src/services/__tests__/twitch-ws-service.eventsub.test.ts
+++ b/src/services/__tests__/twitch-ws-service.eventsub.test.ts
@@ -21,6 +21,7 @@ jest.mock('@app/utils/logger', () => ({
 }));
 
 import {
+  createFakeSocket,
   getTwitchWsTestState,
   resetTwitchWsTestState,
 } from './__fixtures__/twitchWsService.fixture';
@@ -28,6 +29,9 @@ import {
 const twitchWsState = getTwitchWsTestState();
 const mockCreateEventSubscription = jest.mocked(
   twitchService.createEventSubscription,
+);
+const mockDeleteEventSubscription = jest.mocked(
+  twitchService.deleteEventSubscription,
 );
 const mockWarn = jest.mocked(logger.twitchWs.warn);
 
@@ -67,5 +71,96 @@ describe('TwitchWsService EventSub response handling', () => {
       action: 'subscription_create_failed',
       event_type: 'channel.prediction.begin',
     });
+  });
+});
+
+describe('TwitchWsService shared socket teardown', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    resetTwitchWsTestState(twitchWsState);
+    mockDeleteEventSubscription.mockResolvedValue(
+      undefined as unknown as Awaited<
+        ReturnType<typeof mockDeleteEventSubscription>
+      >,
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  async function subscribe(eventType: string, callback: jest.Mock) {
+    mockCreateEventSubscription.mockResolvedValue({
+      data: [{ id: `${eventType}-sub-id` }],
+    } as unknown as Awaited<ReturnType<typeof mockCreateEventSubscription>>);
+
+    await TwitchWsService.subscribeToEvent(
+      eventType,
+      '1',
+      { broadcaster_user_id: 'channel-id' },
+      callback,
+    );
+  }
+
+  test('keeps the socket open while another consumer is still subscribed', async () => {
+    const socket = createFakeSocket();
+    const onPoll = jest.fn();
+    const onRedemption = jest.fn();
+
+    await subscribe('channel.poll.begin', onPoll);
+    await subscribe(
+      'channel.channel_points_custom_reward_redemption.add',
+      onRedemption,
+    );
+    twitchWsState.instance = socket;
+
+    await TwitchWsService.unsubscribeFromEvent('channel.poll.begin', onPoll);
+
+    expect(socket.close).not.toHaveBeenCalled();
+    expect(twitchWsState.instance).toBe(socket);
+  });
+
+  test('closes the socket once the last consumer unsubscribes', async () => {
+    const socket = createFakeSocket();
+    const onPoll = jest.fn();
+    const onRedemption = jest.fn();
+
+    await subscribe('channel.poll.begin', onPoll);
+    await subscribe(
+      'channel.channel_points_custom_reward_redemption.add',
+      onRedemption,
+    );
+    twitchWsState.instance = socket;
+
+    await TwitchWsService.unsubscribeFromEvent('channel.poll.begin', onPoll);
+    await TwitchWsService.unsubscribeFromEvent(
+      'channel.channel_points_custom_reward_redemption.add',
+      onRedemption,
+    );
+
+    expect(socket.close).toHaveBeenCalledWith(1000, 'Manual Disconnect');
+    expect(twitchWsState.instance).toBeNull();
+  });
+
+  test('cancels a pending reconnect when the last consumer leaves', async () => {
+    const socket = createFakeSocket();
+    const onPoll = jest.fn();
+
+    await subscribe('channel.poll.begin', onPoll);
+    twitchWsState.instance = socket;
+
+    // The socket drops and arms the backoff reconnect.
+    twitchWsState.attemptReconnect();
+    expect(twitchWsState.reconnectTimer).not.toBeNull();
+
+    await TwitchWsService.unsubscribeFromEvent('channel.poll.begin', onPoll);
+
+    expect(twitchWsState.reconnectTimer).toBeNull();
+    expect(twitchWsState.isReconnecting).toBe(false);
+
+    // The orphaned timer would have reopened the socket here.
+    jest.advanceTimersByTime(10_000);
+    expect(twitchWsState.instance).toBeNull();
   });
 });

--- a/src/services/__tests__/twitch-ws-service.eventsub.test.ts
+++ b/src/services/__tests__/twitch-ws-service.eventsub.test.ts
@@ -143,6 +143,43 @@ describe('TwitchWsService shared socket teardown', () => {
     expect(twitchWsState.instance).toBeNull();
   });
 
+  test('deletes each subscription once when event types unsubscribe together', async () => {
+    const socket = createFakeSocket();
+    const onBegin = jest.fn();
+    const onEnd = jest.fn();
+
+    await subscribe('channel.poll.begin', onBegin);
+    await subscribe('channel.poll.end', onEnd);
+    twitchWsState.instance = socket;
+
+    // The unmount path in useChannelPoll / useChannelPrediction: several event
+    // types torn down through one Promise.all rather than sequentially.
+    let resolveBegin: () => void = () => {};
+    mockDeleteEventSubscription.mockImplementation(id =>
+      id === 'channel.poll.begin-sub-id'
+        ? new Promise(resolve => {
+            resolveBegin = () => resolve(undefined);
+          })
+        : Promise.resolve(undefined),
+    );
+
+    const unsubscribed = Promise.all([
+      TwitchWsService.unsubscribeFromEvent('channel.poll.begin', onBegin),
+      TwitchWsService.unsubscribeFromEvent('channel.poll.end', onEnd),
+    ]);
+
+    // Let the sibling settle and run teardown while the first delete is still
+    // in flight, then release it.
+    await Promise.resolve();
+    resolveBegin();
+    await unsubscribed;
+
+    expect(mockDeleteEventSubscription.mock.calls.map(([id]) => id)).toEqual([
+      'channel.poll.begin-sub-id',
+      'channel.poll.end-sub-id',
+    ]);
+  });
+
   test('cancels a pending reconnect when the last consumer leaves', async () => {
     const socket = createFakeSocket();
     const onPoll = jest.fn();

--- a/src/services/twitch-ws-service.ts
+++ b/src/services/twitch-ws-service.ts
@@ -444,9 +444,14 @@ class TwitchWsService {
       return;
     }
 
+    // Claim the id before awaiting. The hooks unsubscribe several event types
+    // through one Promise.all, so a sibling that settles first can reach
+    // teardownIfIdle -> cleanupSubscriptions while this delete is still in
+    // flight, and would otherwise delete the same id a second time.
+    TwitchWsService.activeSubscriptions.delete(eventType);
+
     try {
       await twitchService.deleteEventSubscription(subscriptionId);
-      TwitchWsService.activeSubscriptions.delete(eventType);
       TwitchWsService.eventCallbacks.delete(eventType);
 
       logger.twitchWs.info(

--- a/src/services/twitch-ws-service.ts
+++ b/src/services/twitch-ws-service.ts
@@ -48,6 +48,8 @@ class TwitchWsService {
 
   private static keepaliveTimer: ReturnType<typeof setTimeout> | null = null;
 
+  private static reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
   private static eventCallbacks: Map<string, EventCallback[]> = new Map();
 
   private static reconnectUrl: string = '';
@@ -273,9 +275,7 @@ class TwitchWsService {
       TwitchWsService.instance.close(1000, 'Reconnecting');
     }
 
-    setTimeout(() => {
-      TwitchWsService.connect();
-    }, 1000);
+    TwitchWsService.scheduleReconnect(1000);
   }
 
   private static handleRevocation(message: EventSubMessage): void {
@@ -311,6 +311,33 @@ class TwitchWsService {
     }
   }
 
+  private static clearReconnectTimer(): void {
+    if (TwitchWsService.reconnectTimer) {
+      clearTimeout(TwitchWsService.reconnectTimer);
+      TwitchWsService.reconnectTimer = null;
+    }
+  }
+
+  /**
+   * Reconnects are always scheduled through here so a teardown can cancel one
+   * mid-backoff. An uncancelled timer would otherwise reopen the socket, and
+   * re-arm the keepalive, after every consumer has already gone away.
+   */
+  private static scheduleReconnect(delayMs: number): void {
+    TwitchWsService.clearReconnectTimer();
+
+    TwitchWsService.reconnectTimer = setTimeout(() => {
+      TwitchWsService.reconnectTimer = null;
+
+      if (!TwitchWsService.hasActiveListeners()) {
+        TwitchWsService.isReconnecting = false;
+        return;
+      }
+
+      TwitchWsService.connect();
+    }, delayMs);
+  }
+
   private static attemptReconnect(): void {
     if (TwitchWsService.isReconnecting) {
       return;
@@ -320,9 +347,7 @@ class TwitchWsService {
 
     logger.twitchWs.info(`💜 Attempting EventSub reconnection`);
 
-    setTimeout(() => {
-      TwitchWsService.connect();
-    }, 2000);
+    TwitchWsService.scheduleReconnect(2000);
   }
 
   /**
@@ -390,6 +415,7 @@ class TwitchWsService {
         },
       );
       TwitchWsService.removeEventListener(eventType, callback);
+      TwitchWsService.teardownIfIdle();
     }
   }
 
@@ -414,6 +440,7 @@ class TwitchWsService {
 
     const subscriptionId = TwitchWsService.activeSubscriptions.get(eventType);
     if (!subscriptionId) {
+      TwitchWsService.teardownIfIdle();
       return;
     }
 
@@ -438,6 +465,8 @@ class TwitchWsService {
           subscription_id: subscriptionId,
         },
       );
+    } finally {
+      TwitchWsService.teardownIfIdle();
     }
   }
 
@@ -608,15 +637,35 @@ class TwitchWsService {
     }
   }
 
-  public static disconnect() {
+  private static hasActiveListeners(): boolean {
+    for (const callbacks of TwitchWsService.eventCallbacks.values()) {
+      if (callbacks.length > 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Polls, predictions and channel-point redemptions share one EventSub socket,
+   * so the listener registry is the refcount: the socket closes only once the
+   * last consumer has unsubscribed. Closing on any one consumer's unmount would
+   * silently kill the feeds the others are still mounted on.
+   */
+  private static teardownIfIdle(): void {
+    if (TwitchWsService.hasActiveListeners()) {
+      return;
+    }
+
     TwitchWsService.clearKeepaliveTimer();
+    TwitchWsService.clearReconnectTimer();
+    TwitchWsService.isReconnecting = false;
 
     // Close WebSocket immediately for fast disconnection
     if (TwitchWsService.instance) {
       TwitchWsService.instance.close(1000, 'Manual Disconnect');
       TwitchWsService.instance = null;
       TwitchWsService.sessionId = '';
-      TwitchWsService.isReconnecting = false;
     }
 
     // Clean up subscriptions in background without blocking disconnection

--- a/src/utils/chat/resolveMentionLogin/__tests__/searchMentionChatters.perf-test.ts
+++ b/src/utils/chat/resolveMentionLogin/__tests__/searchMentionChatters.perf-test.ts
@@ -1,0 +1,51 @@
+import { measureFunction } from 'reassure';
+
+import { clearMentionLoginIndex } from '@app/utils/chat/resolveMentionLogin/clearMentionLoginIndex';
+import { registerMentionChatter } from '@app/utils/chat/resolveMentionLogin/registerMentionChatter';
+import { registerMentionLogin } from '@app/utils/chat/resolveMentionLogin/registerMentionLogin';
+import { searchMentionChatters } from '@app/utils/chat/resolveMentionLogin/searchMentionChatters';
+
+const MEASURE_OPTIONS = {
+  runs: 5,
+  warmupRuns: 1,
+} as const;
+
+/**
+ * `capMentionIndex` holds 8000 entries per index, so a long session in a busy
+ * channel fills both. Chatters carry a colour; the login-only index does not,
+ * which is the half that has to synthesise one per match.
+ */
+function seedIndexes(): void {
+  clearMentionLoginIndex();
+
+  for (let i = 0; i < 4000; i += 1) {
+    registerMentionChatter({
+      login: `Chatter${i}`,
+      userId: `user-${i}`,
+      color: '#FF7F50',
+    });
+    registerMentionLogin(`Lurker${i}`);
+  }
+}
+
+seedIndexes();
+
+/**
+ * A single leading character matches nearly the whole index, which is the worst
+ * case and also the first keystroke of every mention the user types.
+ */
+describe('searchMentionChatters performance', () => {
+  test('searches a broad single-character query', async () => {
+    await measureFunction(() => {
+      searchMentionChatters('c');
+    }, MEASURE_OPTIONS);
+  });
+
+  test('types a mention one character at a time', async () => {
+    await measureFunction(() => {
+      for (const query of ['c', 'ch', 'cha', 'chat', 'chatt']) {
+        searchMentionChatters(query);
+      }
+    }, MEASURE_OPTIONS);
+  });
+});

--- a/src/utils/chat/resolveMentionLogin/__tests__/searchMentionChatters.test.ts
+++ b/src/utils/chat/resolveMentionLogin/__tests__/searchMentionChatters.test.ts
@@ -34,4 +34,47 @@ describe('searchMentionChatters', () => {
       },
     ]);
   });
+
+  /**
+   * `aaabob` sorts first alphabetically but only matches mid-login, so
+   * alphabetical order alone cannot produce this result.
+   */
+  test('ranks prefix matches above substring matches', () => {
+    registerMentionLogin('aaabob');
+    registerMentionLogin('bobby');
+
+    expect(
+      searchMentionChatters('bob', 5).map(chatter => chatter.login),
+    ).toEqual(['bobby', 'aaabob']);
+  });
+
+  /**
+   * `Zephyr` sorts before `apple` by character code and after it case
+   * insensitively, so this fails if ordering reads the canonical login.
+   */
+  test('orders matches case-insensitively', () => {
+    registerMentionLogin('Zephyr');
+    registerMentionLogin('apple');
+
+    expect(searchMentionChatters('p', 5).map(chatter => chatter.login)).toEqual(
+      ['apple', 'Zephyr'],
+    );
+  });
+
+  test('caps results at the requested limit', () => {
+    for (let i = 0; i < 10; i += 1) {
+      registerMentionLogin(`capped${i}`);
+    }
+
+    expect(searchMentionChatters('capped', 3)).toHaveLength(3);
+  });
+
+  test('prefers a registered chatter over a login-only entry', () => {
+    registerMentionLogin('dupe');
+    registerMentionChatter({ login: 'Dupe', userId: '42', color: '#9147ff' });
+
+    expect(searchMentionChatters('dupe', 5)).toEqual<MentionChatter[]>([
+      { login: 'Dupe', userId: '42', color: '#9147ff' },
+    ]);
+  });
 });

--- a/src/utils/chat/resolveMentionLogin/searchMentionChatters.ts
+++ b/src/utils/chat/resolveMentionLogin/searchMentionChatters.ts
@@ -3,25 +3,43 @@ import { mentionChatterIndex } from '@app/utils/chat/resolveMentionLogin/mention
 import { mentionLoginIndex } from '@app/utils/chat/resolveMentionLogin/mentionLoginIndex';
 import type { MentionChatter } from '@app/utils/chat/resolveMentionLogin/types';
 
-function compareMentionChatters(
-  left: MentionChatter,
-  right: MentionChatter,
-  query: string,
-): number {
-  const leftLogin = left.login.toLowerCase();
-  const rightLogin = right.login.toLowerCase();
-  const leftStarts = leftLogin.startsWith(query);
-  const rightStarts = rightLogin.startsWith(query);
+/**
+ * `chatter` is null for login-only entries, whose colour is synthesised after
+ * the result set has been cut to `limit`.
+ */
+type MentionCandidate = {
+  chatter: MentionChatter | null;
+  key: string;
+  login: string;
+};
 
-  if (leftStarts !== rightStarts) {
-    return leftStarts ? -1 : 1;
-  }
+/**
+ * `String.prototype.localeCompare` with an options object builds a collator per
+ * call; one shared instance does the same comparison.
+ */
+const loginCollator = new Intl.Collator(undefined, { sensitivity: 'base' });
 
-  return left.login.localeCompare(right.login, undefined, {
-    sensitivity: 'base',
-  });
+function compareByKey(left: MentionCandidate, right: MentionCandidate): number {
+  return loginCollator.compare(left.key, right.key);
 }
 
+function toMentionChatter(candidate: MentionCandidate): MentionChatter {
+  return (
+    candidate.chatter ?? {
+      login: candidate.login,
+      userId: candidate.key,
+      color: generateRandomTwitchColor(candidate.login),
+    }
+  );
+}
+
+/**
+ * Both indexes are keyed by the lower-cased login, so matching and ordering
+ * read the key rather than lower-casing every entry on each keystroke.
+ * Prefix matches outrank substring matches, so bucketing on the way past also
+ * removes the need to order the (much larger) substring bucket unless the
+ * prefix bucket comes up short.
+ */
 export function searchMentionChatters(
   query: string,
   limit = 20,
@@ -33,31 +51,38 @@ export function searchMentionChatters(
     return [];
   }
 
-  const matches = new Map<string, MentionChatter>();
+  const prefixed: MentionCandidate[] = [];
+  const contained: MentionCandidate[] = [];
+  const seen = new Set<string>();
 
-  mentionChatterIndex.forEach(chatter => {
-    const login = chatter.login.toLowerCase();
-    if (login.includes(normalisedQuery)) {
-      matches.set(login, chatter);
-    }
-  });
-
-  mentionLoginIndex.forEach(login => {
-    const key = login.toLowerCase();
-    if (!key.includes(normalisedQuery) || matches.has(key)) {
+  const collect = (
+    key: string,
+    login: string,
+    chatter: MentionChatter | null,
+  ) => {
+    const matchIndex = key.indexOf(normalisedQuery);
+    if (matchIndex === -1 || seen.has(key)) {
       return;
     }
 
-    matches.set(key, {
-      login,
-      userId: key,
-      color: generateRandomTwitchColor(login),
-    });
+    seen.add(key);
+    (matchIndex === 0 ? prefixed : contained).push({ chatter, key, login });
+  };
+
+  mentionChatterIndex.forEach((chatter, key) => {
+    collect(key, chatter.login, chatter);
+  });
+  mentionLoginIndex.forEach((login, key) => {
+    collect(key, login, null);
   });
 
-  const results = Array.from(matches.values());
-  results.sort((left, right) =>
-    compareMentionChatters(left, right, normalisedQuery),
-  );
-  return results.slice(0, limit);
+  prefixed.sort(compareByKey);
+  const results = prefixed.slice(0, limit);
+
+  if (results.length < limit && contained.length > 0) {
+    contained.sort(compareByKey);
+    results.push(...contained.slice(0, limit - results.length));
+  }
+
+  return results.map(toMentionChatter);
 }


### PR DESCRIPTION
# Why

Follow-up to the perf audit. Typing a `@mention` in the composer was doing a full scan and sort of both mention indexes synchronously on the JS thread, on every keystroke. `capMentionIndex` holds 8000 entries per index, so a long session in a busy channel makes that 16k entries per character.

Measured on a 4000 + 4000 fixture, so roughly half a full index:

| | before | after |
|---|---|---|
| one keystroke, broad query | 16.08ms | 1.07ms |
| typing a 5-character mention | 87.17ms | 6.03ms |

# How

The dominant cost was not what I expected going in, so this is worth spelling out.

**`localeCompare` with an options object builds a collator per call.** The comparator was `left.login.localeCompare(right.login, undefined, { sensitivity: 'base' })`, running ~48k times for a broad query. Hoisting one shared `Intl.Collator` is the entire 14x win. Everything else below is small by comparison, and I confirmed that by measuring the other changes on their own first (16.08ms -> 15.58ms, i.e. noise).

The rest, kept because they are strictly less work and not more code:

- **Read the Map key instead of re-deriving it.** Both `mentionChatterIndex` and `mentionLoginIndex` are already keyed by the lower-cased login, and `Map.forEach` hands the key over as its second argument. The old code called `.toLowerCase()` on each entry's value instead, once per entry per keystroke, and again on both sides of every comparison.
- **Synthesise colours after the cut.** `generateRandomTwitchColor()` ran for every login-index match; now it runs for the <= 20 that survive `limit`.
- **Bucket prefix and substring matches while scanning**, so the (usually much larger) substring bucket is not ordered at all unless the prefix bucket comes up short. Prefix-before-substring was already the ranking, it was just expressed inside the comparator.
- **`useDeferredValue` in `useUserSuggestions`**, so the search trails the keystroke rather than sharing a frame with the character the composer is echoing.

I also tried bounded selection instead of a full sort, since that was on the audit list. It measured 1.12ms -> 1.01ms for about 30 lines of hand-rolled binary-insertion with two type casts, so I dropped it. Not worth the complexity once the collator fix had already taken this from 16ms to 1.1ms.

# Test Plan

`tsc`, `eslint`, `prettier`, `ast-grep` and the full jest suite (9863 tests) are clean.

New reassure case `searchMentionChatters.perf-test.ts` covers a broad single-character query and a five-character typing run against a seeded 8000-entry pair of indexes.

Four new unit tests pin the ordering semantics, since the algorithm was restructured rather than tweaked. I mutation-checked them rather than trusting green:

- disable the prefix/substring bucketing -> `ranks prefix matches above substring matches` fails
- compare the canonical login instead of the key -> `orders matches case-insensitively` fails

Worth noting my first draft of both tests passed under those mutations because the fixture logins happened to sort into the right order anyway. The fixtures are now chosen so alphabetical order alone cannot produce the expected result.

Behaviour is unchanged: same ranking, same dedupe (chatter entries still win over login-only ones), same `limit` semantics.