### PR TITLE
fix(chat): tint the composer caret and selection with the accent

### DIFF
--- a/src/components/Chat/components/ChatComposer/ChatComposer.ios.tsx
+++ b/src/components/Chat/components/ChatComposer/ChatComposer.ios.tsx
@@ -137,6 +137,13 @@ function ChatComposerComponent({
             placeholderTextColor='rgba(255,255,255,0.46)'
             radius='xl'
             returnKeyType='send'
+            /**
+             * Drives the SwiftUI `.tint`, so the caret and the selection
+             * highlight follow the accent the way every other iOS text field
+             * does. Without it the field falls back to its text colour and
+             * carets near-white.
+             */
+            selectionColor={accentHex}
             style={styles.input}
             submitBehavior='blurAndSubmit'
             variant='soft'

--- a/src/components/Chat/components/ChatComposer/ChatComposer.tsx
+++ b/src/components/Chat/components/ChatComposer/ChatComposer.tsx
@@ -21,6 +21,13 @@ import { UserSuggestionRail } from './UserSuggestionRail';
 export type { ChatComposerHandle };
 export type { SuggestionType } from './chatComposerTypes';
 
+/**
+ * 40% alpha. The highlight sits under the glyphs, so it stays translucent while
+ * the caret and handles take the solid accent - iOS derives the same pair from
+ * a single tint, and Android is pinned to that palette.
+ */
+const SELECTION_HIGHLIGHT_ALPHA = '66';
+
 export interface ChatComposerProps {
   onChangeText?: (text: string) => void;
   onSubmit?: () => void;
@@ -190,9 +197,9 @@ function ChatComposerComponent({
           placeholder={placeholder ?? t('composer.sendAMessage')}
           placeholderTextColor={theme.color.textSecondary.dark}
           returnKeyType='send'
-          cursorColor={theme.color.text.dark}
-          selectionColor={theme.colorTextSelection}
-          selectionHandleColor={theme.colorPrimary}
+          cursorColor={accentHex}
+          selectionColor={`${accentHex}${SELECTION_HIGHLIGHT_ALPHA}`}
+          selectionHandleColor={accentHex}
           style={styles.input}
           submitBehavior='blurAndSubmit'
           /**


### PR DESCRIPTION
# Why

The chat composer caret and selection did not match the rest of the app on iOS.

iOS renders the composer through a SwiftUI `TextField` (`Input.ios.tsx`), where the caret and the selection highlight both come from `.tint`. Nothing passed a tint, so `resolvedCursorColor` fell through to `variantConfig.textColor` — `white/950` for the `soft` variant. The caret drew near-white while the send button immediately beside it was already on the accent.

Android was already setting caret/highlight/handle, but off static tokens (`theme.color.text.dark`, `theme.colorTextSelection`, `theme.colorPrimary`). Those ignore the accent the user actually picks, so the selection handle and the send button could disagree there too.

# How

iOS passes `selectionColor={accentHex}` to `Input`, which lands on `tint()` for the SwiftUI field. One value is enough — SwiftUI derives the translucent highlight from the tint itself, which is why iOS text fields all behave this way.

Android takes the same accent for the caret and handle, plus the accent at 40% alpha for the highlight, since RN wants those three separately. That keeps the two platforms on one palette, consistent with the existing rule that Android controls are pinned to iOS colours rather than Material You.

# Test Plan

`tsc`, eslint and the full Jest suite (321 suites / 9877 tests) pass, but none of that covers the actual change — this is a colour that only exists once SwiftUI renders.

I verified the wiring by reading it rather than by running it:

- `selectionColor` → `resolvedCursorColor = colorValue(cursorColor ?? selectionColor ?? variantConfig.textColor)` (`Input.ios.tsx:206`)
- → `buildTextFieldModifiers({ tintColor: resolvedCursorColor })` (`:272`)
- → `tint(tintColor)` (`:537`), which `@expo/ui` documents as taking a hex string
- `colorValue` is a passthrough with a `transparent` fallback, so a plain `#RRGGBB` survives intact

I also confirmed every palette entry and both scheme tints are 6-digit hex, so appending the alpha suffix on the Android side cannot produce an invalid colour.

**Still wants a device check**, on both platforms:

1. Open a channel, tap the composer, confirm the caret is the accent rather than white.
2. Type and drag-select — highlight should be a translucent accent, handles solid accent on Android.
3. Change the accent in settings and repeat; caret/selection should follow it and match the send button.

I tried a rendering test asserting the three colours track a chosen accent. Jest resolves `ChatComposer.ios.tsx` under this config, so it renders the SwiftUI `TextField` and dies in `useWorkletProp` (`'onTextChange' must be a worklet function`). Getting past that needs a `TextField` mock, at which point the test mostly asserts the mock forwards props — so I dropped it rather than add scaffolding of no real value.

# Notes

Deliberately left alone: `Input.ios.tsx` still defaults its tint to the text colour for every other input in the app. Arguably the accent is the correct iOS default everywhere, but that changes every screen, so I kept this to the composer. Happy to do the broader change as a follow-up.

`@expo/ui`'s SwiftUI layer exposes no `keyboardAppearance` modifier, so a dark keyboard to match the dark composer is not reachable from here.