### PR TITLE
fix(chat): stop emote messages leaving blank gaps on the flex-wrap path

### DIFF
--- a/src/components/Chat/components/ChatMessage/__tests__/RichChatMessage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/__tests__/RichChatMessage.test.tsx
@@ -80,6 +80,17 @@ const touchAt = (pageX: number, pageY: number) => ({
   nativeEvent: { pageX, pageY },
 });
 
+function hasTextAncestor(element: ReactTestInstance): boolean {
+  let ancestor: ReactTestInstance | null = element.parent;
+  while (ancestor) {
+    if (String(ancestor.type) === 'Text') {
+      return true;
+    }
+    ancestor = ancestor.parent;
+  }
+  return false;
+}
+
 function fireMessageLongPress(
   element: ReactTestInstance,
   options: { driftDp?: number } = {},
@@ -615,11 +626,12 @@ describe('RichChatMessage', () => {
       expect(getByTestId('emote-renderer')).toBeOnTheScreen();
     });
 
-    test('renders emotes as flex views, never nested inside a Text', () => {
-      // An emote nested in a <Text> can only be given a fixed line height,
-      // which baseline-aligns and clips the top of the image. Messages with
-      // emotes must take the flex-wrap path so the row grows to the emote's
-      // full intended size. See UserChatBody renderInline gating.
+    test('flows an ordinary emote inline, inside the row Text', () => {
+      // The flex-wrap path makes each text run its own flex item, so an emote
+      // after a run that wraps is pushed onto a fresh flex line and the tail of
+      // the wrapped line is left blank. An ordinary emote therefore belongs in
+      // the row's Text, where `bodyEmoteLine` raises the leading on every
+      // nested span so the attachment is not clipped.
       const emoteData: ParsedPart<'emote'> = {
         type: 'emote',
         content: 'Kappa',
@@ -643,12 +655,37 @@ describe('RichChatMessage', () => {
         />,
       );
 
-      let ancestor: ReactTestInstance | null =
-        getByTestId('emote-renderer').parent;
-      while (ancestor) {
-        expect(ancestor.type).not.toBe('Text');
-        ancestor = ancestor.parent;
-      }
+      expect(hasTextAncestor(getByTestId('emote-renderer'))).toBe(true);
+    });
+
+    test('keeps a zero-width emote out of the row Text', () => {
+      // A zero-width emote composites its overlay with absolute positioning,
+      // which does not survive inside a Text, so it still takes the flex path.
+      const emoteData: ParsedPart<'emote'> = {
+        type: 'emote',
+        content: 'SoSnowy',
+        original_name: 'SoSnowy',
+        name: 'SoSnowy',
+        id: '26',
+        url: 'https://cdn.7tv.app/emote/26/1x.webp',
+        site: '7TV Channel',
+        zero_width: true,
+      };
+
+      const message = createMockMessage([
+        { type: 'text', content: 'look ' },
+        emoteData,
+      ]);
+
+      const { getByTestId } = render(
+        <RichChatMessage
+          {...message}
+          onReply={mockOnReply}
+          onEmotePress={mockOnEmotePress}
+        />,
+      );
+
+      expect(hasTextAncestor(getByTestId('emote-renderer'))).toBe(false);
     });
   });
 

--- a/src/components/Chat/components/ChatMessage/__tests__/RichChatMessage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/__tests__/RichChatMessage.test.tsx
@@ -1,10 +1,13 @@
 /* eslint-disable camelcase */
+import { StyleSheet } from 'react-native';
 import type { ReactTestInstance } from 'react-test-renderer';
 
 import { act, fireEvent, render } from '@testing-library/react-native';
 
+import { getChatTextStyles } from '@app/components/Chat/components/ChatMessage/chatText.styles';
 import { MESSAGE_LONG_PRESS_DELAY_MS } from '@app/components/Chat/hooks/useRichChatMessage';
 import { EmoteSetKind } from '@app/graphql/generated/gql';
+import { chatStore$ } from '@app/store/chat/observables/chatStore';
 import type { ChatMessageType } from '@app/store/chat/types/constants';
 import { preferences$ } from '@app/store/preferenceStore';
 import { theme } from '@app/styles/themes';
@@ -80,15 +83,21 @@ const touchAt = (pageX: number, pageY: number) => ({
   nativeEvent: { pageX, pageY },
 });
 
-function hasTextAncestor(element: ReactTestInstance): boolean {
+function findTextAncestor(
+  element: ReactTestInstance,
+): ReactTestInstance | null {
   let ancestor: ReactTestInstance | null = element.parent;
   while (ancestor) {
     if (String(ancestor.type) === 'Text') {
-      return true;
+      return ancestor;
     }
     ancestor = ancestor.parent;
   }
-  return false;
+  return null;
+}
+
+function hasTextAncestor(element: ReactTestInstance): boolean {
+  return findTextAncestor(element) !== null;
 }
 
 function fireMessageLongPress(
@@ -116,6 +125,7 @@ describe('RichChatMessage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    chatStore$.userPaintIds.set({});
   });
 
   test('coalesces adjacent text parts into one rendered text node', () => {
@@ -686,6 +696,40 @@ describe('RichChatMessage', () => {
       );
 
       expect(hasTextAncestor(getByTestId('emote-renderer'))).toBe(false);
+    });
+
+    test('keeps the emote leading on a painted row that flows its body inline', () => {
+      // A paint renders through a mask, so a painted row cannot put the
+      // username in the body Text - the body still flows inline and carries the
+      // emotes on its own, so it needs the emote leading or they clip.
+      chatStore$.userPaintIds.set({ '123456': 'paint-1' });
+      const emoteData: ParsedPart<'emote'> = {
+        type: 'emote',
+        content: 'Kappa',
+        original_name: 'Kappa',
+        name: 'Kappa',
+        id: '25',
+        url: 'https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/1.0',
+        site: 'Twitch Channel',
+      };
+
+      const message = createMockMessage([
+        { type: 'text', content: 'look ' },
+        emoteData,
+      ]);
+
+      const { getByTestId } = render(
+        <RichChatMessage
+          {...message}
+          onReply={mockOnReply}
+          onEmotePress={mockOnEmotePress}
+        />,
+      );
+
+      const bodyText = findTextAncestor(getByTestId('emote-renderer'));
+      expect(StyleSheet.flatten(bodyText?.props.style).lineHeight).toBe(
+        getChatTextStyles('default', false).bodyEmoteLine.lineHeight,
+      );
     });
   });
 

--- a/src/components/Chat/components/ChatMessage/renderers/UserChatBody.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/UserChatBody.tsx
@@ -11,6 +11,7 @@ import type { UserStateTags } from '@app/types/chat/irc-tags/userstate';
 import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
 import { normaliseChatUsername } from '@app/utils/chat/chatUsernames/normaliseChatUsername';
 import { canFlowInline } from '@app/utils/chat/deriveChatBody/canFlowInline';
+import { getMessageStructure } from '@app/utils/chat/deriveChatBody/getMessageStructure';
 import { generateRandomTwitchColor } from '@app/utils/chat/generateRandomTwitchColor';
 import { cachedLighten } from '@app/utils/chat/resolveCachedSenderColor/cachedLighten';
 
@@ -111,6 +112,14 @@ export function UserChatBody({
     (username ? cachedLighten(generateRandomTwitchColor(username)) : undefined);
   const actionColor = isAction ? inlineUsernameColor : undefined;
   const textStyles = getChatTextStyles(fontScale, compact);
+  /**
+   * A painted row keeps the username out of the body Text but still flows the
+   * body inline, so the body carries emotes on its own and needs the taller
+   * emote leading on every nested span - see InlineMessageLine.
+   */
+  const bodyEmoteLineStyle = getMessageStructure(message).containsEmotes
+    ? textStyles.bodyEmoteLine
+    : undefined;
 
   return (
     <View style={styles.messageColumn}>
@@ -211,9 +220,10 @@ export function UserChatBody({
             </View>
           ) : null}
           {bodyFlowsInline ? (
-            <Text style={textStyles.body}>
+            <Text style={[textStyles.body, bodyEmoteLineStyle]}>
               <InlineMessageSpans
                 {...rendererArgs}
+                emoteLineStyle={bodyEmoteLineStyle}
                 message={message}
                 replyPlainMentionTarget={replyPlainMentionTarget}
                 textColor={actionColor}

--- a/src/components/Chat/components/ChatMessage/renderers/UserChatBody.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/UserChatBody.tsx
@@ -11,7 +11,6 @@ import type { UserStateTags } from '@app/types/chat/irc-tags/userstate';
 import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
 import { normaliseChatUsername } from '@app/utils/chat/chatUsernames/normaliseChatUsername';
 import { canFlowInline } from '@app/utils/chat/deriveChatBody/canFlowInline';
-import { getMessageStructure } from '@app/utils/chat/deriveChatBody/getMessageStructure';
 import { generateRandomTwitchColor } from '@app/utils/chat/generateRandomTwitchColor';
 import { cachedLighten } from '@app/utils/chat/resolveCachedSenderColor/cachedLighten';
 
@@ -99,19 +98,13 @@ export function UserChatBody({
     userId ? Boolean(chatStore$.userPaintIds[userId]?.get()) : false,
   );
   const isModerated = Boolean(moderationNotice);
-  const { containsEmotes: bodyContainsEmotes } = getMessageStructure(message);
   /**
    * A paint renders through a mask, so a painted row cannot put the username
    * in the same Text as the body - but the body alone still flows.
    */
-  const rowFlowsInline = canFlowInline(message, { hasPaint, isModerated });
-  const bodyCanFlowInline = canFlowInline(message, {
-    hasPaint: false,
-    isModerated,
-  });
-  const renderInline = rowFlowsInline && !bodyContainsEmotes;
+  const renderInline = canFlowInline(message, { hasPaint, isModerated });
   const bodyFlowsInline =
-    bodyCanFlowInline && !renderInline && !bodyContainsEmotes;
+    !renderInline && canFlowInline(message, { hasPaint: false, isModerated });
   const inlineUsernameColor =
     cachedSenderColor ??
     (userstateColor ? cachedLighten(userstateColor) : undefined) ??


### PR DESCRIPTION
# Why

Chat has had "blank gaps" for a while. Debugged on a physical iPhone against dima_wallhacks, overlaying the accessibility row rects onto screenshots.

The list is fine. Rows are contiguous at every scroll position, so this was never a LegendList measurement or recycling fault - the gap lives inside a correctly sized row.

`UserChatBody` routed every emote-bearing message to the flex-wrap renderer via `!bodyContainsEmotes`. On that path each text run and each emote is a separate flex item, and a text run that wraps internally still measures as one full-width box. So the emote after it gets pushed onto a brand new flex line, leaving the tail of the wrapped line blank and the emote sitting alone below it.

`duckplayinggames000001: [emote] let's go dima give us 30 bomb [emote]` measured h=70 (two flex lines, the second nearly empty). `loops_cs: crepes [emote]` measured h=40.

# How

Dropped the gate - `renderInline` is just `canFlowInline(...)` again.

That gate came from #716, when an emote nested in a `Text` could only be given a fixed line height and clipped the top of the image. `bodyEmoteLine` in #832 is the real fix for that: it applies `emoteLineHeight` to every **nested** span, which is what TextKit actually needs since it sizes a wrapped line from the paragraph style of the spans on it. That is why bumping the outer lineHeight 32->34 kept failing back in July. It has been dead code ever since the gate landed.

#716 also added `emoteBreaksInline` - the precise gate that keeps zero-width and overlaid emotes on the flex path, since those composite with absolute positioning. That one stays. Adding both in the same commit is the tell that the blanket gate was collateral.

The old regression test pinned the behaviour being removed, so it is replaced by a pair: one asserting an ordinary emote flows inside the row `Text`, and a negative control asserting a zero-width emote does not.

# Test Plan

After the change, same rows: `duckplayinggames000001` 70 -> 38, `loops_cs: crepes [emote]` 40 -> 28. Emote row heights are content driven now instead of a uniform inflated 40.

Checked on device that emotes are not clipped, which is the regression #631/#832 were about - they render complete and uncropped inline mid-sentence, with text flowing after them (`juzzler699: @brrreeezzz both will [emote] but snow leapord will look better`).

`tsc` clean, eslint clean, 8986 tests pass. Worth noting the suite passed even with two type errors in the test edit, since babel-jest skips typecheck - `tsc` caught them separately.

Not fixed here: an occasional genuinely blank emote slot (row sized right, nothing painted). That is the separate ImageRef eviction bug from #838/#839/#840.