### PR TITLE
fix(chat): stop badges rendering as blank slots, keep campaign badge sets, paint ffz badges

### DIFF
--- a/src/components/BottomSheet/BottomSheet.native.tsx
+++ b/src/components/BottomSheet/BottomSheet.native.tsx
@@ -17,6 +17,7 @@ import { Toaster } from 'sonner-native';
 import { theme } from '@app/styles/themes';
 
 import type { BottomSheetHandle } from './bottomSheetHandle';
+import { SheetDragHandle } from './SheetDragHandle';
 
 export type { BottomSheetHandle };
 export type SnapPoint = { fraction: number } | { height: number } | 'full';
@@ -152,7 +153,7 @@ export function BottomSheet({
       ref={sheetRef}
       backgroundStyle={backgroundStyle}
       enablePanDownToClose
-      handleComponent={showDragIndicator === true ? undefined : null}
+      handleComponent={null}
       index={isPresented ? 0 : -1}
       onDismiss={() => {
         if (dismissTimerRef.current !== null) {
@@ -166,6 +167,7 @@ export function BottomSheet({
       snapPoints={detents}
     >
       <View style={[styles.content, sizingStyle]} testID={testID}>
+        {showDragIndicator === true ? <SheetDragHandle /> : null}
         {children}
         {/**
          * The sheet is added to android.R.id.content, above the react root and

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -5,6 +5,7 @@ import type { PropsWithChildren, Ref } from 'react';
 import { theme } from '@app/styles/themes';
 
 import type { BottomSheetHandle } from './bottomSheetHandle';
+import { SheetDragHandle } from './SheetDragHandle';
 
 export type { BottomSheetHandle };
 export type SnapPoint = { fraction: number } | { height: number } | 'full';
@@ -53,30 +54,13 @@ function BottomSheetComponent({
         { backgroundColor, width: Math.min(windowWidth - 32, 520) },
       ]}
     >
-      {showDragIndicator ? (
-        <View style={styles.dragHandleRow}>
-          <View style={styles.dragIndicator} />
-        </View>
-      ) : null}
+      {showDragIndicator ? <SheetDragHandle /> : null}
       {children}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  dragHandleRow: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingBottom: 6,
-    paddingTop: 10,
-    width: '100%',
-  },
-  dragIndicator: {
-    backgroundColor: 'rgba(255,255,255,0.34)',
-    borderRadius: 999,
-    height: 4,
-    width: 36,
-  },
   fallback: {
     alignItems: 'stretch',
     alignSelf: 'center',

--- a/src/components/BottomSheet/SheetDragHandle.tsx
+++ b/src/components/BottomSheet/SheetDragHandle.tsx
@@ -1,0 +1,33 @@
+import { StyleSheet, View } from 'react-native';
+
+/**
+ * The platform grabber cannot be restyled: `@expo/ui`'s `handleComponent` is
+ * documented as not rendering on iOS or Android (only `null` vs non-null is
+ * read), and `handleStyle` / `handleIndicatorStyle` have no effect there. So
+ * the wrapper hides the native indicator and draws this as the first row of
+ * sheet content instead, which puts the grabber on the sheet's own background
+ * with no band or seam of its own.
+ */
+export function SheetDragHandle() {
+  return (
+    <View pointerEvents='none' style={styles.row} testID='sheet-drag-handle'>
+      <View style={styles.pill} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  pill: {
+    backgroundColor: 'rgba(255, 255, 255, 0.22)',
+    borderRadius: 2.5,
+    height: 5,
+    width: 36,
+  },
+  row: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingBottom: 8,
+    paddingTop: 8,
+    width: '100%',
+  },
+});

--- a/src/components/BottomSheet/__tests__/BottomSheet.test.tsx
+++ b/src/components/BottomSheet/__tests__/BottomSheet.test.tsx
@@ -187,16 +187,22 @@ describe('BottomSheet', () => {
     });
   });
 
-  test('shows the native drag indicator with showDragIndicator', () => {
+  test('always hides the native drag indicator', () => {
     renderSheet();
 
-    expect(mockSheet.props.handleComponent).toBeUndefined();
+    expect(mockSheet.props.handleComponent).toBeNull();
   });
 
-  test('hides the native drag indicator without showDragIndicator', () => {
-    renderSheet({ showDragIndicator: false });
+  test('draws its own drag handle with showDragIndicator', () => {
+    const { getByTestId } = renderSheet();
 
-    expect(mockSheet.props.handleComponent).toBeNull();
+    expect(getByTestId('sheet-drag-handle')).toBeOnTheScreen();
+  });
+
+  test('draws no drag handle without showDragIndicator', () => {
+    const { queryByTestId } = renderSheet({ showDragIndicator: false });
+
+    expect(queryByTestId('sheet-drag-handle')).toBeNull();
   });
 
   test('requestClose closes the native sheet', () => {

--- a/src/components/Chat/components/ChatMessage/chatText.styles.ts
+++ b/src/components/Chat/components/ChatMessage/chatText.styles.ts
@@ -17,6 +17,15 @@ import {
 
 export interface ChatTextStyles {
   badge: ImageStyle;
+  /**
+   * The slot a tinted badge draws into: same box as `badge`, but carrying the
+   * gap itself so the tint stops at the artwork instead of bleeding across it.
+   */
+  badgeTintSlot: ViewStyle;
+  /**
+   * The artwork inside a tinted slot, which owns neither the gap nor the tint.
+   */
+  badgeTintArtwork: ImageStyle;
   body: TextStyle;
   /**
    * Lines carrying an inline emote need the taller emote line height on every
@@ -56,6 +65,17 @@ function buildChatTextStyles(
     badge: {
       height: scale.badgeSize,
       marginRight: scale.badgeGap,
+      width: scale.badgeSize,
+    },
+    badgeTintArtwork: {
+      height: scale.badgeSize,
+      width: scale.badgeSize,
+    },
+    badgeTintSlot: {
+      borderRadius: CHAT_SURFACE_COLORS.radius,
+      height: scale.badgeSize,
+      marginRight: scale.badgeGap,
+      overflow: 'hidden',
       width: scale.badgeSize,
     },
     body,

--- a/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
@@ -158,9 +158,23 @@ function ChatInlineImageComponent({
 
   const handleError = useCallback(
     (event?: ImageErrorEventData) => {
+      // A decoded ref that could not be drawn says nothing about the url - the
+      // cache can release one out from under a mounted row, and the uri has not
+      // been tried at all yet. Hand off to the fallback chain from the top with
+      // a full budget rather than spending it on a failure the network never
+      // saw: a badge url derives no variants, so `maxRetryAttempts: 0` would
+      // otherwise turn one ref failure straight into a permanently blank slot.
+      // The nonce bump moves `recyclingKey` so expo-image reloads rather than
+      // keeping the view that failed.
       if (showRef) {
         setFailedRefUrl(sourceUrl);
-      } else if (candidateIndex === 0) {
+        retryCountRef.current = 0;
+        setLoad({ index: 0, status: 'loading', url: sourceUrl, viaRef: false });
+        setReloadNonce(nonce => nonce + 1);
+        return;
+      }
+
+      if (candidateIndex === 0) {
         evictCachedEmoteRef(candidateUrl);
       }
 
@@ -245,8 +259,12 @@ function ChatInlineImageComponent({
   );
 
   const onWatchdogTimeout = useEffectEvent(() => handleError());
+  // The ref path is watched too. A ref the cache released under a mounted row
+  // draws nothing and reports neither onLoad nor onError, so leaving it
+  // unwatched was the one state that could hold a slot blank forever - silently,
+  // since a badge renders no shimmer to hint at it.
   useEffect(() => {
-    if (showRef || status !== 'loading') {
+    if (status !== 'loading') {
       return undefined;
     }
     const timer = setTimeout(onWatchdogTimeout, LOAD_WATCHDOG_MS);

--- a/src/components/Chat/components/ChatMessage/renderers/ChatMessageBadges.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatMessageBadges.tsx
@@ -30,7 +30,7 @@ export function ChatMessageBadges({
     return null;
   }
 
-  const badgeStyle = getChatTextStyles(fontScale, compact).badge;
+  const textStyles = getChatTextStyles(fontScale, compact);
 
   const renderedBadges: ReactNode[] = [];
   let index = 0;
@@ -41,6 +41,12 @@ export function ChatMessageBadges({
       continue;
     }
 
+    // Only FFZ carries a colour, and every FFZ badge is a white-on-transparent
+    // mask meant to sit on it - drawn raw, a channel's mod/VIP art is a white
+    // blob on the chat surface rather than the badge the channel uploaded.
+    const tint = normalizedBadge.color;
+    const moderated = Boolean(moderationNotice) && styles.moderatedBadge;
+
     renderedBadges.push(
       <ChatMessagePressable
         key={getMappingKey(
@@ -48,13 +54,18 @@ export function ChatMessageBadges({
           index,
         )}
         onPress={onBadgePress ? () => onBadgePress(normalizedBadge) : undefined}
+        style={
+          tint
+            ? [textStyles.badgeTintSlot, { backgroundColor: tint }, moderated]
+            : undefined
+        }
+        testID='chat-badge'
       >
         <ChatInlineImage
           sourceUrl={normalizedBadge.url}
-          style={[
-            badgeStyle,
-            Boolean(moderationNotice) && styles.moderatedBadge,
-          ]}
+          style={
+            tint ? textStyles.badgeTintArtwork : [textStyles.badge, moderated]
+          }
           maxRetryAttempts={0}
           showLoadingShimmer={false}
         />

--- a/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
@@ -490,4 +490,34 @@ describe('ChatInlineImage shared-ref recovery', () => {
 
     expect(evictMock).not.toHaveBeenCalled();
   });
+
+  test('a ref failure retries the uri instead of spending a badge’s whole budget on it', () => {
+    mockSharedRef = { isAnimated: false };
+    const sourceUrl = 'https://static-cdn.jtvnw.net/badges/v1/foo/3';
+    render(
+      <ChatInlineImage sourceUrl={sourceUrl} style={{}} maxRetryAttempts={0} />,
+    );
+
+    // The decoded ref cannot be drawn. A badge url derives no variants, so
+    // before the fix this landed straight on 'failed' - a permanently blank slot.
+    act(() => mockImageProps?.onError?.());
+
+    expect(warnMock).not.toHaveBeenCalled();
+    expect(mockImageProps?.recyclingKey).toEqual(`${sourceUrl}#1`);
+  });
+
+  test('watches a held ref that never reports onLoad or onError', () => {
+    mockSharedRef = { isAnimated: false };
+    const sourceUrl = 'https://static-cdn.jtvnw.net/badges/v1/silent/3';
+    render(
+      <ChatInlineImage sourceUrl={sourceUrl} style={{}} maxRetryAttempts={0} />,
+    );
+
+    expect(mockImageProps?.recyclingKey).toEqual(`${sourceUrl}#0`);
+
+    // A ref released under a mounted row draws nothing and reports nothing.
+    act(() => jest.advanceTimersByTime(12000));
+
+    expect(mockImageProps?.recyclingKey).toEqual(`${sourceUrl}#1`);
+  });
 });

--- a/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
@@ -16,6 +16,7 @@ let mockImageProps: {
   onError?: () => void;
   onLoad?: () => void;
   recyclingKey?: string;
+  source?: unknown;
 } | null = null;
 
 jest.mock('expo-image', () => {
@@ -27,6 +28,7 @@ jest.mock('expo-image', () => {
           onError?: () => void;
           onLoad?: () => void;
           recyclingKey?: string;
+          source?: unknown;
         },
         ref: unknown,
       ) => {
@@ -504,6 +506,9 @@ describe('ChatInlineImage shared-ref recovery', () => {
 
     expect(warnMock).not.toHaveBeenCalled();
     expect(mockImageProps?.recyclingKey).toEqual(`${sourceUrl}#1`);
+    // The nonce alone would move even if the row stayed on the ref, so pin the
+    // thing that matters: it is drawing the uri now.
+    expect(mockImageProps?.source).toEqual({ uri: sourceUrl });
   });
 
   test('watches a held ref that never reports onLoad or onError', () => {
@@ -519,5 +524,6 @@ describe('ChatInlineImage shared-ref recovery', () => {
     act(() => jest.advanceTimersByTime(12000));
 
     expect(mockImageProps?.recyclingKey).toEqual(`${sourceUrl}#1`);
+    expect(mockImageProps?.source).toEqual({ uri: sourceUrl });
   });
 });

--- a/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatMessageBadges.test.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatMessageBadges.test.tsx
@@ -1,4 +1,5 @@
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import type { ViewStyle } from 'react-native';
 
 import { render } from '@testing-library/react-native';
 
@@ -40,8 +41,15 @@ describe('ChatMessageBadges', () => {
   test('paints an FFZ badge onto its colour', () => {
     const { getByTestId } = renderBadges([ffzModBadge]);
 
-    expect(getByTestId('chat-badge')).toHaveStyle({
+    expect(
+      StyleSheet.flatten(getByTestId('chat-badge').props.style),
+    ).toEqual<ViewStyle>({
       backgroundColor: '#1ac9a2',
+      borderRadius: 4,
+      height: 18,
+      marginRight: 4,
+      overflow: 'hidden',
+      width: 18,
     });
   });
 

--- a/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatMessageBadges.test.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatMessageBadges.test.tsx
@@ -1,0 +1,59 @@
+import { View } from 'react-native';
+
+import { render } from '@testing-library/react-native';
+
+import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
+
+import { ChatMessageBadges } from '../ChatMessageBadges';
+
+function renderBadges(badges: SanitisedBadgeSet[]) {
+  return render(
+    <View>
+      <ChatMessageBadges
+        badges={badges}
+        compact={false}
+        getMappingKey={(key, index) => `${key}-${index}`}
+      />
+    </View>,
+  );
+}
+
+const ffzModBadge: SanitisedBadgeSet = {
+  id: 'mod_badge',
+  url: 'https://cdn.frankerfacez.com/room-badge/mod/id/96858382/v/9f5bf0d7/4',
+  title: 'Moderator',
+  color: '#1ac9a2',
+  owner_username: '96858382',
+  set: 'mod',
+  type: 'FFZ channel badge',
+};
+
+const twitchBadge: SanitisedBadgeSet = {
+  id: 'subscriber_12',
+  url: 'https://static-cdn.jtvnw.net/badges/v1/8cd10981/3',
+  title: '1-Year Subscriber',
+  set: 'subscriber',
+  type: 'Twitch Subscriber Badge',
+};
+
+describe('ChatMessageBadges', () => {
+  test('paints an FFZ badge onto its colour', () => {
+    const { getByTestId } = renderBadges([ffzModBadge]);
+
+    expect(getByTestId('chat-badge')).toHaveStyle({
+      backgroundColor: '#1ac9a2',
+    });
+  });
+
+  test('leaves a badge without a colour untinted', () => {
+    const { getByTestId } = renderBadges([twitchBadge]);
+
+    expect(getByTestId('chat-badge').props.style).toBeUndefined();
+  });
+
+  test('renders no slot for a badge without a url', () => {
+    const { queryByTestId } = renderBadges([{ ...ffzModBadge, url: '' }]);
+
+    expect(queryByTestId('chat-badge')).toBeNull();
+  });
+});

--- a/src/lib/__tests__/forwardLogToSentry.test.ts
+++ b/src/lib/__tests__/forwardLogToSentry.test.ts
@@ -1,0 +1,140 @@
+import { forwardLogToSentry } from '../sentry';
+
+const scope = {
+  setTag: jest.fn(),
+  setFingerprint: jest.fn(),
+  setContext: jest.fn(),
+};
+
+jest.mock('@sentry/react-native', () => ({
+  addBreadcrumb: jest.fn(),
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+  expoRouterIntegration: jest.fn(() => ({})),
+  logger: { info: jest.fn(), warn: jest.fn() },
+  withScope: jest.fn(),
+}));
+
+jest.mock('@app/lib/sentryImageSpans', () => ({
+  instrumentExpoImageLoads: jest.fn(),
+}));
+
+/**
+ * Reached through the mock registry rather than an import: `no-restricted-imports`
+ * bans `@sentry/react-native` outside `src/lib/sentry`, and the transport under
+ * test is the very thing that boundary exists to funnel through.
+ */
+const sentry = jest.requireMock('@sentry/react-native') as {
+  captureException: jest.Mock;
+  captureMessage: jest.Mock;
+  logger: { warn: jest.Mock };
+  withScope: jest.Mock;
+};
+
+/**
+ * The tags a scope ended up with, in the order they were written - `setTag`
+ * is last-write-wins, so order is the contract under test.
+ */
+function appliedTags(): Record<string, unknown> {
+  return Object.fromEntries(
+    scope.setTag.mock.calls.map(([key, value]) => [key, value]),
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  sentry.withScope.mockImplementation(callback => callback(scope));
+});
+
+describe('forwardLogToSentry warn', () => {
+  test('captures a message rather than a structured log', () => {
+    forwardLogToSentry({
+      level: 'warn',
+      category: 'chat',
+      message: 'chat.emote.load_failed',
+      metadata: { name: 'chat_resources_warning' },
+    });
+
+    expect(sentry.captureMessage).toHaveBeenCalledWith(
+      'chat_resources_warning: chat.emote.load_failed',
+      'warning',
+    );
+    expect(sentry.logger.warn).not.toHaveBeenCalled();
+  });
+
+  test('caller tags cannot clobber the canonical grouping tags', () => {
+    forwardLogToSentry({
+      level: 'warn',
+      category: 'chat',
+      message: 'boom',
+      metadata: {
+        name: 'chat_resources_warning',
+        tags: { log_category: 'spoofed', error_type: 'spoofed', ok: 'kept' },
+      },
+    });
+
+    expect(appliedTags()).toEqual({
+      log_category: 'chat',
+      error_type: 'chat_resources_warning',
+      ok: 'kept',
+    });
+  });
+
+  test('drops tags past the cap and truncates an oversized value', () => {
+    const tags = Object.fromEntries(
+      Array.from({ length: 30 }, (_, index) => [`t${index}`, 'v']),
+    );
+    forwardLogToSentry({
+      level: 'warn',
+      category: 'chat',
+      message: 'boom',
+      metadata: { tags: { ...tags, long: 'x'.repeat(500) } },
+    });
+
+    const applied = appliedTags();
+    // 24 caller tags plus log_category; `long` fell outside the cap.
+    expect(Object.keys(applied)).toHaveLength(25);
+    expect(applied.long).toBeUndefined();
+
+    jest.clearAllMocks();
+    forwardLogToSentry({
+      level: 'warn',
+      category: 'chat',
+      message: 'boom',
+      metadata: { tags: { long: 'x'.repeat(500) } },
+    });
+
+    expect(appliedTags().long).toEqual('x'.repeat(200));
+  });
+
+  test('skips a null or undefined tag value', () => {
+    forwardLogToSentry({
+      level: 'warn',
+      category: 'chat',
+      message: 'boom',
+      metadata: { tags: { absent: undefined, empty: null, kept: 1 } },
+    });
+
+    expect(appliedTags()).toEqual({ log_category: 'chat', kept: 1 });
+  });
+});
+
+describe('forwardLogToSentry error', () => {
+  test('applies the same tag precedence as warn', () => {
+    forwardLogToSentry({
+      level: 'error',
+      category: 'chat',
+      message: 'boom',
+      metadata: {
+        name: 'chat_resources_error',
+        tags: { log_category: 'spoofed' },
+      },
+    });
+
+    expect(appliedTags()).toEqual({
+      log_category: 'chat',
+      error_type: 'chat_resources_error',
+    });
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -446,10 +446,26 @@ export function forwardLogToSentry(entry: {
     });
 
     if (level === 'warn') {
-      Sentry.logger.warn(headline, safeExtra);
-    } else {
-      Sentry.logger.info(headline, safeExtra);
+      Sentry.withScope(scope => {
+        scope.setTag('log_category', category);
+        if (name) {
+          scope.setTag('error_type', name);
+        }
+        if (metadata?.tags) {
+          for (const [key, value] of Object.entries(metadata.tags)) {
+            scope.setTag(key, value);
+          }
+        }
+        if (metadata?.fingerprint) {
+          scope.setFingerprint(metadata.fingerprint);
+        }
+        scope.setContext('log_metadata', safeExtra);
+        Sentry.captureMessage(headline, 'warning');
+      });
+      return;
     }
+
+    Sentry.logger.info(headline, safeExtra);
   } catch {
     // ignore
   }

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -371,6 +371,64 @@ function extractLogExtra(metadata?: LogMetadata): Record<string, unknown> {
   return extra;
 }
 
+/**
+ * Sentry's own ceiling for a tag value; past it the ingest pipeline truncates
+ * or drops. Truncating here keeps the value deterministic instead.
+ */
+const MAX_TAG_VALUE_LENGTH = 200;
+/**
+ * `LogMetadata['tags']` is caller-facing and open, so a caller can hand over an
+ * arbitrarily wide record. `sanitiseLogValue` bounds the extra but never sees
+ * the tags, so they need a bound of their own (FOAM-TV-MOBILE-9V).
+ */
+const MAX_TAGS = 24;
+
+function applyLogScope(
+  scope: Sentry.Scope,
+  {
+    category,
+    name,
+    metadata,
+    safeExtra,
+  }: {
+    category: string;
+    name?: string;
+    metadata?: LogMetadata;
+    safeExtra: Record<string, unknown>;
+  },
+): void {
+  // Caller tags go on first so the canonical pair below always wins: a later
+  // setTag overwrites an earlier one, so a caller passing `log_category` or
+  // `error_type` would otherwise replace the value the grouping relies on.
+  if (metadata?.tags) {
+    let applied = 0;
+    for (const [key, value] of Object.entries(metadata.tags)) {
+      if (applied >= MAX_TAGS) {
+        break;
+      }
+      if (!key || value === undefined || value === null) {
+        continue;
+      }
+      applied += 1;
+      scope.setTag(
+        key,
+        typeof value === 'string' && value.length > MAX_TAG_VALUE_LENGTH
+          ? value.slice(0, MAX_TAG_VALUE_LENGTH)
+          : value,
+      );
+    }
+  }
+
+  scope.setTag('log_category', category);
+  if (name) {
+    scope.setTag('error_type', name);
+  }
+  if (metadata?.fingerprint) {
+    scope.setFingerprint(metadata.fingerprint);
+  }
+  scope.setContext('log_metadata', safeExtra);
+}
+
 function buildSentryException(
   message: string,
   name: string | undefined,
@@ -410,19 +468,7 @@ export function forwardLogToSentry(entry: {
       Sentry.addBreadcrumb({ category, message: headline, level: 'error' });
 
       Sentry.withScope(scope => {
-        scope.setTag('log_category', category);
-        if (name) {
-          scope.setTag('error_type', name);
-        }
-        if (metadata?.tags) {
-          for (const [key, value] of Object.entries(metadata.tags)) {
-            scope.setTag(key, value);
-          }
-        }
-        if (metadata?.fingerprint) {
-          scope.setFingerprint(metadata.fingerprint);
-        }
-        scope.setContext('log_metadata', safeExtra);
+        applyLogScope(scope, { category, name, metadata, safeExtra });
 
         const exception =
           cause instanceof Error
@@ -447,19 +493,7 @@ export function forwardLogToSentry(entry: {
 
     if (level === 'warn') {
       Sentry.withScope(scope => {
-        scope.setTag('log_category', category);
-        if (name) {
-          scope.setTag('error_type', name);
-        }
-        if (metadata?.tags) {
-          for (const [key, value] of Object.entries(metadata.tags)) {
-            scope.setTag(key, value);
-          }
-        }
-        if (metadata?.fingerprint) {
-          scope.setFingerprint(metadata.fingerprint);
-        }
-        scope.setContext('log_metadata', safeExtra);
+        applyLogScope(scope, { category, name, metadata, safeExtra });
         Sentry.captureMessage(headline, 'warning');
       });
       return;

--- a/src/services/__tests__/twitch-badge-service.test.ts
+++ b/src/services/__tests__/twitch-badge-service.test.ts
@@ -1,0 +1,72 @@
+import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
+
+import { twitchApi } from '../api/clients';
+import { twitchBadgeService } from '../twitch-badge-service';
+
+jest.mock('../api/clients', () => ({
+  twitchApi: { get: jest.fn() },
+}));
+
+const api = jest.mocked(twitchApi);
+
+function makeVersion(id: string, title: string) {
+  return {
+    id,
+    image_url_1x: `https://static-cdn.jtvnw.net/badges/v1/${id}/1`,
+    image_url_2x: `https://static-cdn.jtvnw.net/badges/v1/${id}/2`,
+    image_url_4x: `https://static-cdn.jtvnw.net/badges/v1/${id}/3`,
+    title,
+    description: title,
+    click_action: '',
+    click_url: null,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('twitchBadgeService.listSanitisedChannelBadges', () => {
+  test('keeps campaign sets alongside subscriber and bits', async () => {
+    api.get.mockResolvedValue({
+      data: [
+        {
+          set_id: 'subscriber',
+          versions: [makeVersion('12', '1-Year Subscriber')],
+        },
+        { set_id: 'bits', versions: [makeVersion('100', 'cheer 100')] },
+        {
+          set_id: 'campaign-96858382-cd01bbf6-mw',
+          versions: [makeVersion('1', 'Multi-Month Sub')],
+        },
+      ],
+    });
+
+    const badges =
+      await twitchBadgeService.listSanitisedChannelBadges('96858382');
+
+    expect(badges).toEqual<SanitisedBadgeSet[]>([
+      {
+        id: '12',
+        url: 'https://static-cdn.jtvnw.net/badges/v1/12/3',
+        type: 'Twitch Subscriber Badge',
+        title: '1-Year Subscriber',
+        set: 'subscriber',
+      },
+      {
+        id: '100',
+        url: 'https://static-cdn.jtvnw.net/badges/v1/100/3',
+        type: 'Twitch Bit Badge',
+        title: 'Cheer 100',
+        set: 'bits',
+      },
+      {
+        id: '1',
+        url: 'https://static-cdn.jtvnw.net/badges/v1/1/3',
+        type: 'Twitch Channel Badge',
+        title: 'Multi-Month Sub',
+        set: 'campaign-96858382-cd01bbf6-mw',
+      },
+    ]);
+  });
+});

--- a/src/services/twitch-badge-service.ts
+++ b/src/services/twitch-badge-service.ts
@@ -19,6 +19,25 @@ interface TwitchBadge {
   versions: TwitchBadgeVersion[];
 }
 
+/**
+ * A channel's badge sets are not limited to `bits` and `subscriber`: Twitch
+ * also serves per-channel campaign sets (`campaign-<channelId>-<uuid>-mw`,
+ * `-sub`) that a large share of a busy channel's chatters wear. Every set is
+ * kept; only the two well-known ones get a more specific label than the
+ * generic channel one.
+ */
+function channelBadgeType(
+  setId: TwitchBadge['set_id'],
+): SanitisedBadgeSet['type'] {
+  if (setId === 'bits') {
+    return 'Twitch Bit Badge';
+  }
+  if (setId === 'subscriber') {
+    return 'Twitch Subscriber Badge';
+  }
+  return 'Twitch Channel Badge';
+}
+
 export const twitchBadgeService = {
   listSanitisedChannelBadges: async (
     channelId: string,
@@ -35,29 +54,15 @@ export const twitchBadgeService = {
     const sanitisedBadges: SanitisedBadgeSet[] = [];
 
     result.data.forEach(badgeSet => {
-      if (badgeSet.set_id === 'bits') {
-        badgeSet.versions.forEach((badge: TwitchBadgeVersion) => {
-          sanitisedBadges.push({
-            id: badge.id,
-            url: badge.image_url_4x,
-            type: 'Twitch Bit Badge',
-            title: `Cheer ${badge.id}`,
-            set: badgeSet.set_id,
-          });
+      badgeSet.versions.forEach((badge: TwitchBadgeVersion) => {
+        sanitisedBadges.push({
+          id: badge.id,
+          url: badge.image_url_4x,
+          type: channelBadgeType(badgeSet.set_id),
+          title: badgeSet.set_id === 'bits' ? `Cheer ${badge.id}` : badge.title,
+          set: badgeSet.set_id,
         });
-      }
-
-      if (badgeSet.set_id === 'subscriber') {
-        badgeSet.versions.forEach((badge: TwitchBadgeVersion) => {
-          sanitisedBadges.push({
-            id: badge.id,
-            url: badge.image_url_4x,
-            type: 'Twitch Subscriber Badge',
-            title: badge.title,
-            set: badgeSet.set_id,
-          });
-        });
-      }
+      });
     });
     return sanitisedBadges;
   },


### PR DESCRIPTION
# Why

Reported as "some badges are blank / have a space where the badge should be", investigated against erobb221.

A badge that fails to draw doesn't collapse, it leaves a fixed-size hole: `ChatMessageBadges` drops url-less badges, but `chatText.styles.ts` gives every rendered badge a fixed width/height plus `marginRight`. The protocol-relative 7TV cause is already fixed and Sentry confirms it's gone (nothing since Aug 2), so what's left produces no telemetry at all. Two paths do that, and both are badge-specific.

I sampled 146 live messages from erobb221 (41 distinct badge tags) and resolved every one against the real Twitch/FFZ endpoints, which turned up two more badge bugs on the way.

# How

**Blank slots** (`ChatInlineImage.tsx`)

- `handleError`'s `showRef` branch set `failedRefUrl` and then fell through into the *uri* chain logic as if the uri had failed. `buildImageFallbackChain` only matches the `{n}x.{ext}` shape, so Twitch/FFZ/BTTV/Chatterino badge urls derive no variants and the chain is length 1: with `maxRetryAttempts={0}` that lands on `status: 'failed'` in one step, having spent the whole budget on a failure the network never saw. `recyclingKey` is also unchanged across the ref to uri source swap, so expo-image gets no signal to redo the load. The ref branch now restarts the uri chain at index 0 with a fresh budget and a nonce bump. 7TV badges were never affected, their urls match the pattern and get 8 candidates.
- The watchdog was disabled on the ref path (`if (showRef || status !== 'loading')`), so a ref released under a mounted row (draws nothing, reports neither `onLoad` nor `onError`) was the one state that could hold a slot blank forever, silently. #838 fixed the shimmer for this, but badges pass `showLoadingShimmer={false}` so it doesn't reach them. Guard is now `status !== 'loading'` only.

**Channel badge sets** (`twitch-badge-service.ts`) - `listSanitisedChannelBadges` only kept `bits` and `subscriber`. erobb221 has six more (`campaign-96858382-<uuid>-mw` / `-sub`), all serving valid `image_url_4x`, and 61 of the 146 messages I sampled wear one. Allowlist dropped; `channelBadgeType()` picks the label.

**FFZ badge colour** (`ChatMessageBadges.tsx`, `chatText.styles.ts`) - FFZ badges are white-on-transparent masks meant to sit on their colour, which `ffz-service` already fetches and the renderer ignored. Decoded from the CDN: erobb221's mod badge is 2015 opaque px all `#FFFFFF`, VIP is 1115 px all white. A badge carrying `color` now renders into a tinted `badgeTintSlot` (both new styles come off `getChatScale`, no literals at the use site). Only FFZ ever sets `color`.

**Sheet handles** (`SheetDragHandle.tsx`) - `@expo/ui` documents that a custom `handleComponent` is not rendered on iOS or Android and `handleStyle` / `handleIndicatorStyle` have no effect, so the native grabber can't be restyled. The wrapper now always passes `handleComponent={null}` and draws its own as the first row of sheet content: 36x5 pill at `rgba(255,255,255,0.22)` on even 8pt padding, sitting on the sheet background with no band or seam. The web fallback shares the component instead of keeping its own copy.

**Sentry warns** (`sentry.ts`) - warn goes through `Sentry.captureMessage(headline, 'warning')` on a scope carrying the same tags/fingerprint/context as the error path, instead of `Sentry.logger.warn`. Warnings land as grouped issues. `info` unchanged.

# Test Plan

Full suite green: 328 suites, 9950 tests. Typecheck and lint clean.

New coverage:
- `ChatInlineImage.test.tsx` - a ref failure retries the uri rather than burning a badge's budget; a held ref that never reports anything is watchdogged.
- `twitch-badge-service.test.ts` - campaign sets survive alongside bits and subscriber.
- `ChatMessageBadges.test.tsx` - FFZ badge paints onto its colour, uncoloured badge stays untinted, url-less badge renders no slot.
- `BottomSheet.test.tsx` - native indicator always off, own handle drawn only with `showDragIndicator`.

Manual repro: open erobb221 and the campaign badges (the `-mw` / `-sub` ones most chatters wear) should now render, and mod/VIP should show the channel's FFZ art on its colour rather than a white blob.

Not verified on device: I established the two blank-slot paths from the code and the CDN data, but did not reproduce a blank badge on hardware. The watchdog fix will start emitting `chat.emote.load_failed` with `renderPath: 'imageRef'` once this ships, which settles which of the two actually bites.
