### PR TITLE
fix(chat): match 7tv paint rendering to the reference span model

### DIFF
--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintLayerBackground.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintLayerBackground.tsx
@@ -36,6 +36,8 @@ export function PaintLayerBackground({
     height: number;
   } | null>(null);
   const layoutStyle = getLayerLayoutStyle(layer);
+  const layerOpacity = layer.opacity ?? 1;
+  const opacityStyle = layerOpacity < 1 ? { opacity: layerOpacity } : null;
   const gradientConfig = buildLayerGradientConfig(layer, fallbackColor);
   const isRadial = layer.function === 'RADIAL_GRADIENT';
   const isAssetPaint = layer.function === 'URL' && Boolean(layer.image_url);
@@ -56,7 +58,7 @@ export function PaintLayerBackground({
   if (isAssetPaint) {
     if (isTilingCanvasRepeat(layer.canvas_repeat, layer.repeat)) {
       return (
-        <View style={[styles.layer, layoutStyle]}>
+        <View style={[styles.layer, layoutStyle, opacityStyle]}>
           <PaintLayerTiledImage
             canvasRepeat={layer.canvas_repeat}
             imageUrl={layer.image_url}
@@ -65,7 +67,7 @@ export function PaintLayerBackground({
       );
     }
     return (
-      <View style={[styles.layer, layoutStyle]}>
+      <View style={[styles.layer, layoutStyle, opacityStyle]}>
         <Image
           contentFit={imageRepeatFromCanvasRepeat(
             layer.canvas_repeat,
@@ -91,7 +93,10 @@ export function PaintLayerBackground({
     const ry = isEllipse ? halfH * Math.SQRT2 : farthestCorner;
 
     return (
-      <View style={[styles.layer, layoutStyle]} onLayout={handleLayout}>
+      <View
+        style={[styles.layer, layoutStyle, opacityStyle]}
+        onLayout={handleLayout}
+      >
         {layerSize ? (
           <Svg width='100%' height='100%' style={styles.fill}>
             <Defs>
@@ -130,7 +135,7 @@ export function PaintLayerBackground({
   if (useSvgLinear) {
     const { start, end } = gradientConfig;
     return (
-      <View style={[styles.layer, layoutStyle]}>
+      <View style={[styles.layer, layoutStyle, opacityStyle]}>
         <Svg width='100%' height='100%' style={styles.fill}>
           <Defs>
             <SvgLinearGradient
@@ -162,7 +167,7 @@ export function PaintLayerBackground({
   }
 
   return (
-    <View style={[styles.layer, layoutStyle]}>
+    <View style={[styles.layer, layoutStyle, opacityStyle]}>
       <LinearGradient
         colors={gradientConfig.colors as [string, string, ...string[]]}
         locations={gradientConfig.locations as [number, number, ...number[]]}

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintLayerBackground.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintLayerBackground.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import { type LayoutChangeEvent, StyleSheet, View } from 'react-native';
 import Svg, {
   Defs,
@@ -20,12 +20,20 @@ import { imageRepeatFromCanvasRepeat } from './util/paintLayer/imageRepeatFromCa
 import { isTilingCanvasRepeat } from './util/paintLayer/isTilingCanvasRepeat';
 
 interface PaintLayerBackgroundProps {
+  /**
+   * Resolved paint base colour (`paint.color` or the fallback). Painted under
+   * the layer content like the reference span's `background-color:
+   * currentColor`, so the layer opacity fades backing and content together
+   * and an upper layer covers lower ones with the base colour.
+   */
+  baseColor: string;
   fallbackColor: string;
   layer: PaintLayerData;
   layerIndex: number;
 }
 
 export function PaintLayerBackground({
+  baseColor,
   layer,
   fallbackColor,
   layerIndex,
@@ -37,7 +45,6 @@ export function PaintLayerBackground({
   } | null>(null);
   const layoutStyle = getLayerLayoutStyle(layer);
   const layerOpacity = layer.opacity ?? 1;
-  const opacityStyle = layerOpacity < 1 ? { opacity: layerOpacity } : null;
   const gradientConfig = buildLayerGradientConfig(layer, fallbackColor);
   const isRadial = layer.function === 'RADIAL_GRADIENT';
   const isAssetPaint = layer.function === 'URL' && Boolean(layer.image_url);
@@ -55,33 +62,25 @@ export function PaintLayerBackground({
     }
   };
 
+  let content: ReactNode;
   if (isAssetPaint) {
-    if (isTilingCanvasRepeat(layer.canvas_repeat, layer.repeat)) {
-      return (
-        <View style={[styles.layer, layoutStyle, opacityStyle]}>
-          <PaintLayerTiledImage
-            canvasRepeat={layer.canvas_repeat}
-            imageUrl={layer.image_url}
-          />
-        </View>
-      );
-    }
-    return (
-      <View style={[styles.layer, layoutStyle, opacityStyle]}>
-        <Image
-          contentFit={imageRepeatFromCanvasRepeat(
-            layer.canvas_repeat,
-            layer.repeat,
-          )}
-          source={{ uri: layer.image_url }}
-          useAppleWebpCodec={false}
-          style={styles.fill}
-        />
-      </View>
+    content = isTilingCanvasRepeat(layer.canvas_repeat, layer.repeat) ? (
+      <PaintLayerTiledImage
+        canvasRepeat={layer.canvas_repeat}
+        imageUrl={layer.image_url}
+      />
+    ) : (
+      <Image
+        contentFit={imageRepeatFromCanvasRepeat(
+          layer.canvas_repeat,
+          layer.repeat,
+        )}
+        source={{ uri: layer.image_url }}
+        useAppleWebpCodec={false}
+        style={styles.fill}
+      />
     );
-  }
-
-  if (isRadial) {
+  } else if (isRadial) {
     // CSS radial-gradient default sizing is farthest-corner, which needs the
     // rendered layer size in pixels to resolve to a true circle.
     const width = layerSize?.width ?? 0;
@@ -92,82 +91,69 @@ export function PaintLayerBackground({
     const rx = isEllipse ? halfW * Math.SQRT2 : farthestCorner;
     const ry = isEllipse ? halfH * Math.SQRT2 : farthestCorner;
 
-    return (
-      <View
-        style={[styles.layer, layoutStyle, opacityStyle]}
-        onLayout={handleLayout}
-      >
-        {layerSize ? (
-          <Svg width='100%' height='100%' style={styles.fill}>
-            <Defs>
-              <SvgRadialGradient
-                id={`${gradientId}-radial`}
-                gradientUnits='userSpaceOnUse'
-                cx={halfW}
-                cy={halfH}
-                rx={rx}
-                ry={ry}
-                fx={halfW}
-                fy={halfH}
-              >
-                {gradientConfig.colors.map((color, index) => (
-                  <Stop
-                    key={`${color}-${gradientConfig.locations[index]}`}
-                    offset={`${(gradientConfig.locations[index] ?? 0) * 100}%`}
-                    stopColor={color}
-                  />
-                ))}
-              </SvgRadialGradient>
-            </Defs>
-            <Rect
-              x='0'
-              y='0'
-              width='100%'
-              height='100%'
-              fill={`url(#${gradientId}-radial)`}
-            />
-          </Svg>
-        ) : null}
-      </View>
-    );
-  }
-
-  if (useSvgLinear) {
+    content = layerSize ? (
+      <Svg width='100%' height='100%' style={styles.fill}>
+        <Defs>
+          <SvgRadialGradient
+            id={`${gradientId}-radial`}
+            gradientUnits='userSpaceOnUse'
+            cx={halfW}
+            cy={halfH}
+            rx={rx}
+            ry={ry}
+            fx={halfW}
+            fy={halfH}
+          >
+            {gradientConfig.colors.map((color, index) => (
+              <Stop
+                key={`${color}-${gradientConfig.locations[index]}`}
+                offset={`${(gradientConfig.locations[index] ?? 0) * 100}%`}
+                stopColor={color}
+              />
+            ))}
+          </SvgRadialGradient>
+        </Defs>
+        <Rect
+          x='0'
+          y='0'
+          width='100%'
+          height='100%'
+          fill={`url(#${gradientId}-radial)`}
+        />
+      </Svg>
+    ) : null;
+  } else if (useSvgLinear) {
     const { start, end } = gradientConfig;
-    return (
-      <View style={[styles.layer, layoutStyle, opacityStyle]}>
-        <Svg width='100%' height='100%' style={styles.fill}>
-          <Defs>
-            <SvgLinearGradient
-              id={`${gradientId}-linear`}
-              x1={`${start.x * 100}%`}
-              y1={`${start.y * 100}%`}
-              x2={`${end.x * 100}%`}
-              y2={`${end.y * 100}%`}
-            >
-              {gradientConfig.colors.map((color, index) => (
-                <Stop
-                  key={`${color}-${gradientConfig.locations[index]}`}
-                  offset={`${(gradientConfig.locations[index] ?? 0) * 100}%`}
-                  stopColor={color}
-                />
-              ))}
-            </SvgLinearGradient>
-          </Defs>
-          <Rect
-            x='0'
-            y='0'
-            width='100%'
-            height='100%'
-            fill={`url(#${gradientId}-linear)`}
-          />
-        </Svg>
-      </View>
+    content = (
+      <Svg width='100%' height='100%' style={styles.fill}>
+        <Defs>
+          <SvgLinearGradient
+            id={`${gradientId}-linear`}
+            x1={`${start.x * 100}%`}
+            y1={`${start.y * 100}%`}
+            x2={`${end.x * 100}%`}
+            y2={`${end.y * 100}%`}
+          >
+            {gradientConfig.colors.map((color, index) => (
+              <Stop
+                key={`${color}-${gradientConfig.locations[index]}`}
+                offset={`${(gradientConfig.locations[index] ?? 0) * 100}%`}
+                stopColor={color}
+              />
+            ))}
+          </SvgLinearGradient>
+        </Defs>
+        <Rect
+          x='0'
+          y='0'
+          width='100%'
+          height='100%'
+          fill={`url(#${gradientId}-linear)`}
+        />
+      </Svg>
     );
-  }
-
-  return (
-    <View style={[styles.layer, layoutStyle, opacityStyle]}>
+  } else {
+    content = (
       <LinearGradient
         colors={gradientConfig.colors as [string, string, ...string[]]}
         locations={gradientConfig.locations as [number, number, ...number[]]}
@@ -175,6 +161,23 @@ export function PaintLayerBackground({
         end={gradientConfig.end}
         style={styles.fill}
       />
+    );
+  }
+
+  return (
+    <View
+      style={[
+        styles.span,
+        { backgroundColor: baseColor },
+        layerOpacity < 1 ? { opacity: layerOpacity } : null,
+      ]}
+    >
+      <View
+        style={[styles.layer, layoutStyle]}
+        onLayout={isRadial ? handleLayout : undefined}
+      >
+        {content}
+      </View>
     </View>
   );
 }
@@ -189,5 +192,8 @@ const styles = StyleSheet.create({
   },
   layer: {
     overflow: 'hidden',
+  },
+  span: {
+    ...StyleSheet.absoluteFill,
   },
 });

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintLayerBackground.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintLayerBackground.tsx
@@ -27,7 +27,6 @@ interface PaintLayerBackgroundProps {
    * and an upper layer covers lower ones with the base colour.
    */
   baseColor: string;
-  fallbackColor: string;
   layer: PaintLayerData;
   layerIndex: number;
 }
@@ -35,7 +34,6 @@ interface PaintLayerBackgroundProps {
 export function PaintLayerBackground({
   baseColor,
   layer,
-  fallbackColor,
   layerIndex,
 }: PaintLayerBackgroundProps) {
   const gradientId = `paint-layer-${layerIndex}`;
@@ -44,8 +42,8 @@ export function PaintLayerBackground({
     height: number;
   } | null>(null);
   const layoutStyle = getLayerLayoutStyle(layer);
-  const layerOpacity = layer.opacity ?? 1;
-  const gradientConfig = buildLayerGradientConfig(layer, fallbackColor);
+  const layerOpacity = layer.opacity;
+  const gradientConfig = buildLayerGradientConfig(layer);
   const isRadial = layer.function === 'RADIAL_GRADIENT';
   const isAssetPaint = layer.function === 'URL' && Boolean(layer.image_url);
   const isEllipse = layer.shape === 'ellipse';
@@ -80,6 +78,10 @@ export function PaintLayerBackground({
         style={styles.fill}
       />
     );
+  } else if (!gradientConfig) {
+    // Invalid gradient (fewer than two stops): the span keeps only its
+    // base-colour backing, like the reference's invalid background-image.
+    content = null;
   } else if (isRadial) {
     // CSS radial-gradient default sizing is farthest-corner, which needs the
     // rendered layer size in pixels to resolve to a true circle.

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameFill.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameFill.tsx
@@ -6,6 +6,7 @@ import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
 
 import { PaintLayerBackground } from './PaintLayerBackground';
 import { getPaintLayers } from './util/paintLayer/getPaintLayers';
+import { isRenderablePaintLayer } from './util/paintLayer/isRenderablePaintLayer';
 import { withPaintLayerKeys } from './util/paintLayer/paintLayerKey';
 
 interface PaintedUsernameFillProps {
@@ -25,17 +26,25 @@ export function PaintedUsernameFill({
   paint,
   textStyle,
 }: PaintedUsernameFillProps) {
-  const layers = getPaintLayers(paint);
+  const layers = getPaintLayers(paint).filter(isRenderablePaintLayer);
   const keyedLayers = withPaintLayerKeys([...layers].reverse());
   const baseColor =
     paint.color === null ? fallbackColor : sevenTvColorToCss(paint.color);
 
+  /**
+   * Each layer span carries its own base-colour backing, so the plain base
+   * fill only renders when no layer produces a span (the reference's
+   * layer-less fallback).
+   */
   return (
     <View style={styles.stack}>
-      <View style={[styles.baseColor, { backgroundColor: baseColor }]} />
+      {keyedLayers.length === 0 ? (
+        <View style={[styles.baseColor, { backgroundColor: baseColor }]} />
+      ) : null}
       {keyedLayers.map(({ layer, key, layerIndex }) => (
         <PaintLayerBackground
           key={key}
+          baseColor={baseColor}
           fallbackColor={fallbackColor}
           layer={layer}
           layerIndex={layerIndex}

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameFill.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameFill.tsx
@@ -45,7 +45,6 @@ export function PaintedUsernameFill({
         <PaintLayerBackground
           key={key}
           baseColor={baseColor}
-          fallbackColor={fallbackColor}
           layer={layer}
           layerIndex={layerIndex}
         />

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameSkia.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameSkia.tsx
@@ -26,6 +26,7 @@ import {
   type PaintBitmaps,
   type PaintImageLayer,
   type PaintLayerSlot,
+  urlSlotNeedsBacking,
 } from './util/skiaPaintedUsernameRasterizer';
 import { useSkiaPaintFontProvider } from './util/skiaPaintFonts';
 
@@ -170,12 +171,7 @@ function renderLayerSlot(
   if (!overlay) {
     return null;
   }
-  /**
-   * The bottom-most opaque URL span already sits on the foundation's base
-   * fill; drawing the backing there too would double-composite a
-   * semi-transparent base colour. Same condition as `needsUrlBacking`.
-   */
-  const needsBacking = index > 0 || slot.layer.opacity < 1;
+  const needsBacking = urlSlotNeedsBacking(index, slot.layer);
   return (
     <UrlLayerSpan
       // Static, never-reordered list

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameSkia.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameSkia.tsx
@@ -4,9 +4,11 @@ import { PixelRatio } from 'react-native';
 import {
   Canvas,
   Fill,
+  Group,
   Image,
   ImageShader,
   Mask,
+  Skia,
 } from '@shopify/react-native-skia';
 
 import { chatLineMetrics } from '@app/components/Chat/components/ChatMessage/RichChatMessage.styles';
@@ -111,12 +113,12 @@ function paintImageLayerKey(layer: PaintImageLayer): string {
     layer.rect
       ? `${layer.rect.x},${layer.rect.y},${layer.rect.width},${layer.rect.height}`
       : '',
+    layer.opacity,
   ].join('|');
 }
 
 function renderUrlLayerOverlay(
   layer: PaintImageLayer,
-  index: number,
   maskNode: ReactNode,
 ): ReactNode {
   if (!maskNode) {
@@ -125,9 +127,6 @@ function renderUrlLayerOverlay(
   if (layer.tile) {
     return (
       <TiledPaintLayerOverlay
-        // Static, never-reordered list
-        // eslint-disable-next-line react-doctor/no-array-index-as-key
-        key={`url-${index}|${paintImageLayerKey(layer)}`}
         url={layer.url}
         tile={layer.tile}
         maskNode={maskNode}
@@ -137,9 +136,6 @@ function renderUrlLayerOverlay(
   if (layer.rect) {
     return (
       <StretchPaintLayerOverlay
-        // Static, never-reordered list
-        // eslint-disable-next-line react-doctor/no-array-index-as-key
-        key={`url-${index}|${paintImageLayerKey(layer)}`}
         url={layer.url}
         rect={layer.rect}
         maskNode={maskNode}
@@ -170,7 +166,54 @@ function renderLayerSlot(
       />
     );
   }
-  return renderUrlLayerOverlay(slot.layer, index, maskNode);
+  const overlay = renderUrlLayerOverlay(slot.layer, maskNode);
+  if (!overlay) {
+    return null;
+  }
+  return (
+    <UrlLayerSpan
+      // Static, never-reordered list
+      // eslint-disable-next-line react-doctor/no-array-index-as-key
+      key={`url-${index}|${paintImageLayerKey(slot.layer)}`}
+      opacity={slot.layer.opacity}
+    >
+      {bitmaps.backingImage ? (
+        <Image
+          image={bitmaps.backingImage}
+          x={0}
+          y={0}
+          width={bitmaps.width}
+          height={bitmaps.height}
+          fit='fill'
+        />
+      ) : null}
+      {overlay}
+    </UrlLayerSpan>
+  );
+}
+
+/**
+ * One URL layer span: base-colour backing under the texture, faded together
+ * by the layer opacity. `layer` forces a real saveLayer so the fade applies
+ * to the flattened span, not to backing and texture independently.
+ */
+function UrlLayerSpan({
+  opacity,
+  children,
+}: {
+  opacity: number;
+  children: ReactNode;
+}) {
+  const layerPaint = useMemo(() => {
+    if (opacity >= 1) {
+      return false;
+    }
+    const paint = Skia.Paint();
+    paint.setAlphaf(opacity);
+    return paint;
+  }, [opacity]);
+
+  return <Group layer={layerPaint}>{children}</Group>;
 }
 
 /**

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameSkia.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameSkia.tsx
@@ -170,6 +170,12 @@ function renderLayerSlot(
   if (!overlay) {
     return null;
   }
+  /**
+   * The bottom-most opaque URL span already sits on the foundation's base
+   * fill; drawing the backing there too would double-composite a
+   * semi-transparent base colour. Same condition as `needsUrlBacking`.
+   */
+  const needsBacking = index > 0 || slot.layer.opacity < 1;
   return (
     <UrlLayerSpan
       // Static, never-reordered list
@@ -177,7 +183,7 @@ function renderLayerSlot(
       key={`url-${index}|${paintImageLayerKey(slot.layer)}`}
       opacity={slot.layer.opacity}
     >
-      {bitmaps.backingImage ? (
+      {needsBacking && bitmaps.backingImage ? (
         <Image
           image={bitmaps.backingImage}
           x={0}

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/paintBitmapCacheLifecycle.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/paintBitmapCacheLifecycle.test.ts
@@ -11,6 +11,7 @@ import {
 interface FakeEntry extends DisposablePaintBitmaps {
   staticImage: { dispose: jest.Mock };
   maskImage: { dispose: jest.Mock };
+  backingImage: { dispose: jest.Mock };
   strokeImage: { dispose: jest.Mock };
   layerSlots: { kind: 'baked'; image: { dispose: jest.Mock } }[];
 }
@@ -19,6 +20,7 @@ function createEntry({ bakedLayers = 0 }: { bakedLayers?: number } = {}) {
   return {
     staticImage: { dispose: jest.fn() },
     maskImage: { dispose: jest.fn() },
+    backingImage: { dispose: jest.fn() },
     strokeImage: { dispose: jest.fn() },
     layerSlots: Array.from({ length: bakedLayers }, () => ({
       kind: 'baked' as const,
@@ -31,6 +33,7 @@ function disposeCallCounts(entry: FakeEntry) {
   return {
     staticImage: entry.staticImage.dispose.mock.calls.length,
     maskImage: entry.maskImage.dispose.mock.calls.length,
+    backingImage: entry.backingImage.dispose.mock.calls.length,
     strokeImage: entry.strokeImage.dispose.mock.calls.length,
     bakedLayers: entry.layerSlots.map(
       slot => slot.image.dispose.mock.calls.length,
@@ -77,6 +80,7 @@ describe('paintBitmapCacheLifecycle', () => {
     expect(disposeCallCounts(evicted)).toEqual({
       staticImage: 1,
       maskImage: 1,
+      backingImage: 1,
       strokeImage: 1,
       bakedLayers: [1, 1],
     });
@@ -95,6 +99,7 @@ describe('paintBitmapCacheLifecycle', () => {
     expect(disposeCallCounts(retained)).toEqual({
       staticImage: 0,
       maskImage: 0,
+      backingImage: 0,
       strokeImage: 0,
       bakedLayers: [0],
     });
@@ -116,6 +121,7 @@ describe('paintBitmapCacheLifecycle', () => {
     expect(disposeCallCounts(retained)).toEqual({
       staticImage: 0,
       maskImage: 0,
+      backingImage: 0,
       strokeImage: 0,
       bakedLayers: [0],
     });
@@ -125,6 +131,7 @@ describe('paintBitmapCacheLifecycle', () => {
     expect(disposeCallCounts(retained)).toEqual({
       staticImage: 1,
       maskImage: 1,
+      backingImage: 1,
       strokeImage: 1,
       bakedLayers: [1],
     });
@@ -141,6 +148,7 @@ describe('paintBitmapCacheLifecycle', () => {
     expect(disposeCallCounts(cached)).toEqual({
       staticImage: 0,
       maskImage: 0,
+      backingImage: 0,
       strokeImage: 0,
       bakedLayers: [],
     });
@@ -173,6 +181,7 @@ describe('paintBitmapCacheLifecycle', () => {
     expect(disposeCallCounts(cleared)).toEqual({
       staticImage: 1,
       maskImage: 1,
+      backingImage: 1,
       strokeImage: 1,
       bakedLayers: [1],
     });
@@ -190,6 +199,7 @@ describe('paintBitmapCacheLifecycle', () => {
     expect(disposeCallCounts(onScreen)).toEqual({
       staticImage: 0,
       maskImage: 0,
+      backingImage: 0,
       strokeImage: 0,
       bakedLayers: [],
     });
@@ -199,6 +209,7 @@ describe('paintBitmapCacheLifecycle', () => {
     expect(disposeCallCounts(onScreen)).toEqual({
       staticImage: 1,
       maskImage: 1,
+      backingImage: 1,
       strokeImage: 1,
       bakedLayers: [],
     });
@@ -221,6 +232,7 @@ describe('paintBitmapCacheLifecycle', () => {
     expect(disposeCallCounts(disposed)).toEqual({
       staticImage: 1,
       maskImage: 1,
+      backingImage: 1,
       strokeImage: 1,
       bakedLayers: [],
     });
@@ -250,6 +262,7 @@ describe('paintBitmapCacheLifecycle', () => {
     expect(disposeCallCounts(evicted)).toEqual({
       staticImage: 0,
       maskImage: 0,
+      backingImage: 0,
       strokeImage: 0,
       bakedLayers: [],
     });
@@ -259,6 +272,7 @@ describe('paintBitmapCacheLifecycle', () => {
     expect(disposeCallCounts(evicted)).toEqual({
       staticImage: 1,
       maskImage: 1,
+      backingImage: 1,
       strokeImage: 1,
       bakedLayers: [],
     });

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/skiaPaintedUsernameRasterizer.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/skiaPaintedUsernameRasterizer.test.ts
@@ -43,6 +43,7 @@ describe('buildPaintImageLayers', () => {
         url: 'https://cdn.7tv.app/paint/abc/1x.webp',
         rect: { x: 5, y: 3, width: 50, height: 20 },
         tile: null,
+        opacity: 1,
       },
     ]);
   });
@@ -63,6 +64,7 @@ describe('buildPaintImageLayers', () => {
         url: 'https://cdn.7tv.app/paint/abc/1x.webp',
         rect: null,
         tile: { tx: 'repeat', ty: 'decal' },
+        opacity: 1,
       },
     ]);
   });
@@ -80,6 +82,7 @@ describe('buildPaintImageLayers', () => {
         url: 'https://cdn.7tv.app/paint/abc/1x.webp',
         rect: { x: 5, y: 3, width: 50, height: 20 },
         tile: null,
+        opacity: 1,
       },
     ]);
   });
@@ -109,11 +112,38 @@ describe('buildPaintImageLayers', () => {
         url: 'https://cdn.7tv.app/paint/bottom/1x.webp',
         rect: null,
         tile: { tx: 'repeat', ty: 'repeat' },
+        opacity: 1,
       },
       {
         url: 'https://cdn.7tv.app/paint/top/1x.webp',
         rect: { x: 5, y: 3, width: 50, height: 20 },
         tile: null,
+        opacity: 1,
+      },
+    ]);
+  });
+
+  test('threads v4 layer opacity through and skips fully transparent layers', () => {
+    const layers = buildPaintImageLayers({
+      ...layoutBox,
+      layers: [
+        createLayer({
+          image_url: 'https://cdn.7tv.app/paint/faded/1x.webp',
+          opacity: 0.5,
+        }),
+        createLayer({
+          image_url: 'https://cdn.7tv.app/paint/hidden/1x.webp',
+          opacity: 0,
+        }),
+      ],
+    });
+
+    expect(layers).toEqual<PaintImageLayer[]>([
+      {
+        url: 'https://cdn.7tv.app/paint/faded/1x.webp',
+        rect: { x: 5, y: 3, width: 50, height: 20 },
+        tile: null,
+        opacity: 0.5,
       },
     ]);
   });
@@ -169,10 +199,64 @@ describe('planPaintLayerSlotKinds', () => {
     expect(
       planPaintLayerSlotKinds([
         createLayer({ image_url: 'https://cdn.7tv.app/paint/top/1x.webp' }),
-        createLayer({ function: 'LINEAR_GRADIENT' }),
-        createLayer({ function: 'RADIAL_GRADIENT' }),
+        createLayer({
+          function: 'LINEAR_GRADIENT',
+          stops: {
+            0: { at: 0, color: 0xff0000ff },
+            1: { at: 1, color: 0x0000ffff },
+            length: 2,
+          },
+        }),
+        createLayer({
+          function: 'RADIAL_GRADIENT',
+          stops: {
+            0: { at: 0, color: 0xff0000ff },
+            1: { at: 1, color: 0x0000ffff },
+            length: 2,
+          },
+        }),
         createLayer({ image_url: 'https://cdn.7tv.app/paint/bottom/1x.webp' }),
       ]),
     ).toEqual(['url', 'baked', 'url']);
+  });
+
+  test('renders no span for zero-stop gradients or fully transparent layers', () => {
+    expect(
+      planPaintLayerSlotKinds([
+        createLayer({ function: 'LINEAR_GRADIENT' }),
+        createLayer({
+          image_url: 'https://cdn.7tv.app/paint/hidden/1x.webp',
+          opacity: 0,
+        }),
+        createLayer({ image_url: 'https://cdn.7tv.app/paint/shown/1x.webp' }),
+      ]),
+    ).toEqual(['url']);
+  });
+
+  test('a dead URL layer does not split a gradient batch', () => {
+    expect(
+      planPaintLayerSlotKinds([
+        createLayer({
+          function: 'LINEAR_GRADIENT',
+          stops: {
+            0: { at: 0, color: 0xff0000ff },
+            1: { at: 1, color: 0x0000ffff },
+            length: 2,
+          },
+        }),
+        createLayer({
+          image_url: 'https://cdn.7tv.app/paint/hidden/1x.webp',
+          opacity: 0,
+        }),
+        createLayer({
+          function: 'RADIAL_GRADIENT',
+          stops: {
+            0: { at: 0, color: 0xff0000ff },
+            1: { at: 1, color: 0x0000ffff },
+            length: 2,
+          },
+        }),
+      ]),
+    ).toEqual(['baked']);
   });
 });

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/skiaPaintedUsernameRasterizer.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/__tests__/skiaPaintedUsernameRasterizer.test.ts
@@ -18,6 +18,7 @@ const createLayer = (
   canvas_repeat: 'unset',
   at: null,
   size: null,
+  opacity: 1,
   ...overrides,
 });
 

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintBitmapCacheLifecycle.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintBitmapCacheLifecycle.ts
@@ -16,6 +16,7 @@ interface DisposableTexture {
 export interface DisposablePaintBitmaps {
   staticImage: DisposableTexture;
   maskImage: DisposableTexture | null;
+  backingImage: DisposableTexture | null;
   strokeImage: DisposableTexture | null;
   layerSlots: ({ kind: 'baked'; image: DisposableTexture } | { kind: 'url' })[];
 }
@@ -53,6 +54,7 @@ function disposeTextures(entry: DisposablePaintBitmaps): void {
   disposedEntries.add(entry);
   entry.staticImage.dispose();
   entry.maskImage?.dispose();
+  entry.backingImage?.dispose();
   entry.strokeImage?.dispose();
   for (const slot of entry.layerSlots) {
     if (slot.kind === 'baked') {

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintCss/__fixtures__/paintCss.fixture.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintCss/__fixtures__/paintCss.fixture.ts
@@ -25,6 +25,7 @@ export function makeLayer(overrides: Partial<PaintLayerData>): PaintLayerData {
     canvas_repeat: '',
     at: null,
     size: null,
+    opacity: 1,
     ...overrides,
   };
 }

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintCss/__tests__/buildPaintCssDeclarations.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintCss/__tests__/buildPaintCssDeclarations.test.ts
@@ -16,7 +16,8 @@ describe('buildPaintCssDeclarations', () => {
         makeLayer({
           function: 'LINEAR_GRADIENT',
           angle: 90,
-          // Out of order on purpose: stops must be sorted by position.
+          // Out of order on purpose: stops are emitted in written order and
+          // the browser clamps positions, exactly like the reference CSS.
           stops: toIndexed([
             { at: 1, color: BLUE },
             { at: 0, color: RED },
@@ -31,7 +32,7 @@ describe('buildPaintCssDeclarations', () => {
     expect(buildPaintCssDeclarations(paint)).toEqual<PaintCssDeclarations>({
       color: 'inherit',
       backgroundImage:
-        'linear-gradient(90deg, rgba(255, 0, 0, 1.000) 0%, rgba(0, 0, 255, 1.000) 100%)',
+        'linear-gradient(90deg, rgba(0, 0, 255, 1.000) 100%, rgba(255, 0, 0, 1.000) 0%)',
       backgroundPosition: '0% 0%',
       backgroundSize: 'auto',
       backgroundRepeat: 'unset',

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintCss/__tests__/buildPaintCssDeclarations.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintCss/__tests__/buildPaintCssDeclarations.test.ts
@@ -139,7 +139,7 @@ describe('buildPaintCssDeclarations', () => {
     });
   });
 
-  test('URL layer with empty image_url emits none instead of invalid url()', () => {
+  test('unrenderable layers produce no background entry at all', () => {
     const paint = makePaint({
       layers: toIndexed([
         makeLayer({
@@ -154,16 +154,20 @@ describe('buildPaintCssDeclarations', () => {
           function: 'URL',
           image_url: '',
         }),
+        makeLayer({
+          function: 'RADIAL_GRADIENT',
+          stops: toIndexed([]),
+        }),
       ]),
     });
 
     expect(buildPaintCssDeclarations(paint)).toEqual<PaintCssDeclarations>({
       color: 'inherit',
       backgroundImage:
-        'linear-gradient(90deg, rgba(255, 0, 0, 1.000) 0%, rgba(0, 0, 255, 1.000) 100%), none',
-      backgroundPosition: '0% 0%, 0% 0%',
-      backgroundSize: 'auto, auto',
-      backgroundRepeat: 'unset, unset',
+        'linear-gradient(90deg, rgba(255, 0, 0, 1.000) 0%, rgba(0, 0, 255, 1.000) 100%)',
+      backgroundPosition: '0% 0%',
+      backgroundSize: 'auto',
+      backgroundRepeat: 'unset',
       filter: 'inherit',
       fontWeight: 'inherit',
       webkitTextStrokeWidth: 'inherit',
@@ -171,5 +175,22 @@ describe('buildPaintCssDeclarations', () => {
       textShadow: 'unset',
       textTransform: 'unset',
     });
+  });
+
+  test('a single-stop gradient renders as its currentColor backing', () => {
+    const paint = makePaint({
+      layers: toIndexed([
+        makeLayer({
+          function: 'LINEAR_GRADIENT',
+          angle: 90,
+          stops: toIndexed([{ at: 0, color: RED }]),
+        }),
+      ]),
+    });
+
+    const declarations = buildPaintCssDeclarations(paint);
+    expect(declarations.backgroundImage).toBe(
+      'linear-gradient(0deg, currentColor 0%, currentColor 100%)',
+    );
   });
 });

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintCss/buildPaintCssDeclarations.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintCss/buildPaintCssDeclarations.ts
@@ -6,6 +6,7 @@ import type {
   PaintStop,
 } from '@app/types/seventv/cosmetics';
 import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
+import { sevenTvColorToRgba } from '@app/utils/color/sevenTvColorToRgba';
 
 import type { PaintCssDeclarations } from './types';
 import { webKitSafeLayerImageUrl } from './webKitSafeLayerImageUrl';
@@ -17,15 +18,23 @@ type CssLayer = {
   repeat: string;
 };
 
-function sortedLayerStops(layer: PaintLayerData): PaintStop[] {
-  return indexedCollectionToArray<PaintStop>(layer.stops)
-    .slice()
-    .sort((a, b) => a.at - b.at);
+function stopColorCss(color: number, layerOpacity: number): string {
+  if (layerOpacity >= 1) {
+    return sevenTvColorToCss(color);
+  }
+  const { r, g, b, a } = sevenTvColorToRgba(color);
+  return `rgba(${r}, ${g}, ${b}, ${((a / 255) * layerOpacity).toFixed(3)})`;
 }
 
-function cssStopList(stops: PaintStop[]): string {
-  return stops
-    .map(stop => `${sevenTvColorToCss(stop.color)} ${stop.at * 100}%`)
+/**
+ * Stops stay in written order - the browser clamps out-of-order positions
+ * itself (css-images-3 §3.4.2). Layer opacity folds into each stop's alpha,
+ * since a single-element background list has no per-layer opacity.
+ */
+function cssStopList(layer: PaintLayerData): string {
+  const layerOpacity = layer.opacity ?? 1;
+  return indexedCollectionToArray<PaintStop>(layer.stops)
+    .map(stop => `${stopColorCss(stop.color, layerOpacity)} ${stop.at * 100}%`)
     .join(', ');
 }
 
@@ -33,10 +42,10 @@ function cssLayer(layer: PaintLayerData): CssLayer {
   let image: string;
   switch (layer.function) {
     case 'LINEAR_GRADIENT':
-      image = `${layer.repeat ? 'repeating-' : ''}linear-gradient(${layer.angle ?? 0}deg, ${cssStopList(sortedLayerStops(layer))})`;
+      image = `${layer.repeat ? 'repeating-' : ''}linear-gradient(${layer.angle ?? 0}deg, ${cssStopList(layer)})`;
       break;
     case 'RADIAL_GRADIENT':
-      image = `${layer.repeat ? 'repeating-' : ''}radial-gradient(${layer.shape ?? 'circle'}, ${cssStopList(sortedLayerStops(layer))})`;
+      image = `${layer.repeat ? 'repeating-' : ''}radial-gradient(${layer.shape ?? 'circle'}, ${cssStopList(layer)})`;
       break;
     case 'URL':
       // Empty URLs are skipped by Skia/RN paths; emit `none` so invalid

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintCss/buildPaintCssDeclarations.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintCss/buildPaintCssDeclarations.ts
@@ -83,9 +83,12 @@ function cssLayer(layer: PaintLayerData): CssLayer {
 export function buildPaintCssDeclarations(
   paint: PaintData,
 ): PaintCssDeclarations {
-  const layers = getPaintLayers(paint)
-    .filter(isRenderablePaintLayer)
-    .map(cssLayer);
+  const layers: CssLayer[] = [];
+  for (const layer of getPaintLayers(paint)) {
+    if (isRenderablePaintLayer(layer)) {
+      layers.push(cssLayer(layer));
+    }
+  }
   const shadows = indexedCollectionToArray(paint.shadows);
   const textStyle = paint.textStyle;
   const textShadows = textStyle?.shadows

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintCss/buildPaintCssDeclarations.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintCss/buildPaintCssDeclarations.ts
@@ -1,4 +1,5 @@
 import { getPaintLayers } from '@app/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/getPaintLayers';
+import { isRenderablePaintLayer } from '@app/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/isRenderablePaintLayer';
 import { indexedCollectionToArray } from '@app/services/ws/util/indexedCollection';
 import type {
   PaintData,
@@ -32,7 +33,7 @@ function stopColorCss(color: number, layerOpacity: number): string {
  * since a single-element background list has no per-layer opacity.
  */
 function cssStopList(layer: PaintLayerData): string {
-  const layerOpacity = layer.opacity ?? 1;
+  const layerOpacity = layer.opacity;
   return indexedCollectionToArray<PaintStop>(layer.stops)
     .map(stop => `${stopColorCss(stop.color, layerOpacity)} ${stop.at * 100}%`)
     .join(', ');
@@ -42,17 +43,24 @@ function cssLayer(layer: PaintLayerData): CssLayer {
   let image: string;
   switch (layer.function) {
     case 'LINEAR_GRADIENT':
-      image = `${layer.repeat ? 'repeating-' : ''}linear-gradient(${layer.angle ?? 0}deg, ${cssStopList(layer)})`;
-      break;
     case 'RADIAL_GRADIENT':
-      image = `${layer.repeat ? 'repeating-' : ''}radial-gradient(${layer.shape ?? 'circle'}, ${cssStopList(layer)})`;
+      /**
+       * A single-stop gradient is invalid CSS, and one invalid entry wipes
+       * the whole comma-separated background-image list; the reference span
+       * would show only its currentColor backing, so emit exactly that.
+       */
+      if (layer.stops.length < 2) {
+        image = 'linear-gradient(0deg, currentColor 0%, currentColor 100%)';
+      } else if (layer.function === 'LINEAR_GRADIENT') {
+        image = `${layer.repeat ? 'repeating-' : ''}linear-gradient(${layer.angle ?? 0}deg, ${cssStopList(layer)})`;
+      } else {
+        image = `${layer.repeat ? 'repeating-' : ''}radial-gradient(${layer.shape ?? 'circle'}, ${cssStopList(layer)})`;
+      }
       break;
     case 'URL':
-      // Empty URLs are skipped by Skia/RN paths; emit `none` so invalid
-      // `url()` cannot wipe a comma-separated background-image list.
-      image = layer.image_url
-        ? `url(${webKitSafeLayerImageUrl(layer.image_url)})`
-        : 'none';
+      // Empty urls never reach here; unrenderable layers are filtered out
+      // before the css layer list is built.
+      image = `url(${webKitSafeLayerImageUrl(layer.image_url)})`;
       break;
     default:
       image = 'none';
@@ -75,7 +83,9 @@ function cssLayer(layer: PaintLayerData): CssLayer {
 export function buildPaintCssDeclarations(
   paint: PaintData,
 ): PaintCssDeclarations {
-  const layers = getPaintLayers(paint).map(cssLayer);
+  const layers = getPaintLayers(paint)
+    .filter(isRenderablePaintLayer)
+    .map(cssLayer);
   const shadows = indexedCollectionToArray(paint.shadows);
   const textStyle = paint.textStyle;
   const textShadows = textStyle?.shadows

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/__tests__/cssClampedStops.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/__tests__/cssClampedStops.test.ts
@@ -1,0 +1,29 @@
+import { cssClampedStops } from '../cssClampedStops';
+
+describe('cssClampedStops', () => {
+  test('keeps in-order stops untouched', () => {
+    const stops = [
+      { at: 0, color: 1 },
+      { at: 0.5, color: 2 },
+      { at: 1, color: 3 },
+    ];
+
+    expect(cssClampedStops(stops)).toEqual(stops);
+  });
+
+  test('clamps out-of-order positions to the running maximum', () => {
+    expect(
+      cssClampedStops([
+        { at: 0, color: 1 },
+        { at: 0.5, color: 2 },
+        { at: 0.3, color: 3 },
+        { at: 0.8, color: 4 },
+      ]),
+    ).toEqual([
+      { at: 0, color: 1 },
+      { at: 0.5, color: 2 },
+      { at: 0.5, color: 3 },
+      { at: 0.8, color: 4 },
+    ]);
+  });
+});

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/__tests__/isRenderablePaintLayer.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/__tests__/isRenderablePaintLayer.test.ts
@@ -13,6 +13,7 @@ function createLayer(overrides: Partial<PaintLayerData>): PaintLayerData {
     canvas_repeat: '',
     at: null,
     size: null,
+    opacity: 1,
     ...overrides,
   };
 }

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/__tests__/isRenderablePaintLayer.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/__tests__/isRenderablePaintLayer.test.ts
@@ -1,0 +1,62 @@
+import type { PaintLayerData } from '@app/types/seventv/cosmetics';
+
+import { isRenderablePaintLayer } from '../isRenderablePaintLayer';
+
+function createLayer(overrides: Partial<PaintLayerData>): PaintLayerData {
+  return {
+    function: 'LINEAR_GRADIENT',
+    image_url: '',
+    stops: { length: 0 },
+    angle: 0,
+    shape: 'circle',
+    repeat: false,
+    canvas_repeat: '',
+    at: null,
+    size: null,
+    ...overrides,
+  };
+}
+
+const TWO_STOPS = {
+  0: { at: 0, color: 0xff0000ff },
+  1: { at: 1, color: 0x0000ffff },
+  length: 2,
+};
+
+describe('isRenderablePaintLayer', () => {
+  test('gradient with stops renders; zero-stop gradient does not', () => {
+    expect(isRenderablePaintLayer(createLayer({ stops: TWO_STOPS }))).toBe(
+      true,
+    );
+    expect(isRenderablePaintLayer(createLayer({}))).toBe(false);
+  });
+
+  test('url layer needs an image url', () => {
+    expect(
+      isRenderablePaintLayer(
+        createLayer({
+          function: 'URL',
+          image_url: 'https://cdn.7tv.app/paint/abc/1x.webp',
+        }),
+      ),
+    ).toBe(true);
+    expect(isRenderablePaintLayer(createLayer({ function: 'URL' }))).toBe(
+      false,
+    );
+  });
+
+  test('fully transparent layers never render', () => {
+    expect(
+      isRenderablePaintLayer(createLayer({ stops: TWO_STOPS, opacity: 0 })),
+    ).toBe(false);
+    expect(
+      isRenderablePaintLayer(
+        createLayer({
+          function: 'URL',
+          image_url: 'https://cdn.7tv.app/paint/abc/1x.webp',
+          opacity: 0,
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/__tests__/paintLayerKey.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/__tests__/paintLayerKey.test.ts
@@ -13,6 +13,7 @@ function layer(overrides: Partial<PaintLayerData> = {}): PaintLayerData {
     canvas_repeat: 'unset',
     at: null,
     size: null,
+    opacity: 1,
     ...overrides,
   };
 }

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/buildLayerGradientConfig.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/buildLayerGradientConfig.ts
@@ -3,21 +3,13 @@ import type { PaintLayerData, PaintStop } from '@app/types/seventv/cosmetics';
 import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
 
 import { angleToPoints } from '../angleToPoints';
+import { cssClampedStops } from './cssClampedStops';
 
 export interface LayerGradientConfig {
   colors: string[];
   locations: number[];
   start: { x: number; y: number };
   end: { x: number; y: number };
-}
-
-function solidGradientConfig(color: string): LayerGradientConfig {
-  return {
-    colors: [color, color],
-    locations: [0, 1],
-    start: { x: 0, y: 0 },
-    end: { x: 1, y: 0 },
-  };
 }
 
 /**
@@ -69,58 +61,51 @@ function expandRepeatingStops(stops: PaintStop[]): PaintStop[] {
   return expanded;
 }
 
-// Keyed on the (memoised, stable) layer object, then on fallbackColor - the
-// only per-call input. Repeating-gradient stop expansion + sorting + colour
-// conversion are the heaviest paint work; sharing the result across every user
-// wearing the paint is the main per-render saving.
+// Keyed on the (memoised, stable) layer object. Repeating-gradient stop
+// expansion + colour conversion are the heaviest paint work; sharing the
+// result across every user wearing the paint is the main per-render saving.
 const layerGradientConfigCache = new WeakMap<
   PaintLayerData,
-  Map<string, LayerGradientConfig>
+  { config: LayerGradientConfig | null }
 >();
 
+/**
+ * Gradient config for a layer span, or null when the layer draws no gradient
+ * (URL layers, and gradients with fewer than two stops - invalid CSS whose
+ * span keeps only its base-colour backing).
+ */
 export function buildLayerGradientConfig(
   layer: PaintLayerData,
-  fallbackColor: string,
-): LayerGradientConfig {
-  let byFallback = layerGradientConfigCache.get(layer);
-  if (!byFallback) {
-    byFallback = new Map();
-    layerGradientConfigCache.set(layer, byFallback);
-  }
-  const cached = byFallback.get(fallbackColor);
+): LayerGradientConfig | null {
+  const cached = layerGradientConfigCache.get(layer);
   if (cached) {
-    return cached;
+    return cached.config;
   }
-  const config = computeLayerGradientConfig(layer, fallbackColor);
-  byFallback.set(fallbackColor, config);
+  const config = computeLayerGradientConfig(layer);
+  layerGradientConfigCache.set(layer, { config });
   return config;
 }
 
 function computeLayerGradientConfig(
   layer: PaintLayerData,
-  fallbackColor: string,
-): LayerGradientConfig {
-  if (layer.function === 'URL' || !layer.stops || layer.stops.length === 0) {
-    return solidGradientConfig(fallbackColor);
+): LayerGradientConfig | null {
+  if (layer.function === 'URL') {
+    return null;
   }
 
-  let stops = indexedCollectionToArray<PaintStop>(layer.stops)
-    .slice()
-    .sort((a, b) => a.at - b.at);
+  let stops = cssClampedStops(indexedCollectionToArray<PaintStop>(layer.stops));
   if (layer.repeat) {
     stops = expandRepeatingStops(stops);
   }
 
-  const gradientColors = stops.map(stop => sevenTvColorToCss(stop.color));
-
-  if (gradientColors.length < 2) {
-    return solidGradientConfig(gradientColors[0] || fallbackColor);
+  if (stops.length < 2) {
+    return null;
   }
 
   const points = angleToPoints(layer.angle || 0);
 
   return {
-    colors: gradientColors,
+    colors: stops.map(stop => sevenTvColorToCss(stop.color)),
     locations: stops.map(stop => stop.at),
     start: points.start,
     end: points.end,

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/cssClampedStops.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/cssClampedStops.ts
@@ -1,0 +1,17 @@
+import type { PaintStop } from '@app/types/seventv/cosmetics';
+
+/**
+ * CSS keeps colour stops in written order and clamps each position to the
+ * running maximum so far (css-images-3 §3.4.2) - it never reorders them - so
+ * an out-of-order stop becomes a hard transition exactly as the browser
+ * renders the reference CSS.
+ */
+export function cssClampedStops(stops: PaintStop[]): PaintStop[] {
+  let runningMax = Number.NEGATIVE_INFINITY;
+  return stops.map(stop => {
+    runningMax = Math.max(runningMax, stop.at);
+    return runningMax === stop.at
+      ? stop
+      : { at: runningMax, color: stop.color };
+  });
+}

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/getPaintLayers.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/getPaintLayers.ts
@@ -44,6 +44,7 @@ function computePaintLayers(paint: PaintData): PaintLayerData[] {
       canvas_repeat: 'unset',
       at: null,
       size: null,
+      opacity: 1,
     },
   ];
 }

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/isRenderablePaintLayer.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/isRenderablePaintLayer.ts
@@ -6,7 +6,7 @@ import type { PaintLayerData } from '@app/types/seventv/cosmetics';
  * fully transparent layers, which render as nothing.
  */
 export function isRenderablePaintLayer(layer: PaintLayerData): boolean {
-  if ((layer.opacity ?? 1) <= 0) {
+  if (layer.opacity <= 0) {
     return false;
   }
   if (layer.function === 'URL') {

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/isRenderablePaintLayer.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/isRenderablePaintLayer.ts
@@ -1,0 +1,16 @@
+import type { PaintLayerData } from '@app/types/seventv/cosmetics';
+
+/**
+ * Whether a paint layer produces a span at all. The reference drops layers
+ * with nothing to draw (no texture url, no gradient stops) and we also skip
+ * fully transparent layers, which render as nothing.
+ */
+export function isRenderablePaintLayer(layer: PaintLayerData): boolean {
+  if ((layer.opacity ?? 1) <= 0) {
+    return false;
+  }
+  if (layer.function === 'URL') {
+    return Boolean(layer.image_url);
+  }
+  return layer.stops.length > 0;
+}

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/paintLayerKey.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/paintLayerKey.ts
@@ -14,6 +14,7 @@ function paintLayerFingerprint(layer: PaintLayerData): string {
     layer.canvas_repeat,
     layer.at?.join(',') ?? '',
     layer.size?.join(',') ?? '',
+    layer.opacity ?? 1,
     stops,
   ].join('|');
 }

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/paintLayerKey.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/paintLayerKey.ts
@@ -14,7 +14,7 @@ function paintLayerFingerprint(layer: PaintLayerData): string {
     layer.canvas_repeat,
     layer.at?.join(',') ?? '',
     layer.size?.join(',') ?? '',
-    layer.opacity ?? 1,
+    layer.opacity,
     stops,
   ].join('|');
 }

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/skiaPaintedUsernameRasterizer.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/skiaPaintedUsernameRasterizer.ts
@@ -33,6 +33,7 @@ import {
 } from './paintBitmapCacheLifecycle';
 import { getPaintDropShadows } from './paintLayer/getPaintDropShadows';
 import { getPaintLayers } from './paintLayer/getPaintLayers';
+import { isRenderablePaintLayer } from './paintLayer/isRenderablePaintLayer';
 import { isTilingCanvasRepeat } from './paintLayer/isTilingCanvasRepeat';
 import {
   type PaintLayerTileMode,
@@ -97,29 +98,20 @@ function cssClampedLayerStops(layer: PaintLayerData): PaintStop[] {
 
 /**
  * A gradient layer renders as a span when it has at least one stop and is not
- * fully transparent. Zero-stop layers produce no span at all (the reference
- * filters them out); a single-stop layer is an invalid CSS gradient whose
+ * fully transparent. A single-stop layer is an invalid CSS gradient whose
  * span keeps only its base-colour backing.
  */
 function isDrawableGradientLayer(layer: PaintLayerData): boolean {
-  return (
-    layer.function !== 'URL' &&
-    layer.stops.length > 0 &&
-    (layer.opacity ?? 1) > 0
-  );
+  return layer.function !== 'URL' && isRenderablePaintLayer(layer);
 }
 
 /**
- * A URL layer composites live only when it has a texture and is not fully
- * transparent; a dead URL layer produces no span, so it must not push the
- * paint onto the live-composite path or split a gradient batch.
+ * A URL layer composites live only when it produces a span; a dead URL layer
+ * must not push the paint onto the live-composite path or split a gradient
+ * batch.
  */
 function isLiveUrlLayer(layer: PaintLayerData): boolean {
-  return (
-    layer.function === 'URL' &&
-    Boolean(layer.image_url) &&
-    (layer.opacity ?? 1) > 0
-  );
+  return layer.function === 'URL' && isRenderablePaintLayer(layer);
 }
 
 function skColor(color: number): Float32Array {

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/skiaPaintedUsernameRasterizer.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/skiaPaintedUsernameRasterizer.ts
@@ -78,10 +78,48 @@ const BLUR_EXTENT_SIGMAS = 3;
  */
 const GRADIENT_PREMUL_FLAG = 1;
 
-function sortedLayerStops(layer: PaintLayerData): PaintStop[] {
-  return indexedCollectionToArray<PaintStop>(layer.stops)
-    .slice()
-    .sort((a, b) => a.at - b.at);
+/**
+ * CSS keeps colour stops in written order and clamps each position to the
+ * running maximum so far (css-images-3 §3.4.2) - it never reorders them - so
+ * an out-of-order stop becomes a hard transition exactly as the browser
+ * renders the reference CSS.
+ */
+function cssClampedLayerStops(layer: PaintLayerData): PaintStop[] {
+  const stops = indexedCollectionToArray<PaintStop>(layer.stops);
+  let runningMax = Number.NEGATIVE_INFINITY;
+  return stops.map(stop => {
+    runningMax = Math.max(runningMax, stop.at);
+    return runningMax === stop.at
+      ? stop
+      : { at: runningMax, color: stop.color };
+  });
+}
+
+/**
+ * A gradient layer renders as a span when it has at least one stop and is not
+ * fully transparent. Zero-stop layers produce no span at all (the reference
+ * filters them out); a single-stop layer is an invalid CSS gradient whose
+ * span keeps only its base-colour backing.
+ */
+function isDrawableGradientLayer(layer: PaintLayerData): boolean {
+  return (
+    layer.function !== 'URL' &&
+    layer.stops.length > 0 &&
+    (layer.opacity ?? 1) > 0
+  );
+}
+
+/**
+ * A URL layer composites live only when it has a texture and is not fully
+ * transparent; a dead URL layer produces no span, so it must not push the
+ * paint onto the live-composite path or split a gradient batch.
+ */
+function isLiveUrlLayer(layer: PaintLayerData): boolean {
+  return (
+    layer.function === 'URL' &&
+    Boolean(layer.image_url) &&
+    (layer.opacity ?? 1) > 0
+  );
 }
 
 function skColor(color: number): Float32Array {
@@ -96,7 +134,7 @@ function skColor(color: number): Float32Array {
  * `repeating-radial-gradient` do - no stop-expansion approximation.
  */
 function layerShader(layer: PaintLayerData, rect: LayerRect): SkShader | null {
-  const stops = sortedLayerStops(layer);
+  const stops = cssClampedLayerStops(layer);
   if (stops.length < 2) {
     return null;
   }
@@ -477,26 +515,43 @@ function drawPaintedUsername(
     }
   }
 
-  if (options.includeBaseFill) {
-    const basePaint = Skia.Paint();
-    basePaint.setColor(
-      paint.color === null ? Skia.Color(fallbackColor) : skColor(paint.color),
-    );
+  const basePaint = Skia.Paint();
+  basePaint.setColor(
+    paint.color === null ? Skia.Color(fallbackColor) : skColor(paint.color),
+  );
+
+  /**
+   * `PaintData.layers` lists the topmost layer first, so draw back-to-front.
+   * Image (URL) layers composite live; only gradient shaders are baked here.
+   */
+  const gradientsToDraw = (
+    options.gradientLayers ?? [...layout.layers].reverse()
+  ).filter(isDrawableGradientLayer);
+
+  /**
+   * With no layer spans the reference renders the plain username, which the
+   * base fill reproduces; the live-composite foundation also passes an empty
+   * layer list to get the fill that backs its URL textures.
+   */
+  if (options.includeBaseFill && gradientsToDraw.length === 0) {
     drawGlyphs(basePaint);
   }
 
-  /**
-   * `background-image` lists the topmost layer first, so draw back-to-front.
-   * Image (URL) layers composite live; only gradient shaders are baked here.
-   */
-  const gradientsToDraw =
-    options.gradientLayers ??
-    [...layout.layers].reverse().filter(layer => layer.function !== 'URL');
-
   for (const layer of gradientsToDraw) {
-    if (layer.function === 'URL') {
-      continue;
+    const layerOpacity = layer.opacity ?? 1;
+    const grouped = layerOpacity < 1;
+    if (grouped) {
+      const groupPaint = Skia.Paint();
+      groupPaint.setAlphaf(layerOpacity);
+      canvas.saveLayer(groupPaint);
     }
+    /**
+     * Each reference layer span paints `background-color: currentColor`
+     * beneath its own background and the whole span then fades by the layer
+     * opacity, so an upper layer covers lower ones with the base colour
+     * rather than blending into them.
+     */
+    drawGlyphs(basePaint);
     const rect = layerRectInBox(
       layer.at,
       layer.size,
@@ -510,24 +565,26 @@ function drawPaintedUsername(
       height: rect.height,
     };
     const shader = layerShader(layer, canvasRect);
-    if (!shader) {
-      continue;
+    if (shader) {
+      const fillPaint = Skia.Paint();
+      fillPaint.setShader(shader);
+      canvas.save();
+      canvas.clipRect(
+        Skia.XYWHRect(
+          canvasRect.x,
+          canvasRect.y,
+          canvasRect.width,
+          canvasRect.height,
+        ),
+        ClipOp.Intersect,
+        true,
+      );
+      drawGlyphs(fillPaint);
+      canvas.restore();
     }
-    const fillPaint = Skia.Paint();
-    fillPaint.setShader(shader);
-    canvas.save();
-    canvas.clipRect(
-      Skia.XYWHRect(
-        canvasRect.x,
-        canvasRect.y,
-        canvasRect.width,
-        canvasRect.height,
-      ),
-      ClipOp.Intersect,
-      true,
-    );
-    drawGlyphs(fillPaint);
-    canvas.restore();
+    if (grouped) {
+      canvas.restore();
+    }
   }
 
   /**
@@ -575,6 +632,11 @@ export interface PaintImageLayer {
   url: string;
   rect: LogicalRect | null;
   tile: { tx: PaintLayerTileMode; ty: PaintLayerTileMode } | null;
+  /**
+   * v4 layer-span opacity; the live compositor fades the span (backing +
+   * texture) by this.
+   */
+  opacity: number;
 }
 
 /**
@@ -599,6 +661,12 @@ export type PaintLayerSlot =
 export interface PaintBitmaps {
   staticImage: SkImage;
   maskImage: SkImage | null;
+  /**
+   * Base-colour glyphs drawn beneath each URL texture, mirroring the
+   * reference's per-span `background-color: currentColor` backing. Null when
+   * the foundation's own fill already provides it (single opaque URL layer).
+   */
+  backingImage: SkImage | null;
   layerSlots: PaintLayerSlot[];
   strokeImage: SkImage | null;
   /**
@@ -618,9 +686,10 @@ function toPaintImageLayer(
     'glyphWidthPx' | 'glyphHeightPx' | 'originX' | 'originY' | 'scale'
   >,
 ): PaintImageLayer | null {
-  if (layer.function !== 'URL' || !layer.image_url) {
+  if (!isLiveUrlLayer(layer)) {
     return null;
   }
+  const opacity = layer.opacity ?? 1;
   const url = skiaDecodableLayerUrl(layer.image_url);
 
   if (isTilingCanvasRepeat(layer.canvas_repeat, layer.repeat)) {
@@ -628,6 +697,7 @@ function toPaintImageLayer(
       url,
       rect: null,
       tile: paintLayerTileModes(layer.canvas_repeat),
+      opacity,
     };
   }
 
@@ -646,6 +716,7 @@ function toPaintImageLayer(
       height: rect.height / layout.scale,
     },
     tile: null,
+    opacity,
   };
 }
 
@@ -692,14 +763,14 @@ export function planPaintLayerSlotKinds(
   };
 
   for (const layer of [...layers].reverse()) {
-    if (layer.function === 'URL') {
+    if (isLiveUrlLayer(layer)) {
       flushGradients();
-      if (layer.image_url) {
-        kinds.push('url');
-      }
+      kinds.push('url');
       continue;
     }
-    pendingGradients = true;
+    if (isDrawableGradientLayer(layer)) {
+      pendingGradients = true;
+    }
   }
   flushGradients();
 
@@ -735,16 +806,16 @@ function buildPaintLayerSlots(
   };
 
   for (const layer of [...layout.layers].reverse()) {
-    if (layer.function === 'URL') {
+    const imageLayer = toPaintImageLayer(layer, layout);
+    if (imageLayer) {
       flushGradients();
-      const imageLayer = toPaintImageLayer(layer, layout);
-      if (imageLayer) {
-        imageLayers.push(imageLayer);
-        layerSlots.push({ kind: 'url', layer: imageLayer });
-      }
+      imageLayers.push(imageLayer);
+      layerSlots.push({ kind: 'url', layer: imageLayer });
       continue;
     }
-    gradientBatch.push(layer);
+    if (isDrawableGradientLayer(layer)) {
+      gradientBatch.push(layer);
+    }
   }
   flushGradients();
 
@@ -805,14 +876,13 @@ export function getPaintBitmaps(
     return null;
   }
 
-  const hasUrlLayers = layout.layers.some(
-    layer => layer.function === 'URL' && Boolean(layer.image_url),
-  );
+  const hasUrlLayers = layout.layers.some(isLiveUrlLayer);
 
   let staticImage: SkImage | null;
   let layerSlots: PaintLayerSlot[] = [];
   let imageLayers: PaintImageLayer[] = [];
   let strokeImage: SkImage | null = null;
+  let backingImage: SkImage | null = null;
 
   if (hasUrlLayers) {
     staticImage = snapshotPaintSurface(layout, canvas => {
@@ -829,6 +899,27 @@ export function getPaintBitmaps(
     }
 
     ({ layerSlots, imageLayers } = buildPaintLayerSlots(opts, layout));
+
+    /**
+     * A URL span that sits above other layers (or fades) needs its own
+     * base-colour backing in the live composite; the bottom-most opaque URL
+     * already sits on the foundation's fill.
+     */
+    const needsUrlBacking = layerSlots.some(
+      (slot, index) =>
+        slot.kind === 'url' && (index > 0 || slot.layer.opacity < 1),
+    );
+    if (needsUrlBacking) {
+      backingImage = snapshotPaintSurface(layout, canvas => {
+        drawPaintedUsername(canvas, opts, layout, {
+          includeDropShadows: false,
+          includeTextShadows: false,
+          includeBaseFill: true,
+          gradientLayers: [],
+          includeStroke: false,
+        });
+      });
+    }
 
     if (layout.stroke) {
       strokeImage = snapshotPaintSurface(layout, canvas => {
@@ -875,6 +966,7 @@ export function getPaintBitmaps(
   const bitmaps: PaintBitmaps = {
     staticImage,
     maskImage,
+    backingImage,
     layerSlots,
     strokeImage,
     imageLayers,

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/skiaPaintedUsernameRasterizer.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/skiaPaintedUsernameRasterizer.ts
@@ -31,6 +31,7 @@ import {
   clearPaintBitmapCache,
   getCachedPaintBitmaps,
 } from './paintBitmapCacheLifecycle';
+import { cssClampedStops } from './paintLayer/cssClampedStops';
 import { getPaintDropShadows } from './paintLayer/getPaintDropShadows';
 import { getPaintLayers } from './paintLayer/getPaintLayers';
 import { isRenderablePaintLayer } from './paintLayer/isRenderablePaintLayer';
@@ -80,23 +81,6 @@ const BLUR_EXTENT_SIGMAS = 3;
 const GRADIENT_PREMUL_FLAG = 1;
 
 /**
- * CSS keeps colour stops in written order and clamps each position to the
- * running maximum so far (css-images-3 §3.4.2) - it never reorders them - so
- * an out-of-order stop becomes a hard transition exactly as the browser
- * renders the reference CSS.
- */
-function cssClampedLayerStops(layer: PaintLayerData): PaintStop[] {
-  const stops = indexedCollectionToArray<PaintStop>(layer.stops);
-  let runningMax = Number.NEGATIVE_INFINITY;
-  return stops.map(stop => {
-    runningMax = Math.max(runningMax, stop.at);
-    return runningMax === stop.at
-      ? stop
-      : { at: runningMax, color: stop.color };
-  });
-}
-
-/**
  * A gradient layer renders as a span when it has at least one stop and is not
  * fully transparent. A single-stop layer is an invalid CSS gradient whose
  * span keeps only its base-colour backing.
@@ -126,7 +110,9 @@ function skColor(color: number): Float32Array {
  * `repeating-radial-gradient` do - no stop-expansion approximation.
  */
 function layerShader(layer: PaintLayerData, rect: LayerRect): SkShader | null {
-  const stops = cssClampedLayerStops(layer);
+  const stops = cssClampedStops(
+    indexedCollectionToArray<PaintStop>(layer.stops),
+  );
   if (stops.length < 2) {
     return null;
   }
@@ -530,11 +516,10 @@ function drawPaintedUsername(
   }
 
   for (const layer of gradientsToDraw) {
-    const layerOpacity = layer.opacity ?? 1;
-    const grouped = layerOpacity < 1;
+    const grouped = layer.opacity < 1;
     if (grouped) {
       const groupPaint = Skia.Paint();
-      groupPaint.setAlphaf(layerOpacity);
+      groupPaint.setAlphaf(layer.opacity);
       canvas.saveLayer(groupPaint);
     }
     /**
@@ -640,6 +625,19 @@ export type PaintLayerSlot =
   { kind: 'url'; layer: PaintImageLayer } | { kind: 'baked'; image: SkImage };
 
 /**
+ * The bottom-most opaque URL span already sits on the foundation's base
+ * fill; only spans above other slots, or faded ones, need the shared
+ * base-colour backing. Shared by the bitmap builder and the live compositor
+ * so they cannot disagree about when a backing exists.
+ */
+export function urlSlotNeedsBacking(
+  index: number,
+  layer: PaintImageLayer,
+): boolean {
+  return index > 0 || layer.opacity < 1;
+}
+
+/**
  * Cache-friendly render inputs for a painted username. `staticImage` is the
  * foundation (drop shadows, text-shadows, base fill). When the paint has URL
  * layers, `layerSlots` holds back-to-front URL overlays and baked gradient
@@ -681,7 +679,7 @@ function toPaintImageLayer(
   if (!isLiveUrlLayer(layer)) {
     return null;
   }
-  const opacity = layer.opacity ?? 1;
+  const { opacity } = layer;
   const url = skiaDecodableLayerUrl(layer.image_url);
 
   if (isTilingCanvasRepeat(layer.canvas_repeat, layer.repeat)) {
@@ -892,14 +890,9 @@ export function getPaintBitmaps(
 
     ({ layerSlots, imageLayers } = buildPaintLayerSlots(opts, layout));
 
-    /**
-     * A URL span that sits above other layers (or fades) needs its own
-     * base-colour backing in the live composite; the bottom-most opaque URL
-     * already sits on the foundation's fill.
-     */
     const needsUrlBacking = layerSlots.some(
       (slot, index) =>
-        slot.kind === 'url' && (index > 0 || slot.layer.opacity < 1),
+        slot.kind === 'url' && urlSlotNeedsBacking(index, slot.layer),
     );
     if (needsUrlBacking) {
       backingImage = snapshotPaintSurface(layout, canvas => {

--- a/src/components/Chat/util/normalizeSevenTvCosmetics/normalizeSevenTvPaint.ts
+++ b/src/components/Chat/util/normalizeSevenTvCosmetics/normalizeSevenTvPaint.ts
@@ -93,6 +93,7 @@ function normalizePaintLayer(layer: PaintGradientLayer): PaintLayerData {
       layer.size && layer.size.length === 2
         ? [layer.size[0], layer.size[1]]
         : null,
+    opacity: layer.opacity ?? 1,
   };
 }
 

--- a/src/components/Chat/util/normalizeSevenTvCosmetics/types.ts
+++ b/src/components/Chat/util/normalizeSevenTvCosmetics/types.ts
@@ -15,6 +15,7 @@ export type PaintGradientLayer = {
   shape?: string;
   angle?: number;
   repeat?: boolean;
+  opacity?: number;
 };
 
 export type RawSevenTvPaintInput = Partial<PaintData> & {

--- a/src/types/seventv/cosmetics.ts
+++ b/src/types/seventv/cosmetics.ts
@@ -130,6 +130,11 @@ export interface PaintLayerData {
   canvas_repeat: PaintCanvasRepeat;
   at: [number, number] | null;
   size: [number, number] | null;
+  /**
+   * v4 per-layer opacity (0-1); the whole layer span fades by this amount.
+   * Absent on v3-era data, which renderers treat as 1.
+   */
+  opacity?: number;
 }
 
 export interface PaintTextStroke {

--- a/src/types/seventv/cosmetics.ts
+++ b/src/types/seventv/cosmetics.ts
@@ -132,9 +132,9 @@ export interface PaintLayerData {
   size: [number, number] | null;
   /**
    * v4 per-layer opacity (0-1); the whole layer span fades by this amount.
-   * Absent on v3-era data, which renderers treat as 1.
+   * v3-era data carries no opacity; normalization defaults it to 1.
    */
-  opacity?: number;
+  opacity: number;
 }
 
 export interface PaintTextStroke {

--- a/src/utils/color/sevenTvPaintData/__tests__/convertV4PaintToPaintData.test.ts
+++ b/src/utils/color/sevenTvPaintData/__tests__/convertV4PaintToPaintData.test.ts
@@ -1,0 +1,131 @@
+import { PaintRadialGradientShape } from '@app/graphql/generated/gql';
+import { indexedCollectionToArray } from '@app/services/ws/util/indexedCollection';
+import type { PaintLayerData } from '@app/types/seventv/cosmetics';
+import { convertV4PaintToPaintData } from '@app/utils/color/sevenTvPaintData/convertV4PaintToPaintData';
+import type { SevenTvPaintSource } from '@app/utils/color/sevenTvPaintData/types';
+
+const RED = { r: 255, g: 0, b: 0, a: 255 };
+const BLUE = { r: 0, g: 0, b: 255, a: 255 };
+
+const PACKED_RED = 0xff0000ff;
+const PACKED_BLUE = 0x0000ffff;
+
+describe('convertV4PaintToPaintData', () => {
+  test('reverses v4 layer order so the topmost layer is listed first', () => {
+    const source = {
+      id: 'paint-1',
+      name: 'Layered',
+      data: {
+        layers: [
+          {
+            id: 'layer-bottom',
+            opacity: 1,
+            ty: {
+              __typename: 'PaintLayerTypeLinearGradient',
+              angle: 90,
+              repeating: false,
+              stops: [
+                { at: 0, color: RED },
+                { at: 1, color: BLUE },
+              ],
+            },
+          },
+          {
+            id: 'layer-top',
+            opacity: 0.5,
+            ty: {
+              __typename: 'PaintLayerTypeRadialGradient',
+              repeating: true,
+              shape: PaintRadialGradientShape.Ellipse,
+              stops: [
+                { at: 0.25, color: BLUE },
+                { at: 0.75, color: RED },
+              ],
+            },
+          },
+        ],
+        shadows: [],
+      },
+    } satisfies SevenTvPaintSource;
+
+    const paint = convertV4PaintToPaintData(source);
+
+    expect(indexedCollectionToArray(paint.layers)).toEqual<PaintLayerData[]>([
+      {
+        function: 'RADIAL_GRADIENT',
+        stops: {
+          0: { at: 0.25, color: PACKED_BLUE },
+          1: { at: 0.75, color: PACKED_RED },
+          length: 2,
+        },
+        angle: 0,
+        shape: 'ellipse',
+        repeat: true,
+        image_url: '',
+        canvas_repeat: 'unset',
+        at: null,
+        size: [1, 1],
+        opacity: 0.5,
+      },
+      {
+        function: 'LINEAR_GRADIENT',
+        stops: {
+          0: { at: 0, color: PACKED_RED },
+          1: { at: 1, color: PACKED_BLUE },
+          length: 2,
+        },
+        angle: 90,
+        shape: 'circle',
+        repeat: false,
+        image_url: '',
+        canvas_repeat: 'unset',
+        at: null,
+        size: [1, 1],
+        opacity: 1,
+      },
+    ]);
+    expect(paint.color).toBeNull();
+  });
+
+  test('converts a single-colour layer to a two-stop gradient with its opacity', () => {
+    const source = {
+      id: 'paint-2',
+      name: 'Solid',
+      data: {
+        layers: [
+          {
+            id: 'layer-solid',
+            opacity: 0.25,
+            ty: {
+              __typename: 'PaintLayerTypeSingleColor',
+              color: RED,
+            },
+          },
+        ],
+        shadows: [],
+      },
+    } satisfies SevenTvPaintSource;
+
+    const paint = convertV4PaintToPaintData(source);
+
+    expect(indexedCollectionToArray(paint.layers)).toEqual<PaintLayerData[]>([
+      {
+        function: 'LINEAR_GRADIENT',
+        stops: {
+          0: { at: 0, color: PACKED_RED },
+          1: { at: 1, color: PACKED_RED },
+          length: 2,
+        },
+        angle: 0,
+        shape: 'circle',
+        repeat: false,
+        image_url: '',
+        canvas_repeat: 'unset',
+        at: null,
+        size: [1, 1],
+        opacity: 0.25,
+      },
+    ]);
+    expect(paint.color).toBe(PACKED_RED);
+  });
+});

--- a/src/utils/color/sevenTvPaintData/convertV4PaintToPaintData.ts
+++ b/src/utils/color/sevenTvPaintData/convertV4PaintToPaintData.ts
@@ -21,7 +21,7 @@ const packRgba = (color: {
 const convertV4Layer = (
   layer: V4Paint['data']['layers'][number],
 ): PaintGradientLayer | null => {
-  const { ty } = layer;
+  const { ty, opacity } = layer;
   // eslint-disable-next-line no-underscore-dangle
   switch (ty.__typename) {
     case 'PaintLayerTypeLinearGradient':
@@ -35,6 +35,7 @@ const convertV4Layer = (
         })),
         canvas_repeat: '',
         size: [1, 1],
+        opacity,
       };
     case 'PaintLayerTypeRadialGradient':
       return {
@@ -48,6 +49,7 @@ const convertV4Layer = (
         })),
         canvas_repeat: '',
         size: [1, 1],
+        opacity,
       };
     case 'PaintLayerTypeSingleColor': {
       const packed = packRgba(ty.color);
@@ -59,6 +61,7 @@ const convertV4Layer = (
         ],
         canvas_repeat: '',
         size: [1, 1],
+        opacity,
       };
     }
     case 'PaintLayerTypeImage':
@@ -68,6 +71,7 @@ const convertV4Layer = (
         stops: [],
         canvas_repeat: '',
         size: [1, 1],
+        opacity,
       };
     default:
       return null;
@@ -77,9 +81,15 @@ const convertV4Layer = (
 export const convertV4PaintToPaintData = (
   paint: SevenTvPaintSource,
 ): PaintData => {
+  /**
+   * v4 lists layers bottom-to-top (the website stacks them as sibling spans,
+   * later siblings painting on top); `PaintData.layers` keeps the CSS
+   * `background-image` convention of first-is-topmost, so reverse here.
+   */
   const gradients = paint.data.layers
     .map(convertV4Layer)
-    .filter((layer): layer is PaintGradientLayer => layer !== null);
+    .filter((layer): layer is PaintGradientLayer => layer !== null)
+    .reverse();
 
   const singleColorLayer = paint.data.layers.find(
     layer => layer.ty.__typename === 'PaintLayerTypeSingleColor',


### PR DESCRIPTION
# Why

Painted usernames were close to the reference renderers ([7TV website paint.svelte](https://github.com/SevenTV/SevenTV/blob/main/apps/website/src/components/paint.svelte), [UChat paint.svelte](https://github.com/Fiszh/UChat/blob/0ab689681bd477fd135f81fbfeb8ad4066d4e3cf/app/src/components/chat/paint.svelte)) but diverged in ways you can see on real paints:

- v4 per-layer `opacity` was dropped everywhere, so faded layers rendered at full strength.
- v4 lists layers bottom-to-top while `PaintData.layers` keeps the CSS topmost-first convention. Nothing reversed, so multi-layer v4 paints stacked upside down.
- Gradient stops were sorted by position before building shaders and CSS. Browsers never reorder stops - they clamp out-of-order positions to the running max (css-images-3 §3.4.2) - so sorting smoothed away hard transitions that paint authors put there on purpose.
- Layers blended into each other. Each reference span paints `background-color: currentColor` under its own background, so an upper layer covers lower ones with the base colour instead of compositing onto them.

# How

`opacity` rides along from both cosmetic sources (v3 normalize defaults it to 1, v4 convert passes it through) into `PaintLayerData`, the paint-layer cache key, the CSS builder, the RN fallback views and both Skia paths. Baked gradient spans fade through a `saveLayer` alpha; live URL spans render inside a `Group` with a layer paint so backing and texture flatten before the fade, same as `style:opacity` on the reference span.

Every span now draws base-colour glyphs beneath its own background. For live URL spans that means a new `backingImage` bitmap, wired into the bitmap-cache disposal.

Stops keep their written order with running-max clamping. v4 layers get reversed into the topmost-first convention. Span filtering matches the reference: zero-stop gradients and opacity-0 layers produce no span, and a single-stop gradient (invalid CSS) keeps only its backing.

Found while wiring this up: `hasUrlLayers` in `getPaintBitmaps` didn't apply the opacity filter. A paint with a gradient plus an opacity-0 URL layer took the live-composite path, baked the gradient into a layer slot, then rendered through the static-only canvas because `imageLayers` was empty - the gradient silently vanished. A shared `isLiveUrlLayer` predicate now gates `hasUrlLayers`, the slot planner and the slot builder, and a dead URL layer no longer splits a gradient batch into two baked bitmaps.

# Test Plan

`tsc`, eslint and the full Jest suite pass. New coverage:

- `convertV4PaintToPaintData`: layer-order reversal and single-colour opacity (new suite)
- rasterizer: opacity threading, transparent-layer skipping, dead URL layers not splitting gradient batches
- CSS builder: written-order stops with clamping semantics
- cache lifecycle: `backingImage` disposal alongside the other textures

Pixel output isn't unit-testable, so the span semantics still want an on-device look at known layered paints (anything with a fade or an image layer over a gradient).

# Notes

One deliberate divergence: when the bottom-most layer is a semi-transparent URL span, the reference lets the chat background show through, while our live path keeps the opaque base fill underneath because the drop shadows bake from it. The result is a solid-colour name with a faded texture rather than a see-through name. Fixing it properly needs shadow-only foundation bitmaps; documented in the code where it happens.

The single-element CSS path (`buildPaintCssDeclarations`) folds gradient-layer opacity into stop alpha and can't fade URL layers at all - one element has no per-layer opacity. That path is preview/HTML only; the Skia renderer is exact.
