### PR TITLE
fix(settings): make full row tappable in ios form navigation rows

### DIFF
--- a/src/screens/SettingsScreen/components/FormNavigationRow.tsx
+++ b/src/screens/SettingsScreen/components/FormNavigationRow.tsx
@@ -6,7 +6,12 @@ import {
   Spacer,
   Text as NativeText,
 } from '@expo/ui/swift-ui';
-import { buttonStyle, foregroundStyle } from '@expo/ui/swift-ui/modifiers';
+import {
+  buttonStyle,
+  contentShape,
+  foregroundStyle,
+  shapes,
+} from '@expo/ui/swift-ui/modifiers';
 import type { SFSymbol } from 'sf-symbols-typescript';
 
 import { theme } from '@app/styles/themes';
@@ -24,7 +29,7 @@ export function FormNavigationRow({
 }: FormNavigationRowProps) {
   return (
     <Button onPress={onPress} modifiers={[buttonStyle('plain')]}>
-      <HStack>
+      <HStack modifiers={[contentShape(shapes.rectangle())]}>
         <Label systemImage={systemImage}>
           <NativeText modifiers={[foregroundStyle(theme.color.text.dark)]}>
             {label}


### PR DESCRIPTION
settings index rows on ios were only tappable on the label/chevron - the plain-style swiftui button only hit-tests visible content, so the spacer in the middle of the row was a dead zone.

added `contentShape(shapes.rectangle())` to the row's HStack, which is the standard swiftui fix (and what the @expo/ui docs recommend for exactly this case). since FormNavigationRow is shared, this also fixes the dev-tools screen and the ios profile card rows.

js-only modifier change, no native rebuild needed.