### PR TITLE
chore(infrastructure): make self-hosted runner opt-in for deploys

### DIFF
--- a/.github/workflows/deploy-ota-or-native.yml
+++ b/.github/workflows/deploy-ota-or-native.yml
@@ -40,14 +40,11 @@ on:
         required: false
         type: boolean
         default: false
-      runner:
-        description: 'Runner to use for non-build jobs (use foam when github-hosted runners are degraded)'
+      self_hosted:
+        description: 'Run on the self-hosted foam runner (default is github-hosted)'
         required: false
-        type: choice
-        default: 'github-hosted'
-        options:
-          - github-hosted
-          - foam
+        type: boolean
+        default: false
 
 env:
   EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
@@ -62,7 +59,7 @@ concurrency:
 jobs:
   prepare:
     name: 📋 Prepare
-    runs-on: ${{ inputs.runner == 'foam' && 'foam' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.self_hosted && 'foam' || 'ubuntu-latest' }}
     timeout-minutes: 10
     outputs:
       version: ${{ steps.get_version.outputs.version }}
@@ -87,7 +84,7 @@ jobs:
 
   test:
     name: 🧪 Test
-    runs-on: ${{ inputs.runner == 'foam' && 'foam' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.self_hosted && 'foam' || 'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
       - name: 🏗 Checkout
@@ -107,7 +104,7 @@ jobs:
   detect-changes:
     name: 🔍 Detect Changes
     needs: [prepare, test]
-    runs-on: ${{ inputs.runner == 'foam' && 'foam' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.self_hosted && 'foam' || 'ubuntu-latest' }}
     timeout-minutes: 20
     permissions:
       contents: read
@@ -202,7 +199,7 @@ jobs:
     name: 🔨 Native Build
     needs: [prepare, detect-changes]
     if: needs['detect-changes'].outputs['deploy-type'] == 'build'
-    runs-on: foam
+    runs-on: ${{ inputs.self_hosted && 'foam' || 'macos-latest' }}
     timeout-minutes: 90
     concurrency: eas-build-${{ inputs.variant || 'production' }}-${{ inputs.platform || 'ios' }}
     steps:
@@ -281,7 +278,7 @@ jobs:
     name: 📦 OTA Update
     needs: [prepare, detect-changes]
     if: needs['detect-changes'].outputs['deploy-type'] == 'ota'
-    runs-on: ${{ inputs.runner == 'foam' && 'foam' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.self_hosted && 'foam' || 'ubuntu-latest' }}
     timeout-minutes: 30
     concurrency: eas-update-${{ inputs.variant || 'production' }}-${{ inputs.platform || 'ios' }}
     outputs:
@@ -402,7 +399,7 @@ jobs:
     name: 📝 Changelog / Release
     needs: [prepare, detect-changes, build, ota]
     if: always() && needs['detect-changes'].result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.ota.result == 'success' || needs.ota.result == 'skipped') && !inputs.dry_run
-    runs-on: ${{ inputs.runner == 'foam' && 'foam' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.self_hosted && 'foam' || 'ubuntu-latest' }}
     timeout-minutes: 20
     permissions:
       contents: write
@@ -496,7 +493,7 @@ jobs:
     name: 📢 Slack Notification
     needs: [release]
     if: always() && needs.release.result == 'success' && !inputs.dry_run
-    runs-on: ${{ inputs.runner == 'foam' && 'foam' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.self_hosted && 'foam' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - name: 🏗 Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   fingerprint:
     name: 🔍 Check Fingerprint
-    runs-on: foam
+    runs-on: macos-latest
     timeout-minutes: 15
     outputs:
       hash: ${{ steps.fingerprint.outputs.hash }}
@@ -60,7 +60,7 @@ jobs:
     name: 🔨 Build E2E App
     needs: fingerprint
     if: needs.fingerprint.outputs.cache-hit != 'true' || inputs.force_rebuild
-    runs-on: foam
+    runs-on: macos-latest
     timeout-minutes: 90
     steps:
       - name: 🏗 Checkout
@@ -117,7 +117,7 @@ jobs:
     name: 🧪 Run E2E Tests
     needs: [fingerprint, build]
     if: always() && needs.fingerprint.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped')
-    runs-on: foam
+    runs-on: macos-latest
     timeout-minutes: 45
     steps:
       - name: 🏗 Checkout


### PR DESCRIPTION
foam (self-hosted) is now opt-in only, via a checkbox on deploy-ota-or-native. Everything else runs on github-hosted runners.

- deploy-ota-or-native: replaced the `runner` choice input with a `self_hosted` boolean (default off). The native build job was hardcoded to foam - it now follows the checkbox too, falling back to macos-latest since it runs `eas build --local`
- e2e: moved off foam onto macos-latest (needs macOS for the local iOS build + simulator)
- self-hosted-runner.yml stays on foam - it's the smoke test for the runner itself and only fires on dispatch or the self-hosted-test label

caveat: android native builds with the box unchecked will likely fail at gradle - GH's arm64 macOS images don't ship the android SDK. tick the box for android native builds; android OTA is unaffected (ubuntu).