### PR TITLE
fix(emotes): restore expo-image webp codec patch

### DIFF
--- a/patches/expo-image@57.0.0.patch
+++ b/patches/expo-image@57.0.0.patch
@@ -1,3 +1,83 @@
+diff --git a/ios/AnimatedImage.swift b/ios/AnimatedImage.swift
+index 350c9e4d90680baf8370e49b3529f6e45781244e..fd438254be1cfd1b4c057a426fa95c9c20943824 100644
+--- a/ios/AnimatedImage.swift
++++ b/ios/AnimatedImage.swift
+@@ -8,16 +8,20 @@ internal import SDWebImage
+ final class AnimatedImage: SDAnimatedImage {
+   var frames: [SDImageFrame]?
+ 
++  var hasMultipleFrames: Bool {
++    return animatedImageFrameCount > 1
++  }
++
+   // MARK: - UIImage
+ 
+   override var images: [UIImage]? {
+-    preloadAllFrames()
+-    return frames?.map({ $0.image })
++    return nil
+   }
+ 
+   override var duration: TimeInterval {
+-    preloadAllFrames()
+-    return frames?.reduce(0, { $0 + $1.duration }) ?? 0.0
++    return (0..<animatedImageFrameCount).reduce(0.0) { total, index in
++      return total + animatedImageDuration(at: index)
++    }
+   }
+ 
+   // MARK: - SDAnimatedImage
+diff --git a/ios/Coders/WebPCoder.swift b/ios/Coders/WebPCoder.swift
+index 785effb851802a339f159fb1189b092b84a949b7..804672e98c2bf367a7dd1ebfeedc0b1085d1681f 100644
+--- a/ios/Coders/WebPCoder.swift
++++ b/ios/Coders/WebPCoder.swift
+@@ -40,6 +40,16 @@ internal final class WebPCoder: NSObject, SDAnimatedImageCoder {
+   }
+ 
+   func decodedImage(with data: Data?, options: [SDImageCoderOption: Any]? = nil) -> UIImage? {
++    // The shared coder instance carries the default `useAppleWebpCodec` rather than the
++    // caller's, so honour the per-decode option here too. `SDImageAWebPCoder` builds
++    // multi-frame animated WebP as a plain `UIImage` of lazy `CGImage`s, which UIKit
++    // renders through a `CAKeyframeAnimation` and decodes on the main thread inside the
++    // CoreAnimation commit - a multi-second hang for a screenful of animated emotes.
++    if self.instantiatedCoder == nil,
++      let useAppleWebpCodec = options?[imageCoderOptionUseAppleWebpCodec] as? Bool {
++      let coder: SDAnimatedImageCoder = useAppleWebpCodec ? SDImageAWebPCoder.shared : SDImageWebPCoder.shared
++      return coder.decodedImage(with: data, options: options)
++    }
+     return self.coder.decodedImage(with: data, options: options)
+   }
+ 
+diff --git a/ios/Image.swift b/ios/Image.swift
+index 5c92efa2ec1ca32fc4c49b0e30f3f809259508f3..2c2dd898a9b5721ac16738640a06d80ebf259190 100644
+--- a/ios/Image.swift
++++ b/ios/Image.swift
+@@ -8,6 +8,9 @@ internal final class Image: SharedRef<UIImage> {
+   }
+ 
+   var isAnimated: Bool {
++    if let animatedImage = ref as? AnimatedImage {
++      return animatedImage.hasMultipleFrames
++    }
+     return !(ref.images?.isEmpty ?? true)
+   }
+ 
+diff --git a/ios/ImageLoader.swift b/ios/ImageLoader.swift
+index de6e2c368e45bedd01e563cf254c006190aca233..cd29dcd08631da9c703175756882af0127164f35 100644
+--- a/ios/ImageLoader.swift
++++ b/ios/ImageLoader.swift
+@@ -14,7 +14,10 @@ internal final class ImageLoader {
+   func load(_ source: ImageSource, options: ImageLoadOptions) async throws -> UIImage {
+     // This loader uses only the disk cache. We may want to give more control on this, but the memory cache
+     // doesn't make much sense for shared refs as they're kept in memory as long as their JS objects.
+-    var context = createSDWebImageContext(forSource: source, cachePolicy: .disk)
++    // `useAppleWebpCodec` defaults to true, but images loaded here become long-lived
++    // `ImageRef`s that are rendered directly, so the Apple codec's lazy frames would be
++    // decoded on the main thread at render time. Use libwebp for the ref path.
++    var context = createSDWebImageContext(forSource: source, cachePolicy: .disk, useAppleWebpCodec: false)
+ 
+     if let maxSize = options.getMaxSize() {
+       // Note that setting the thumbnail size rasterizes vector images into a bitmap.
 diff --git a/ios/ImageView.swift b/ios/ImageView.swift
 index cccedd7adf7328b18bb61333c3fe2473c79e72cd..8917134a516b206eda2bead68bbe151d8d3efc16 100644
 --- a/ios/ImageView.swift


### PR DESCRIPTION
#819 reverted patches/expo-image@57.0.0.patch back to the #678 baseline, which removed the animated webp fix from #795. Internal build 147 was cut from that commit and the watchdog hang (FOAM-TV-MOBILE-25) is expected to reproduce on it.

The revert was based on a repro on testflight b40, but there's no Sentry event on dist:foam-tv-testflight backing it, and we already got burned once by testers actually running the pre-fix prod variant (build 314). No event in Sentry shows the webp hang on a build that verifiably contained the fix.

Without the native hunk, WebPCoder.shared ignores the per-decode useAppleWebpCodec option (upstream constructs it with the default true), so the JS side passing useAppleWebpCodec={false} does nothing on that path - animated webp decodes via SDImageAWebPCoder into lazy ImageIO frames that CoreAnimation decodes on the main thread inside the CA commit. That's the exact stack in FOAM-TV-MOBILE-25.

This restores the four hunks (WebPCoder, AnimatedImage, Image, ImageLoader) unchanged. Native patch, so it needs a fresh internal build - verify on build 148+ with Sentry filtered by dist:foam-tv-internal, and relaunch after any freeze so the fatal hang event uploads.

Fixes FOAM-TV-MOBILE-25