### PR TITLE
chore(infrastructure): use infrastructure commit scope for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: chore(infrastructure)
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5


### PR DESCRIPTION
dependabot commits use `chore(deps)` but `deps` isn't in the commitlint scope enum, so the cz check fails on every dependabot PR. Prefix its commits with `chore(infrastructure)` instead.