### PR TITLE
fix(app): disable synchronous screens updates and freeze, stop shipping cached js in release builds

### DIFF
--- a/.github/actions/native-build-submit/action.yml
+++ b/.github/actions/native-build-submit/action.yml
@@ -33,6 +33,9 @@ runs:
         SENTRY_RELEASE: ${{ inputs.sentry_release }}
         SENTRY_DIST: ${{ inputs.sentry_dist }}
         SENTRY_LOAD_DOTENV: 0
+        # A build-cache hit re-serves a whole earlier artifact, embedded JS
+        # bundle included; release builds must never ship stale JS.
+        DISABLE_EAS_BUILD_CACHE: 1
       run: |
         set -euo pipefail
 

--- a/app.config.ts
+++ b/app.config.ts
@@ -201,7 +201,7 @@ const config: ExpoConfig = {
     },
   },
   plugins: [
-    'expo-router',
+    ['expo-router', { disableSynchronousScreensUpdates: true }],
     'expo-image',
     'expo-localization',
     [

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -19,7 +19,7 @@ configureReanimatedLogger({
   strict: false,
 });
 
-enableFreeze(true);
+enableFreeze(false);
 
 WebBrowser.maybeCompleteAuthSession();
 sweepOversizedSentryEnvelopes();


### PR DESCRIPTION
## What

- opt out of react-native-screens synchronous shadow-state updates via the expo-router plugin (`disableSynchronousScreensUpdates: true`)
- flip `enableFreeze(true)` -> `enableFreeze(false)` in the root layout
- set `DISABLE_EAS_BUILD_CACHE=1` for all deploy-pipeline native builds

## Why

TestFlight navigation feels slow. Investigation turned up two problems:

- the 1.0.6 TestFlight binary was cut from the broken dup react-native-screens lockfile state (#803, fixed in #823). That bundle crash-loops at boot (internal 147/148), so the binary that actually shipped almost certainly came from an EAS build-cache fingerprint hit - a cached artifact is re-served whole, stale embedded JS included. Release builds should never take that path, hence the cache opt-out in the deploy action.
- for the next (fresh) build on screens 4.26.2: 4.26.0 turned synchronous screen/header shadow-state updates on by default on iOS, moving layout work onto the main thread during mount/transition (expo ships the plugin kill switch for it), and `enableFreeze(true)` is exposed to the unfixed DelayedFreeze race (software-mansion/react-native-screens#3514) where a state update landing as a screen blurs can freeze navigation for seconds - easy to hit with how chatty the chat store is. Both are now off; if nav is fixed and we want to know which one mattered, re-enable one at a time in internal builds.

## Notes

- `disableSynchronousScreensUpdates` lands in `extra.router` and is applied by expo-router's `initScreensFeatureFlags` at startup; both toggles ride the JS bundle, but HEAD already needs a native build for the screens 4.26.2 bump - deploy testflight as a native build, not OTA

tsc clean, eslint clean, src/app tests green.