### PR TITLE
fix(chat): stop reply quotes clipping emotes and mixing type scales

### DIFF
--- a/src/components/Chat/components/ChatMessage/RichChatMessage.styles.ts
+++ b/src/components/Chat/components/ChatMessage/RichChatMessage.styles.ts
@@ -290,6 +290,26 @@ export const styles = StyleSheet.create({
   replyContextEmoteLine: {
     lineHeight: 24,
   },
+  replyContextLinkText: {
+    color: theme.color.brand.twitch,
+    fontSize: theme.fontSize12,
+    lineHeight: 15,
+    textDecorationLine: 'underline',
+  },
+  replyContextLinkTextCompact: {
+    fontSize: theme.fontSize11,
+    lineHeight: 14,
+  },
+  replyContextMentionText: {
+    fontSize: theme.fontSize12,
+    lineHeight: 15,
+    marginHorizontal: 2,
+  },
+  replyContextMentionTextCompact: {
+    fontSize: theme.fontSize11,
+    lineHeight: 14,
+    marginHorizontal: 1,
+  },
   messageText: {
     ...chatLineMetrics.comfortable,
   },
@@ -348,7 +368,8 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     minWidth: 0,
-    marginBottom: 4,
+    marginBottom: 3,
+    marginTop: 2,
     width: '100%',
   },
   replyContextContent: {
@@ -377,7 +398,6 @@ export const styles = StyleSheet.create({
     alignSelf: 'stretch',
     backgroundColor: noticeSurfaceTint(CHAT_NOTICE_ACCENTS.replyToYou, 0.14),
     borderRadius: 4,
-    marginBottom: 4,
     paddingHorizontal: 6,
     paddingVertical: 3,
   },

--- a/src/components/Chat/components/ChatMessage/__tests__/RichChatMessage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/__tests__/RichChatMessage.test.tsx
@@ -76,6 +76,28 @@ const createMockMessage = (
   };
 };
 
+const parseReplyQuote = (text: string): ParsedPart[] =>
+  text.split(' ').map(word => {
+    if (word === 'Kappa') {
+      return {
+        type: 'emote',
+        name: 'Kappa',
+        content: 'Kappa',
+        id: 'kappa-1',
+        url: 'https://example.com/kappa.webp',
+        width: 28,
+        height: 28,
+      } satisfies ParsedPart<'emote'>;
+    }
+    if (word.startsWith('@')) {
+      return { type: 'mention', content: word } satisfies ParsedPart<'mention'>;
+    }
+    if (word.startsWith('http')) {
+      return { type: 'link', content: word } satisfies ParsedPart<'link'>;
+    }
+    return { type: 'text', content: `${word} ` } satisfies ParsedPart<'text'>;
+  });
+
 const touchAt = (pageX: number, pageY: number) => ({
   nativeEvent: { pageX, pageY },
 });
@@ -552,6 +574,62 @@ describe('RichChatMessage', () => {
       expect(otherMention).not.toHaveStyle({
         color: 'rgba(255, 255, 255, 0.5)',
       });
+    });
+
+    test('renders every span of an emote reply quote on the taller emote line', () => {
+      const message = createMockMessage(
+        [{ type: 'text', content: 'sure' }],
+        { 'reply-parent-msg-id': 'parent-msg-456' },
+        {
+          parentDisplayName: 'OriginalUser',
+          replyBody: 'lol Kappa @SomeoneElse https://twitch.tv done',
+          replyDisplayName: 'OriginalUser',
+        },
+      );
+
+      const { getByText } = render(
+        <RichChatMessage
+          {...message}
+          showInlineReplyContext
+          parseTextForEmotes={parseReplyQuote}
+        />,
+      );
+
+      const replyLineMetrics = { fontSize: 12, lineHeight: 24 };
+
+      expect(getByText('Replying to @OriginalUser: ')).toHaveStyle(
+        replyLineMetrics,
+      );
+
+      expect(getByText('lol ')).toHaveStyle(replyLineMetrics);
+
+      expect(getByText('@SomeoneElse')).toHaveStyle(replyLineMetrics);
+
+      expect(getByText('https://twitch.tv')).toHaveStyle(replyLineMetrics);
+
+      expect(getByText('done ')).toHaveStyle(replyLineMetrics);
+    });
+
+    test('keeps the message body at chat scale when the reply quote is scaled down', () => {
+      const message = createMockMessage(
+        [{ type: 'text', content: 'sure' }],
+        { 'reply-parent-msg-id': 'parent-msg-456' },
+        {
+          parentDisplayName: 'OriginalUser',
+          replyBody: 'lol Kappa',
+          replyDisplayName: 'OriginalUser',
+        },
+      );
+
+      const { getByText } = render(
+        <RichChatMessage
+          {...message}
+          showInlineReplyContext
+          parseTextForEmotes={parseReplyQuote}
+        />,
+      );
+
+      expect(getByText('sure')).toHaveStyle({ fontSize: 14, lineHeight: 17 });
     });
   });
 

--- a/src/components/Chat/components/ChatMessage/renderers/ChatMessageBody.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatMessageBody.tsx
@@ -1,3 +1,5 @@
+import type { StyleProp, TextStyle } from 'react-native';
+
 import type { ParsedPart } from '@app/utils/chat/parsedPart';
 import { getParsedPartStringContent } from '@app/utils/chat/parsedPartContent';
 
@@ -6,6 +8,13 @@ import type { UseChatMessagePartRendererArgs } from './useChatMessagePartRendere
 
 type ChatMessageBodyProps = UseChatMessagePartRendererArgs & {
   mode: 'message' | 'system';
+  /**
+   * Metrics for text, link and mention parts on surfaces that render the body
+   * at a different scale than the chat line (the reply quote).
+   */
+  bodyTextStyle?: StyleProp<TextStyle>;
+  linkTextStyle?: StyleProp<TextStyle>;
+  mentionTextStyle?: StyleProp<TextStyle>;
 };
 
 export function ChatMessageBody({

--- a/src/components/Chat/components/ChatMessage/renderers/ChatMessagePart.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatMessagePart.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import type { StyleProp, TextStyle } from 'react-native';
 
 import { MediaLinkCard } from '@app/components/Chat/components/MediaLinkCard';
 import { StvEmoteEvent } from '@app/components/Chat/components/StvEmoteEvent';
@@ -22,6 +23,9 @@ type ChatMessagePartProps = Omit<UseChatMessagePartRendererArgs, 'message'> & {
   message: ParsedPart[];
   mode: 'message' | 'system';
   part: ParsedPart;
+  bodyTextStyle?: StyleProp<TextStyle>;
+  linkTextStyle?: StyleProp<TextStyle>;
+  mentionTextStyle?: StyleProp<TextStyle>;
 };
 
 export function ChatMessagePart({
@@ -42,6 +46,9 @@ export function ChatMessagePart({
   emoteTargetSize,
   textColor,
   part,
+  bodyTextStyle,
+  linkTextStyle,
+  mentionTextStyle,
 }: ChatMessagePartProps) {
   const subMessage =
     'subscriptionEvent' in part ? part.subscriptionEvent?.message : undefined;
@@ -57,9 +64,10 @@ export function ChatMessagePart({
     () => [
       styles.messageText,
       compact && styles.messageTextCompact,
+      bodyTextStyle,
       Boolean(moderationNotice) && styles.moderatedMessageText,
     ],
-    [compact, moderationNotice],
+    [bodyTextStyle, compact, moderationNotice],
   );
 
   if (mode === 'system' && part.type === 'text') {
@@ -98,6 +106,7 @@ export function ChatMessagePart({
           style={[
             styles.messageText,
             compact && styles.messageTextCompact,
+            bodyTextStyle,
             textColor ? getChatColorStyle(textColor) : null,
             Boolean(moderationNotice) && styles.moderatedMessageText,
           ]}
@@ -152,6 +161,7 @@ export function ChatMessagePart({
           style={[
             styles.messageLink,
             compact && styles.messageLinkCompact,
+            linkTextStyle,
             Boolean(moderationNotice) && styles.moderatedMessageText,
           ]}
         >
@@ -195,6 +205,7 @@ export function ChatMessagePart({
           key={getPartKey(part, index)}
           content={getParsedPartStringContent(part)}
           baseTextStyle={mentionBaseTextStyle}
+          mentionTextStyle={mentionTextStyle}
           compact={compact}
           isModerated={Boolean(moderationNotice)}
           getMentionColor={getMentionColor}

--- a/src/components/Chat/components/ChatMessage/renderers/InlineMessageSpans.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/InlineMessageSpans.tsx
@@ -33,6 +33,12 @@ type InlineMessageSpansProps = Pick<
    * emote attachment overflows and clips.
    */
   emoteLineStyle?: StyleProp<TextStyle>;
+  /**
+   * Metrics for link and mention spans on surfaces that render the body at a
+   * different scale than the chat line (the reply quote).
+   */
+  linkTextStyle?: StyleProp<TextStyle>;
+  mentionTextStyle?: StyleProp<TextStyle>;
   textColor?: string;
 };
 
@@ -50,6 +56,8 @@ function InlineMessageSpansComponent({
   emoteTargetSize,
   textStyle,
   emoteLineStyle,
+  linkTextStyle,
+  mentionTextStyle,
   textColor,
 }: InlineMessageSpansProps) {
   const fontScaleStyle = getChatFontScaleStyle(fontScale, compact);
@@ -126,6 +134,7 @@ function InlineMessageSpansComponent({
             styles.messageLink,
             compact && styles.messageLinkCompact,
             fontScaleStyle,
+            linkTextStyle,
             emoteLineStyle,
           ]}
         >
@@ -146,6 +155,7 @@ function InlineMessageSpansComponent({
           baseTextStyle={baseTextStyle}
           fontScaleStyle={fontScaleStyle}
           emoteLineStyle={emoteLineStyle}
+          mentionTextStyle={mentionTextStyle}
           compact={compact}
           getMentionColor={getMentionColor}
           effectiveHighlightedUserSet={effectiveHighlightedUserSet}

--- a/src/components/Chat/components/ChatMessage/renderers/MentionSpan.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/MentionSpan.tsx
@@ -17,6 +17,11 @@ interface MentionSpanProps {
   baseTextStyle?: StyleProp<TextStyle>;
   fontScaleStyle?: StyleProp<TextStyle>;
   emoteLineStyle?: StyleProp<TextStyle>;
+  /**
+   * Replaces the default chat-body mention metrics, for surfaces that render
+   * the body at a different scale (the reply quote).
+   */
+  mentionTextStyle?: StyleProp<TextStyle>;
   compact?: boolean;
   isModerated?: boolean;
   getMentionColor?: (username: string) => string;
@@ -37,6 +42,7 @@ function MentionSpanComponent({
   baseTextStyle,
   fontScaleStyle,
   emoteLineStyle,
+  mentionTextStyle,
   compact,
   isModerated,
   getMentionColor,
@@ -78,6 +84,7 @@ function MentionSpanComponent({
         styles.mention,
         compact && styles.mentionCompact,
         fontScaleStyle,
+        mentionTextStyle,
         emoteLineStyle,
         isHighlightedMention && styles.mentionHighlighted,
         getChatColorStyle(mentionColor),

--- a/src/components/Chat/components/ChatMessage/renderers/ReplyingToHeader.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ReplyingToHeader.tsx
@@ -69,15 +69,28 @@ export function ReplyingToHeader({
   const replyContextIconColor = isReplyingToCurrentUser
     ? CHAT_NOTICE_ACCENTS.replyToYou
     : 'rgba(255, 255, 255, 0.5)';
+  const replyContextEmoteLineStyle = quoteContainsEmotes
+    ? styles.replyContextEmoteLine
+    : undefined;
   const replyContextPrefixTextStyle = [
     styles.replyContextPrefixText,
     compact && styles.replyContextTextCompact,
     isReplyingToCurrentUser && styles.replyContextTextReplyToYou,
+    replyContextEmoteLineStyle,
   ];
   const replyContextBodyTextStyle = [
     styles.replyContextBodyText,
     compact && styles.replyContextTextCompact,
     isReplyingToCurrentUser && styles.replyContextTextReplyToYou,
+    replyContextEmoteLineStyle,
+  ];
+  const replyContextLinkTextStyle = [
+    styles.replyContextLinkText,
+    compact && styles.replyContextLinkTextCompact,
+  ];
+  const replyContextMentionTextStyle = [
+    styles.replyContextMentionText,
+    compact && styles.replyContextMentionTextCompact,
   ];
 
   const content = (
@@ -93,24 +106,21 @@ export function ReplyingToHeader({
       />
       <View style={styles.replyContextContent}>
         {canRenderInlineQuote ? (
-          <Text
-            numberOfLines={1}
-            style={[
-              replyContextPrefixTextStyle,
-              quoteContainsEmotes && styles.replyContextEmoteLine,
-            ]}
-          >
+          <Text numberOfLines={1} style={replyContextPrefixTextStyle}>
             <Text style={replyContextPrefixTextStyle}>
               {parsedReplyBody.length > 0 ? `${prefix}: ` : prefix}
             </Text>
             <InlineMessageSpans
               {...partRendererArgs}
               compact={compact}
+              emoteLineStyle={replyContextEmoteLineStyle}
               emoteTargetSize={
                 compact
                   ? REPLY_CONTEXT_EMOTE_SIZE_COMPACT
                   : REPLY_CONTEXT_EMOTE_SIZE_COMFORTABLE
               }
+              linkTextStyle={replyContextLinkTextStyle}
+              mentionTextStyle={replyContextMentionTextStyle}
               message={parsedReplyBody as InlineFlowPart[]}
               replyPlainMentionTarget={replyPlainMentionTarget}
               textStyle={replyContextBodyTextStyle}
@@ -129,12 +139,15 @@ export function ReplyingToHeader({
                 <View style={styles.replyContextBodyParts}>
                   <ChatMessageBody
                     {...partRendererArgs}
+                    bodyTextStyle={replyContextBodyTextStyle}
                     compact={compact}
                     emoteTargetSize={
                       compact
                         ? REPLY_CONTEXT_EMOTE_SIZE_COMPACT
                         : REPLY_CONTEXT_EMOTE_SIZE_COMFORTABLE
                     }
+                    linkTextStyle={replyContextLinkTextStyle}
+                    mentionTextStyle={replyContextMentionTextStyle}
                     mode='message'
                     message={parsedReplyBody}
                     replyPlainMentionTarget={replyPlainMentionTarget}


### PR DESCRIPTION
# Why

Reply rows look squashed - the emote in a "Replying to @x: ..." quote gets its top chopped off and the line has no room to breathe.

The reply quote applied its taller emote lineHeight (24) to the outer `Text` only. TextKit sizes a line from the paragraph style carried by every span on it, so the nested 15pt spans held the line at 15pt and clipped the 20pt emote attachment. This is the exact failure `InlineMessageLine` already documents and guards against for the main chat line - the reply header just never got the same treatment.

Two more scale mismatches on the same line while I was in there:
- links and non-target @mentions rendered at chat body scale (14pt/17) next to 12pt reply text, in both the inline and the flex (zero-width/overlaid emote) quote paths
- the flex quote path rendered the whole quoted body at 14/17

# How

- `ReplyingToHeader` computes the emote line style once and puts it on every span (prefix, body, links, mentions), instead of only the outer `Text`
- `InlineMessageSpans` / `ChatMessageBody` / `ChatMessagePart` / `MentionSpan` take optional `linkTextStyle` / `mentionTextStyle` / `bodyTextStyle` overrides so a surface can render the body at its own scale. Undefined for every existing caller, so the chat line is untouched
- reply-scale link and mention metrics added to `RichChatMessage.styles.ts`
- small rhythm change: reply header gets `marginTop: 2` / `marginBottom: 3` so the header groups with its own message rather than sitting equidistant between two rows. Dropped the duplicated `marginBottom` on `replyContextRowReplyToYou`

# Test Plan

Two regression tests in `RichChatMessage.test.tsx` assert every span of an emote reply quote lands on 12pt/24 line height, and that the message body below stays at 14/17.

Measured before/after with a throwaway probe that flattens the rendered styles:

before
```
TEXT "Replying to @OriginalUser:" fontSize=12 lineHeight=15
TEXT "lol "                       fontSize=12 lineHeight=15
TEXT "@SomeoneElse"               fontSize=14 lineHeight=17
TEXT "https://x.com"              fontSize=14 lineHeight=17
EMOTE 20x20                       <- 20pt attachment on a 15pt line
```

after
```
TEXT "Replying to @OriginalUser:" fontSize=12 lineHeight=24
TEXT "lol "                       fontSize=12 lineHeight=24
TEXT "@SomeoneElse"               fontSize=12 lineHeight=24
TEXT "https://x.com"              fontSize=12 lineHeight=24
EMOTE 20x20
```

`bun run jest src/components/Chat src/screens/Preferences` - 114 suites / 761 tests pass. `tsc --noEmit` and eslint clean.

Not yet verified on device - worth a look at a reply with an emote in it before this comes out of draft.