### PR TITLE
fix(chat): stop blank chat rows when the emote cache drops a ref under a mounted row

### DIFF
--- a/src/Providers/CachedEmotesProvider/__tests__/cache-service.test.ts
+++ b/src/Providers/CachedEmotesProvider/__tests__/cache-service.test.ts
@@ -37,6 +37,17 @@ const flushMicrotasks = () =>
     setTimeout(resolve, 0);
   });
 
+/**
+ * requestAnimationFrame is polyfilled onto setTimeout here, so each turn drains
+ * one deferred release pass. A release can be re-queued a few times, hence
+ * several turns.
+ */
+const flushAnimationFrames = async (turns = 6) => {
+  for (let turn = 0; turn < turns; turn += 1) {
+    await flushMicrotasks();
+  }
+};
+
 describe('cache-service', () => {
   beforeEach(() => {
     loadAsync.mockImplementation(() => Promise.resolve({} as ImageRef));
@@ -249,6 +260,47 @@ describe('cache-service', () => {
     // The most-recently warmed ref survives; the oldest was evicted to fit.
     expect(getCachedEmoteRef(urls.at(-1)!)).toEqual(animatedRef());
     expect(getCachedEmoteRef(urls[0]!)).toBeNull();
+  });
+
+  test('the byte budget never evicts a ref a mounted row is still subscribed to', async () => {
+    loadAsync.mockResolvedValue(animatedRef());
+    const mountedUrl = 'https://cdn.7tv.app/emote/bigMounted/2x.avif';
+    await warmCachedEmoteRefs([mountedUrl]);
+    const unsubscribe = subscribeCachedEmoteRef(mountedUrl, jest.fn());
+
+    const unsubscribedUrl = 'https://cdn.7tv.app/emote/bigUnsubscribed/2x.avif';
+    await warmCachedEmoteRefs([unsubscribedUrl]);
+
+    await warmCachedEmoteRefs(
+      Array.from(
+        { length: 900 },
+        (_, i) => `https://cdn.7tv.app/emote/bigChurn${i}/2x.avif`,
+      ),
+    );
+
+    // Evicting the subscribed url would free nothing and only un-count its bytes,
+    // so the scan sheds an unsubscribed one instead.
+    expect(getCachedEmoteRef(mountedUrl)).toEqual(animatedRef());
+    expect(getCachedEmoteRef(unsubscribedUrl)).toBeNull();
+    expect(getCachedEmoteByteEstimate()).toBeLessThanOrEqual(
+      MAX_DECODED_BYTES_HIGH_TIER,
+    );
+    unsubscribe();
+  });
+
+  test('a memory-pressure trim frees a bitmap even while a row is still subscribed', async () => {
+    const url = 'https://cdn.7tv.app/emote/pressure/2x.avif';
+    const release = jest.fn();
+    loadAsync.mockResolvedValueOnce(makeImageRef({ release }));
+    await warmCachedEmoteRefs([url]);
+    const unsubscribe = subscribeCachedEmoteRef(url, jest.fn());
+
+    releaseChannelEmoteRefs();
+    await flushAnimationFrames();
+
+    // The trim notified first, so the row has already dropped to its uri fallback.
+    expect(release).toHaveBeenCalledTimes(1);
+    unsubscribe();
   });
 
   test('the byte budget never evicts pinned refs', async () => {

--- a/src/Providers/CachedEmotesProvider/cache-service.ts
+++ b/src/Providers/CachedEmotesProvider/cache-service.ts
@@ -109,8 +109,15 @@ function dropRefBytes(url: string): void {
   refAspect.delete(url);
 }
 
-const pendingReleases: { url: string; ref: ImageRef }[] = [];
+const pendingReleases: { url: string; ref: ImageRef; frames: number }[] = [];
 let releaseFlushScheduled = false;
+
+/**
+ * Frames a release may be re-queued for while a listener is still registered.
+ * Enough to cover the mount race below, bounded so a url that stays subscribed
+ * cannot defer its release forever.
+ */
+const MAX_RELEASE_DEFER_FRAMES = 2;
 
 function markRecentlyReleased(url: string): void {
   recentlyReleased.add(url);
@@ -129,23 +136,32 @@ function markRecentlyReleased(url: string): void {
  * drawing — the emote, and an emote-only message, goes blank. By the next frame
  * the subscription exists, so an absent listener reliably means nothing holds
  * the ref. A released ref throws on any later native call, hence the try/catch.
+ *
+ * The re-queue is capped: every path that queues a release notifies first, so a
+ * listener still present a couple of frames later has already fallen back to the
+ * `uri` source. Unbounded, a memory-pressure trim freed nothing at all for an
+ * emote that stayed on screen.
  */
 function flushPendingReleases(): void {
   releaseFlushScheduled = false;
   const batch = pendingReleases.splice(0, pendingReleases.length);
-  for (const { url, ref } of batch) {
-    if (listeners.has(url)) {
+  for (const pending of batch) {
+    if (
+      listeners.has(pending.url) &&
+      pending.frames < MAX_RELEASE_DEFER_FRAMES
+    ) {
       // A new subscriber raced in before this flush — re-queue so the ref is
-      // retried next frame instead of leaking when that subscriber leaves.
-      pendingReleases.push({ url, ref });
+      // retried next frame instead of being detached mid-draw.
+      pending.frames += 1;
+      pendingReleases.push(pending);
       continue;
     }
     try {
-      ref.release();
+      pending.ref.release();
     } catch {
       // ignore
     }
-    markRecentlyReleased(url);
+    markRecentlyReleased(pending.url);
   }
   if (pendingReleases.length > 0 && !releaseFlushScheduled) {
     releaseFlushScheduled = true;
@@ -161,7 +177,7 @@ function flushPendingReleases(): void {
 function releaseRef(url: string): boolean {
   const ref = refs.get(url);
   if (ref) {
-    pendingReleases.push({ url, ref });
+    pendingReleases.push({ url, ref, frames: 0 });
     if (!releaseFlushScheduled) {
       releaseFlushScheduled = true;
       requestAnimationFrame(flushPendingReleases);
@@ -181,6 +197,11 @@ function withinBudget(incomingBytes: number): boolean {
  * Evict least-recently-rendered unpinned refs until the incoming decode fits
  * under both the byte budget and the entry-count backstop. Stops once no
  * unpinned entry remains so a fully-pinned cache can still grow rather than spin.
+ *
+ * A live listener is skipped alongside a pin: `flushPendingReleases` won't free a
+ * bitmap anything is subscribed to, so evicting one frees nothing while
+ * `dropRefBytes` un-counts its bytes. The budget then under-reports and the cache
+ * over-commits into real memory pressure.
  */
 function evictUnpinnedToFit(incomingBytes: number): void {
   if (withinBudget(incomingBytes)) {
@@ -190,7 +211,7 @@ function evictUnpinnedToFit(incomingBytes: number): void {
     if (withinBudget(incomingBytes)) {
       return;
     }
-    if (pinned.has(url)) {
+    if (pinned.has(url) || listeners.has(url)) {
       continue;
     }
     releaseRef(url);

--- a/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
@@ -100,22 +100,28 @@ function ChatInlineImageComponent({
   );
 
   const [reloadNonce, setReloadNonce] = useState(0);
-  // Per-emote load progress, tagged with the url it belongs to. When LegendList
-  // recycles the row to a new emote the tag stops matching, so we derive a fresh
-  // "first candidate, loading" view until a handler writes the new url back. This
-  // avoids both a frame showing the previous emote's fallback variant and any
-  // render-phase setState to reset it.
+  // Per-emote load progress, tagged with the url it belongs to and the path that
+  // rendered it. When LegendList recycles the row to a new emote the tag stops
+  // matching, so we derive a fresh "first candidate, loading" view until a
+  // handler writes the new url back. This avoids both a frame showing the
+  // previous emote's fallback variant and any render-phase setState to reset it.
+  //
+  // `viaRef` is part of the tag because the cache can drop a decoded ref out from
+  // under a mounted row. Untagged, the 'loaded' left behind by the ref render
+  // suppresses the shimmer and the slot draws nothing while the uri re-reads from
+  // disk - an emote-only message reads as a blank full-height row.
   const [load, setLoad] = useState<{
     index: number;
     status: 'loading' | 'loaded' | 'failed';
     url: string;
-  }>({ index: 0, status: 'loading', url: sourceUrl });
+    viaRef: boolean;
+  }>({ index: 0, status: 'loading', url: sourceUrl, viaRef: false });
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [failedRefUrl, setFailedRefUrl] = useState<string | null>(null);
 
-  const isCurrentUrl = load.url === sourceUrl;
   const showRef = sharedRef != null && failedRefUrl !== sourceUrl;
+  const isCurrentUrl = load.url === sourceUrl && load.viaRef === showRef;
   const candidateIndex = !showRef && isCurrentUrl ? load.index : 0;
   const status = isCurrentUrl ? load.status : 'loading';
 
@@ -146,8 +152,9 @@ function ChatInlineImageComponent({
       index: prev.url === sourceUrl ? prev.index : 0,
       status: 'loaded',
       url: sourceUrl,
+      viaRef: showRef,
     }));
-  }, [sourceUrl]);
+  }, [showRef, sourceUrl]);
 
   const handleError = useCallback(
     (event?: ImageErrorEventData) => {
@@ -167,10 +174,12 @@ function ChatInlineImageComponent({
           to: fallbackChain[candidateIndex + 1],
         });
         retryCountRef.current = 0;
+        // Either showRef was already false, or setFailedRefUrl just turned it off.
         setLoad({
           index: candidateIndex + 1,
           status: 'loading',
           url: sourceUrl,
+          viaRef: false,
         });
         return;
       }
@@ -199,7 +208,12 @@ function ChatInlineImageComponent({
             cacheReleaseRaces: getEmoteRefReleaseRaceCount(),
           },
         });
-        setLoad({ index: candidateIndex, status: 'failed', url: sourceUrl });
+        setLoad({
+          index: candidateIndex,
+          status: 'failed',
+          url: sourceUrl,
+          viaRef: false,
+        });
         return;
       }
 
@@ -269,11 +283,12 @@ function ChatInlineImageComponent({
     };
   }, [rowVisibility, animated]);
 
-  // Show the shimmer only while there's nothing real to display yet: a decoded
-  // sharedRef is instant, so cached emotes (the busy-chat common case) never
-  // shimmer and stay on the bare-image fast path with no extra Fabric node.
-  const overlayVisible =
-    showLoadingShimmer && sharedRef == null && status !== 'loaded';
+  // Show the shimmer only while there's nothing real to display yet. Keyed off
+  // showRef so a ref we hold but can't draw (it failed, or the cache released it
+  // under us) still gets a loading box; a ref we are drawing is instant, so
+  // cached emotes (the busy-chat common case) never shimmer and stay on the
+  // bare-image fast path with no extra Fabric node.
+  const overlayVisible = showLoadingShimmer && !showRef && status !== 'loaded';
 
   // Render the decoded sharedRef whenever it's available and hasn't failed to
   // display; otherwise render the current fallback variant's uri.

--- a/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
@@ -355,6 +355,25 @@ describe('ChatInlineImage loading shimmer', () => {
     expect(screen.queryByTestId('chat-image-shimmer')).not.toBeOnTheScreen();
   });
 
+  test('a ref released under a mounted row falls back to the uri with a loading box, not a blank one', () => {
+    mockSharedRef = { isAnimated: false };
+    const sourceUrl = 'https://cdn.7tv.app/emote/released/2x.avif';
+    render(<ChatInlineImage sourceUrl={sourceUrl} style={{}} />);
+
+    act(() => mockImageProps?.onLoad?.());
+    expect(screen.queryByTestId('chat-image-shimmer')).not.toBeOnTheScreen();
+
+    // A memory-pressure trim sheds the decoded ref while the row stays mounted.
+    mockSharedRef = null;
+    screen.rerender(<ChatInlineImage sourceUrl={sourceUrl} style={{}} />);
+
+    expect(screen.getByTestId('chat-image-shimmer')).toBeOnTheScreen();
+
+    act(() => mockImageProps?.onLoad?.());
+
+    expect(screen.queryByTestId('chat-image-shimmer')).not.toBeOnTheScreen();
+  });
+
   test('showLoadingShimmer=false suppresses the overlay on an uncached load', () => {
     mockSharedRef = null;
     render(


### PR DESCRIPTION
Blank full-height rows in chat on device. Never reproduces on a simulator: `MAX_DECODED_BYTES` is 2.5% of `getTotalDeviceMemoryBytes()`, which returns the Mac's RAM there so it always clamps to the 192MB ceiling, and iOS memory-pressure notifications don't fire.

Three things in the decoded-emote `ImageRef` path:

- `evictUnpinnedToFit` skipped pins but not live listeners. `flushPendingReleases` won't free a bitmap anything is subscribed to, so evicting a subscribed url freed nothing while `dropRefBytes` un-counted its bytes. The budget under-reported, the cache over-committed on every later decode, and the process climbed to real memory pressure, where `releaseChannelEmoteRefs` sheds the whole working set out from under the visible rows.
- `flushPendingReleases` re-queued a subscribed release every frame forever. A pressure trim, or a manual cache clear with chat on screen, gave back no memory at all for any emote still visible. Capped at 2 frames, which is safe because every path that queues a release notifies first.
- `ChatInlineImage` tagged its load state with the url but not the render path. When the cache dropped a ref, `source` swapped to the uri fallback but `status` was still `'loaded'` from the ref render, so the shimmer stayed suppressed and the slot drew nothing until the disk read landed. An emote-only message read as a blank full-height row.

## Testing

- Each of the three tests verified failing with its own fix reverted, then passing with it restored.
- Full suite green: 326 suites, 9943 tests. tsc, eslint, prettier clean.
- Ran on the sim against ohnePixel after the change: emotes, badges and painted usernames all render, no regressions.

Doesn't cover the separate name-width blank where a painted username renders nothing. That still looks like the `sevenTvPaintRenderer: 'native'` MaskedView path and is untouched here.
