### PR TITLE
fix(chat): stop animated emotes decoding through dav1d and animating unpaused

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Name fixture files after the thing under test, using the pattern `{thing}.fixtur
 
 That naming keeps the fixture tied to the surface it supports. A file called `chatHookFixtures.ts` sounds like a generic bucket. A file called `useChat.fixture.ts` says what it exists for and makes it harder to keep adding unrelated test data over time.
 
-The one exception is a fixture the app itself imports. `src/dev/chatHotspotBench` runs the perf fixtures on-device from the `dev-tools/chat-perf` route, so those files are part of the app's module graph. EAS strips `__tests__` directories from the build context, so a fixture under `__tests__` resolves locally and then fails the eager bundle in CI with `Unable to resolve module`. Fixtures shared with the bench live in a sibling `__fixtures__` directory *outside* `__tests__` (for example `src/components/Chat/util/__fixtures__/resolveMessageEmoteParts.perf.fixture.ts`), and the perf-test imports them with `../__fixtures__/...`. The `no-tests-dir-import` ast-grep rules enforce this.
+The one exception is a fixture the app itself imports. `src/dev/chatHotspotBench` runs the perf fixtures on-device from the `dev-tools/chat-perf` route, so those files are part of the app's module graph. EAS strips `__tests__` directories from the build context, so a fixture under `__tests__` resolves locally and then fails the eager bundle in CI with `Unable to resolve module`. Fixtures shared with the bench live in a sibling `__fixtures__` directory _outside_ `__tests__` (for example `src/components/Chat/util/__fixtures__/resolveMessageEmoteParts.perf.fixture.ts`), and the perf-test imports them with `../__fixtures__/...`. The `no-tests-dir-import` ast-grep rules enforce this.
 
 ## Legend State Store Layout
 

--- a/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
@@ -243,11 +243,6 @@ function ChatInlineImageComponent({
   // The native isAnimated getter is a JSI hop per render; the url already
   // encodes the kind for everything but BTTV's bare url form.
   const urlKind = useMemo(() => describeEmoteUrl(sourceUrl).kind, [sourceUrl]);
-  // The ref is consulted only for the url forms that don't encode the kind
-  // (BTTV's bare url, FFZ's bare scale). Requiring one outright used to opt the
-  // whole uri path out of the pause, and animated emotes are deliberately left
-  // out of the channel warm (useCachedEmotes), so that path is where they
-  // normally start - the emotes the pause exists for were the ones skipping it.
   const animated =
     urlKind === null ? sharedRef?.isAnimated === true : urlKind === 'animated';
   const imageRef = useRef<ExpoImage>(null);

--- a/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
@@ -243,9 +243,13 @@ function ChatInlineImageComponent({
   // The native isAnimated getter is a JSI hop per render; the url already
   // encodes the kind for everything but BTTV's bare url form.
   const urlKind = useMemo(() => describeEmoteUrl(sourceUrl).kind, [sourceUrl]);
+  // The ref is consulted only for the url forms that don't encode the kind
+  // (BTTV's bare url, FFZ's bare scale). Requiring one outright used to opt the
+  // whole uri path out of the pause, and animated emotes are deliberately left
+  // out of the channel warm (useCachedEmotes), so that path is where they
+  // normally start - the emotes the pause exists for were the ones skipping it.
   const animated =
-    sharedRef != null &&
-    (urlKind === null ? sharedRef.isAnimated === true : urlKind === 'animated');
+    urlKind === null ? sharedRef?.isAnimated === true : urlKind === 'animated';
   const imageRef = useRef<ExpoImage>(null);
   useEffect(() => {
     if (!rowVisibility || !animated) {

--- a/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
@@ -149,6 +149,48 @@ describe('ChatInlineImage off-screen pause', () => {
     expect(mockStopAnimating).not.toHaveBeenCalled();
   });
 
+  test('pauses an animated emote that has no decoded ref yet', () => {
+    // Animated emotes are held out of the channel warm, so the uri path is
+    // where they start - and it is where the pause used to be skipped.
+    mockSharedRef = null;
+    const store = createRowVisibilityStore(false);
+
+    render(
+      <RowVisibilityContext.Provider value={store}>
+        <ChatInlineImage
+          sourceUrl='https://cdn.7tv.app/emote/uncached/2x.webp'
+          style={{}}
+        />
+      </RowVisibilityContext.Provider>,
+    );
+
+    expect(mockStopAnimating).toHaveBeenCalledTimes(1);
+
+    act(() => store.setVisible(true));
+    expect(mockStartAnimating).toHaveBeenCalledTimes(1);
+  });
+
+  test('leaves a refless url of unknown kind animating', () => {
+    // BTTV's bare url doesn't say whether it's animated and there's no ref to
+    // ask, so there is nothing to act on.
+    mockSharedRef = null;
+    const store = createRowVisibilityStore(false);
+
+    render(
+      <RowVisibilityContext.Provider value={store}>
+        <ChatInlineImage
+          sourceUrl='https://cdn.betterttv.net/emote/bare/2x'
+          style={{}}
+        />
+      </RowVisibilityContext.Provider>,
+    );
+
+    act(() => store.setVisible(true));
+
+    expect(mockStartAnimating).not.toHaveBeenCalled();
+    expect(mockStopAnimating).not.toHaveBeenCalled();
+  });
+
   test('static images skip the pause path entirely, even off-screen', () => {
     mockSharedRef = { isAnimated: false };
     const store = createRowVisibilityStore(false);

--- a/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
@@ -150,8 +150,6 @@ describe('ChatInlineImage off-screen pause', () => {
   });
 
   test('pauses an animated emote that has no decoded ref yet', () => {
-    // Animated emotes are held out of the channel warm, so the uri path is
-    // where they start - and it is where the pause used to be skipped.
     mockSharedRef = null;
     const store = createRowVisibilityStore(false);
 
@@ -171,8 +169,6 @@ describe('ChatInlineImage off-screen pause', () => {
   });
 
   test('leaves a refless url of unknown kind animating', () => {
-    // BTTV's bare url doesn't say whether it's animated and there's no ref to
-    // ask, so there is nothing to act on.
     mockSharedRef = null;
     const store = createRowVisibilityStore(false);
 

--- a/src/utils/color/sevenTvPaintData/__tests__/pickBestImage.test.ts
+++ b/src/utils/color/sevenTvPaintData/__tests__/pickBestImage.test.ts
@@ -1,0 +1,68 @@
+import type { Image } from '@app/graphql/generated/gql';
+
+import { pickBestImage } from '../pickBestImage';
+
+const makeImage = (overrides: Partial<Image>): Image => ({
+  __typename: 'Image',
+  url: 'https://cdn.7tv.app/emote/test/2x.webp',
+  mime: 'image/webp',
+  scale: 2,
+  frameCount: 1,
+  size: 0,
+  width: 0,
+  height: 0,
+  ...overrides,
+});
+
+describe('pickBestImage', () => {
+  test('prefers WebP for an animated image so it does not decode through dav1d', () => {
+    const images: Image[] = [
+      makeImage({
+        scale: 4,
+        frameCount: 24,
+        mime: 'image/avif',
+        url: 'https://cdn.7tv.app/emote/test/4x.avif',
+      }),
+      makeImage({
+        scale: 4,
+        frameCount: 24,
+        mime: 'image/webp',
+        url: 'https://cdn.7tv.app/emote/test/4x.webp',
+      }),
+    ];
+
+    expect(pickBestImage(images)?.url).toBe(
+      'https://cdn.7tv.app/emote/test/4x.webp',
+    );
+  });
+
+  test('keeps AVIF for a static image, where it is simply the smaller file', () => {
+    const images: Image[] = [
+      makeImage({
+        scale: 4,
+        mime: 'image/webp',
+        url: 'https://cdn.7tv.app/emote/test/4x.webp',
+      }),
+      makeImage({
+        scale: 4,
+        mime: 'image/avif',
+        url: 'https://cdn.7tv.app/emote/test/4x.avif',
+      }),
+    ];
+
+    expect(pickBestImage(images)?.url).toBe(
+      'https://cdn.7tv.app/emote/test/4x.avif',
+    );
+  });
+
+  test('takes the largest scale that has any image', () => {
+    const images: Image[] = [
+      makeImage({ scale: 1, url: 'https://cdn.7tv.app/emote/test/1x.webp' }),
+      makeImage({ scale: 3, url: 'https://cdn.7tv.app/emote/test/3x.webp' }),
+    ];
+
+    expect(pickBestImage(images)?.url).toBe(
+      'https://cdn.7tv.app/emote/test/3x.webp',
+    );
+  });
+});

--- a/src/utils/color/sevenTvPaintData/pickBestImage.ts
+++ b/src/utils/color/sevenTvPaintData/pickBestImage.ts
@@ -15,10 +15,6 @@ export function pickBestImage(images: readonly Image[]): Image | undefined {
       return undefined;
     }
 
-    // Animated goes through pickAnimatedFormat, which prefers WebP. AVIF is the
-    // smaller file and the right call for a static image, but animated AVIF
-    // decodes through dav1d in software and that is the single largest CPU cost
-    // in chat.
     const animated = atScale.filter(img => img.frameCount > 1);
     return animated.length > 0
       ? pickAnimatedFormat(animated)

--- a/src/utils/color/sevenTvPaintData/pickBestImage.ts
+++ b/src/utils/color/sevenTvPaintData/pickBestImage.ts
@@ -1,4 +1,5 @@
 import { type Image } from '@app/graphql/generated/gql';
+import { pickAnimatedFormat } from '@app/utils/color/sevenTvPaintData/pickAnimatedFormat';
 import { pickBestFormat } from '@app/utils/color/sevenTvPaintData/pickBestFormat';
 
 export function pickBestImage(images: readonly Image[]): Image | undefined {
@@ -14,9 +15,13 @@ export function pickBestImage(images: readonly Image[]): Image | undefined {
       return undefined;
     }
 
+    // Animated goes through pickAnimatedFormat, which prefers WebP. AVIF is the
+    // smaller file and the right call for a static image, but animated AVIF
+    // decodes through dav1d in software and that is the single largest CPU cost
+    // in chat.
     const animated = atScale.filter(img => img.frameCount > 1);
     return animated.length > 0
-      ? pickBestFormat(animated)
+      ? pickAnimatedFormat(animated)
       : pickBestFormat(atScale);
   }, undefined);
 }

--- a/src/utils/seventv/__tests__/seventvWsInterpreter.test.ts
+++ b/src/utils/seventv/__tests__/seventvWsInterpreter.test.ts
@@ -278,6 +278,51 @@ describe('interpretSeventvWsMessage', () => {
       });
     });
 
+    test('picks webp for an animated emote and avif for a static one', () => {
+      const pickUrl = (frameCount: number) => {
+        const emote = createSevenTvEmote({
+          id: 'emote-fmt',
+          name: 'fmtEmote',
+          files: [
+            createSevenTvFile({
+              name: '4x.avif',
+              width: 128,
+              height: 128,
+              frame_count: frameCount,
+              format: 'AVIF',
+            }),
+            createSevenTvFile({
+              name: '4x.webp',
+              width: 128,
+              height: 128,
+              frame_count: frameCount,
+              format: 'WEBP',
+            }),
+          ],
+        });
+        const decisions = interpretSeventvWsMessage(
+          createDispatchMessage(
+            createEmoteSetUpdateEvent({
+              id: 'set-1',
+              pushed: [createPushedChange(emote)],
+            }),
+          ),
+          createContext(),
+        );
+        const decision = decisions[0];
+        if (decision?.type !== 'applyEmoteUpdate') {
+          throw new Error(`expected applyEmoteUpdate, got ${decision?.type}`);
+        }
+        return decision.added[0]?.url;
+      };
+
+      // Animated avif decodes through dav1d in software; webp is much cheaper.
+      expect({ animated: pickUrl(30), static: pickUrl(1) }).toEqual({
+        animated: 'https://cdn.7tv.app/emote/emote-fmt/4x.webp',
+        static: 'https://cdn.7tv.app/emote/emote-fmt/4x.avif',
+      });
+    });
+
     test('ignores updates for a different emote set but still notifies the raw event', () => {
       const event = createEmoteSetUpdateEvent({
         id: 'other-set',

--- a/src/utils/seventv/__tests__/seventvWsInterpreter.test.ts
+++ b/src/utils/seventv/__tests__/seventvWsInterpreter.test.ts
@@ -316,7 +316,6 @@ describe('interpretSeventvWsMessage', () => {
         return decision.added[0]?.url;
       };
 
-      // Animated avif decodes through dav1d in software; webp is much cheaper.
       expect({ animated: pickUrl(30), static: pickUrl(1) }).toEqual({
         animated: 'https://cdn.7tv.app/emote/emote-fmt/4x.webp',
         static: 'https://cdn.7tv.app/emote/emote-fmt/4x.avif',

--- a/src/utils/seventv/seventvWsInterpreter.ts
+++ b/src/utils/seventv/seventvWsInterpreter.ts
@@ -126,30 +126,42 @@ export type SeventvWsDecision =
   | { type: 'reconnect' }
   | { type: 'unhandledOp'; op: number };
 
+const withScales = (format: string) =>
+  ['4x', '3x', '2x', '1x'].map(scale => `${scale}.${format}`);
+
 /**
- * The EventAPI advertises several encodes per emote. Prefer avif at the largest
- * scale (best size/quality, and the url form the CDN expects), but fall back to
- * webp so an emote whose host only ships webp still resolves real dimensions —
- * otherwise width/height collapse to 0 and a non-square emote renders as a 1:1
- * square at the wrong width. As a last resort take the widest encode that
- * carries dimensions so the aspect ratio is at least correct.
+ * The EventAPI advertises several encodes per emote. For a static emote prefer
+ * avif at the largest scale (best size/quality), falling back to webp so an
+ * emote whose host only ships webp still resolves real dimensions — otherwise
+ * width/height collapse to 0 and a non-square emote renders as a 1:1 square at
+ * the wrong width.
  */
-const SEVEN_TV_FILE_PREFERENCE = [
-  '4x.avif',
-  '3x.avif',
-  '2x.avif',
-  '1x.avif',
-  '4x.webp',
-  '3x.webp',
-  '2x.webp',
-  '1x.webp',
-] as const;
+const SEVEN_TV_STATIC_PREFERENCE = [
+  ...withScales('avif'),
+  ...withScales('webp'),
+];
+
+/**
+ * Animated inverts that. These emotes carry no `image_variants`, so the url
+ * picked here is the one chat renders, and animated avif decodes through dav1d
+ * in software - the dominant CPU cost in a busy channel. The v4 fetch path
+ * already prefers webp for animated (`pickAnimatedFormat`); a live add over the
+ * EventAPI has to match or the same emote costs more when it arrives that way.
+ */
+const SEVEN_TV_ANIMATED_PREFERENCE = [
+  ...withScales('webp'),
+  ...withScales('avif'),
+];
 
 function pickBestSevenTvFile(
   files: readonly SevenTvFile[],
 ): SevenTvFile | undefined {
   const byName = new Map(files.map(file => [file.name, file]));
-  for (const name of SEVEN_TV_FILE_PREFERENCE) {
+  const preference = files.some(file => file.frame_count > 1)
+    ? SEVEN_TV_ANIMATED_PREFERENCE
+    : SEVEN_TV_STATIC_PREFERENCE;
+
+  for (const name of preference) {
     const match = byName.get(name);
     if (match) {
       return match;

--- a/src/utils/seventv/seventvWsInterpreter.ts
+++ b/src/utils/seventv/seventvWsInterpreter.ts
@@ -130,24 +130,17 @@ const withScales = (format: string) =>
   ['4x', '3x', '2x', '1x'].map(scale => `${scale}.${format}`);
 
 /**
- * The EventAPI advertises several encodes per emote. For a static emote prefer
- * avif at the largest scale (best size/quality), falling back to webp so an
- * emote whose host only ships webp still resolves real dimensions — otherwise
+ * The EventAPI advertises several encodes per emote. Take the largest scale of
+ * the cheaper format for the emote's kind, then the other format so an emote
+ * whose host ships only one still resolves real dimensions — otherwise
  * width/height collapse to 0 and a non-square emote renders as a 1:1 square at
- * the wrong width.
+ * the wrong width. As a last resort take the widest encode that carries
+ * dimensions so the aspect ratio is at least correct.
  */
 const SEVEN_TV_STATIC_PREFERENCE = [
   ...withScales('avif'),
   ...withScales('webp'),
 ];
-
-/**
- * Animated inverts that. These emotes carry no `image_variants`, so the url
- * picked here is the one chat renders, and animated avif decodes through dav1d
- * in software - the dominant CPU cost in a busy channel. The v4 fetch path
- * already prefers webp for animated (`pickAnimatedFormat`); a live add over the
- * EventAPI has to match or the same emote costs more when it arrives that way.
- */
 const SEVEN_TV_ANIMATED_PREFERENCE = [
   ...withScales('webp'),
   ...withScales('avif'),


### PR DESCRIPTION
Low fps with a lot of animated images on screen. Split out of #834.

Instruments (iPhone 17 Pro, steady60) put animated AVIF decode at **~60-75% of total process CPU** - dav1d in software, no hardware path. JS was 2.4% self. So this is about doing fewer of those decodes, not about the JS thread. Three fixes, all JS, no native change and no rebuild.

## 1. The off-screen/scroll pause was skipped for animated emotes

`ChatInlineImage` decided an emote was animated with:

```ts
const animated = sharedRef != null && (urlKind === null ? sharedRef.isAnimated === true : urlKind === 'animated');
```

Animated emotes are **deliberately excluded from the channel warm** (`useCachedEmotes.ts:38-41` - "multi-frame decode is the entry storm; they warm on first paint"), so the uri path with no `sharedRef` is where they normally start. `animated` was therefore `false`, the pause effect returned early, and `autoplay` fell through to `true`. The emotes the pause exists for were the ones bypassing it - animating off-screen in the draw buffer and straight through every fling.

The url already encodes the kind for everything but BTTV's bare form, so ask it, and keep the ref for the shapes that can't say.

## 2. Emotes added over the 7TV EventAPI decoded as AVIF

`SEVEN_TV_FILE_PREFERENCE` was avif-first at every scale, and `toSanitisedSevenTvEmote` sets no `image_variants` - so the url picked there is the one chat renders. Every emote added live went through dav1d, while the same emote fetched over v4 came back as WebP (`pickAnimatedFormat`). Animated now prefers WebP; static keeps AVIF, where it is just the smaller file.

## 3. `pickBestImage` used the static preference on its animated subset

Same root cause, one function along: it filtered to `frameCount > 1` and then handed that to `pickBestFormat` (AVIF-first). Now uses `pickAnimatedFormat`. This one only feeds `emote.url`, which is a fallback while `image_variants.animated` is populated, but it should not disagree with the rest of the animated path.

## Trade-off

WebP is ~2-3x larger on the wire than AVIF. That is the right trade when dav1d is the bottleneck, and it is the trade already made on the v4 path.

## What this does not do

No concurrency cap on animated emotes in chat. Freezing an arbitrary Nth visible emote mid-message reads as broken, and the visibility + scroll gates already bound concurrency to "visible at rest" - which, with fix 1, they now actually do.

`AGENTS.md` is formatted here too; prettier has been failing on it on main since before this branch.

## Test plan

- 9,934 tests pass, plus the reassure suite; tsc, eslint and prettier clean.
- New: the uri-path pause, the unknown-kind refless case staying untouched, the WS animated/static format split, and `pickBestImage`'s animated preference.
- Device check still wanted: chat-perf raid on a fresh launch with the image cache cleared. Persisted `channelCaches` hold old AVIF urls, so "Refetch Emotes and Badges" first or the variants won't have been rebuilt.