### PR TITLE
fix(cosmetics): keep 7tv paints on usernames while chat scrolls

### DIFF
--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsername.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsername.tsx
@@ -1,9 +1,8 @@
 import { memo } from 'react';
-import { type StyleProp, StyleSheet, TextStyle, View } from 'react-native';
+import { type StyleProp, StyleSheet, TextStyle } from 'react-native';
 
 import { useSelector } from '@legendapp/state/react';
 
-import { useChatScrollActive } from '@app/components/Chat/hooks/useChatScrollActive';
 import { Text } from '@app/components/ui/Text/Text';
 import { chatStore$ } from '@app/store/chat/observables/chatStore';
 import { usePaintRenderer } from '@app/store/preferenceStore';
@@ -12,20 +11,10 @@ import type { PaintData } from '@app/types/seventv/cosmetics';
 import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
 
 import { chatLineMetrics } from '../chatScale';
-import { PaintedUsernameDropShadowLayer } from './PaintedUsernameDropShadowLayer';
-import { PaintedUsernameMaskedFill } from './PaintedUsernameMaskedFill';
+import { PaintedUsernameHostedLayers } from './PaintedUsernameHostedLayers';
 import { PaintedUsernameSkia } from './PaintedUsernameSkia';
-import { PaintedUsernameWebView } from './PaintedUsernameWebView';
 import { DEFAULT_PAINT_DROP_SHADOW_MODE } from './util/paintLayer/DEFAULT_PAINT_DROP_SHADOW_MODE';
-import {
-  getPaintDropShadows,
-  type PaintDropShadowMode,
-} from './util/paintLayer/getPaintDropShadows';
-import { paintShadowKey } from './util/paintLayer/paintShadowKey';
-import { buildPaintUsernameTextStyle } from './util/paintTextStyle/buildPaintUsernameTextStyle';
-import { getPaintTextShadows } from './util/paintTextStyle/getPaintTextShadows';
-import { getPaintTextStroke } from './util/paintTextStyle/getPaintTextStroke';
-import { paintStrokeToShadow } from './util/paintTextStyle/paintStrokeToShadow';
+import type { PaintDropShadowMode } from './util/paintLayer/getPaintDropShadows';
 
 interface PaintedUsernameProps {
   username: string;
@@ -60,8 +49,6 @@ function PaintedUsernameWithPaint({
   sevenTvPaintDropShadows,
   usernameTextStyle,
 }: PaintedUsernameWithPaintProps) {
-  // Painted rows only - in the parent this re-renders every visible row twice per fling.
-  const isScrolling = useChatScrollActive();
   const paintRenderer = usePaintRenderer();
 
   if (paintRenderer === 'off') {
@@ -74,22 +61,8 @@ function PaintedUsernameWithPaint({
     );
   }
 
-  // Solid colour during fling: skip MaskedView/gradient/SVG/image layers while
-  // the render encoder is pressured (FOAM-TV-MOBILE-BJ). Full paint returns ~150ms after settle.
-  if (isScrolling) {
-    return (
-      <Text
-        style={[
-          styles.plainUsername,
-          { color: fallbackColor },
-          usernameTextStyle,
-        ]}
-      >
-        {displayUsername}
-      </Text>
-    );
-  }
-
+  // Skia draws a cached bitmap, so a fling costs it no more than rest does and
+  // it keeps its paint throughout; only the hosted renderers shed.
   if (paintRenderer === 'skia' && !isModerated) {
     return (
       <PaintedUsernameSkia
@@ -101,57 +74,17 @@ function PaintedUsernameWithPaint({
     );
   }
 
-  if (paintRenderer === 'webview' && !isModerated) {
-    return (
-      <PaintedUsernameWebView
-        username={displayUsername}
-        paint={paint}
-        fallbackColor={fallbackColor}
-        fontSize={fontSize}
-        lineHeight={lineHeight}
-      />
-    );
-  }
-
-  const paintTextStyle = buildPaintUsernameTextStyle(paint);
-  const dropShadows = getPaintDropShadows(paint, sevenTvPaintDropShadows);
-  const textShadows = getPaintTextShadows(paint);
-  const stroke = getPaintTextStroke(paint);
-
-  const maskTextStyle = [
-    styles.maskText,
-    usernameTextStyle,
-    paintTextStyle,
-  ] as StyleProp<TextStyle>;
-
-  // Back to front: drop-shadows, text-shadows, stroke, then painted fill.
-  const underlayShadows = [
-    ...dropShadows.map(shadow => ({ shadow, source: 'drop' })),
-    ...textShadows.map(shadow => ({ shadow, source: 'text' })),
-    ...(stroke
-      ? [{ shadow: paintStrokeToShadow(stroke), source: 'stroke' }]
-      : []),
-  ];
-
   return (
-    <View style={styles.paintedWrapper}>
-      {underlayShadows.map(({ shadow, source }, index) => (
-        <PaintedUsernameDropShadowLayer
-          // Static, never-reordered list
-          // eslint-disable-next-line react-doctor/no-array-index-as-key
-          key={`${source}-${index}-${paintShadowKey(shadow)}`}
-          displayUsername={displayUsername}
-          maskTextStyle={maskTextStyle}
-          shadow={shadow}
-        />
-      ))}
-      <PaintedUsernameMaskedFill
-        displayUsername={displayUsername}
-        fallbackColor={fallbackColor}
-        paint={paint}
-        maskTextStyle={maskTextStyle}
-      />
-    </View>
+    <PaintedUsernameHostedLayers
+      displayUsername={displayUsername}
+      fallbackColor={fallbackColor}
+      fontSize={fontSize}
+      lineHeight={lineHeight}
+      paint={paint}
+      sevenTvPaintDropShadows={sevenTvPaintDropShadows}
+      usernameTextStyle={usernameTextStyle}
+      useWebView={paintRenderer === 'webview' && !isModerated}
+    />
   );
 }
 
@@ -213,15 +146,6 @@ function PaintedUsernameComponent({
 }
 
 const styles = StyleSheet.create({
-  maskText: {
-    ...chatLineMetrics.comfortable,
-    color: 'black',
-    fontWeight: 'bold',
-  },
-  paintedWrapper: {
-    alignSelf: 'flex-start',
-    position: 'relative',
-  },
   plainUsername: {
     ...chatLineMetrics.comfortable,
     fontWeight: 'bold',

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameHostedLayers.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameHostedLayers.tsx
@@ -1,0 +1,135 @@
+import { type StyleProp, StyleSheet, TextStyle, View } from 'react-native';
+
+import { useChatScrollActive } from '@app/components/Chat/hooks/useChatScrollActive';
+import { Text } from '@app/components/ui/Text/Text';
+import type { PaintData } from '@app/types/seventv/cosmetics';
+
+import { chatLineMetrics } from '../chatScale';
+import { PaintedUsernameDropShadowLayer } from './PaintedUsernameDropShadowLayer';
+import { PaintedUsernameMaskedFill } from './PaintedUsernameMaskedFill';
+import { PaintedUsernameWebView } from './PaintedUsernameWebView';
+import {
+  getPaintDropShadows,
+  type PaintDropShadowMode,
+} from './util/paintLayer/getPaintDropShadows';
+import { getPaintSolidColor } from './util/paintLayer/getPaintSolidColor';
+import { paintShadowKey } from './util/paintLayer/paintShadowKey';
+import { buildPaintUsernameTextStyle } from './util/paintTextStyle/buildPaintUsernameTextStyle';
+import { getPaintTextShadows } from './util/paintTextStyle/getPaintTextShadows';
+import { getPaintTextStroke } from './util/paintTextStyle/getPaintTextStroke';
+import { paintStrokeToShadow } from './util/paintTextStyle/paintStrokeToShadow';
+
+interface PaintedUsernameHostedLayersProps {
+  displayUsername: string;
+  fallbackColor: string;
+  fontSize?: number;
+  lineHeight?: number;
+  paint: PaintData;
+  sevenTvPaintDropShadows: PaintDropShadowMode;
+  usernameTextStyle?: StyleProp<TextStyle>;
+  useWebView: boolean;
+}
+
+/**
+ * The renderers that hang native views off every painted row: a WKWebView per
+ * name, or a MaskedView over a stack of gradient and image layers. Both shed
+ * to a solid paint colour while the list is flinging, when the render encoder
+ * is most pressured (FOAM-TV-MOBILE-BJ), and return ~150ms after it settles.
+ */
+export function PaintedUsernameHostedLayers({
+  displayUsername,
+  fallbackColor,
+  fontSize,
+  lineHeight,
+  paint,
+  sevenTvPaintDropShadows,
+  usernameTextStyle,
+  useWebView,
+}: PaintedUsernameHostedLayersProps) {
+  const isScrolling = useChatScrollActive();
+  const paintTextStyle = buildPaintUsernameTextStyle(paint);
+
+  // Weight and transform carry over with the colour, so only the fill changes.
+  if (isScrolling) {
+    return (
+      <Text
+        style={[
+          styles.scrollUsername,
+          usernameTextStyle,
+          paintTextStyle,
+          { color: getPaintSolidColor(paint) ?? fallbackColor },
+        ]}
+      >
+        {displayUsername}
+      </Text>
+    );
+  }
+
+  if (useWebView) {
+    return (
+      <PaintedUsernameWebView
+        username={displayUsername}
+        paint={paint}
+        fallbackColor={fallbackColor}
+        fontSize={fontSize}
+        lineHeight={lineHeight}
+      />
+    );
+  }
+
+  const dropShadows = getPaintDropShadows(paint, sevenTvPaintDropShadows);
+  const textShadows = getPaintTextShadows(paint);
+  const stroke = getPaintTextStroke(paint);
+
+  const maskTextStyle = [
+    styles.maskText,
+    usernameTextStyle,
+    paintTextStyle,
+  ] as StyleProp<TextStyle>;
+
+  // Back to front: drop-shadows, text-shadows, stroke, then painted fill.
+  const underlayShadows = [
+    ...dropShadows.map(shadow => ({ shadow, source: 'drop' })),
+    ...textShadows.map(shadow => ({ shadow, source: 'text' })),
+    ...(stroke
+      ? [{ shadow: paintStrokeToShadow(stroke), source: 'stroke' }]
+      : []),
+  ];
+
+  return (
+    <View style={styles.paintedWrapper}>
+      {underlayShadows.map(({ shadow, source }, index) => (
+        <PaintedUsernameDropShadowLayer
+          // Static, never-reordered list
+          // eslint-disable-next-line react-doctor/no-array-index-as-key
+          key={`${source}-${index}-${paintShadowKey(shadow)}`}
+          displayUsername={displayUsername}
+          maskTextStyle={maskTextStyle}
+          shadow={shadow}
+        />
+      ))}
+      <PaintedUsernameMaskedFill
+        displayUsername={displayUsername}
+        fallbackColor={fallbackColor}
+        paint={paint}
+        maskTextStyle={maskTextStyle}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  maskText: {
+    ...chatLineMetrics.comfortable,
+    color: 'black',
+    fontWeight: 'bold',
+  },
+  paintedWrapper: {
+    alignSelf: 'flex-start',
+    position: 'relative',
+  },
+  scrollUsername: {
+    ...chatLineMetrics.comfortable,
+    fontWeight: 'bold',
+  },
+});

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/__tests__/PaintedUsername.test.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/__tests__/PaintedUsername.test.tsx
@@ -1,0 +1,116 @@
+import { act, render, screen } from '@testing-library/react-native';
+
+import { chatScrollActivity } from '@app/components/Chat/util/chatScrollActivity';
+import type { PaintData } from '@app/types/seventv/cosmetics';
+
+import { PaintedUsername } from '../PaintedUsername';
+
+const TWITCH_COLOR = 'rgb(0, 0, 255)';
+
+const GRADIENT_PAINT: PaintData = {
+  id: 'paint-1',
+  name: 'Gradient',
+  color: null,
+  layers: {
+    0: {
+      function: 'LINEAR_GRADIENT',
+      stops: {
+        0: { at: 0, color: 0xff0000ff },
+        1: { at: 0.5, color: 0x00ff00ff },
+        length: 2,
+      },
+      angle: 90,
+      shape: 'circle',
+      repeat: false,
+      image_url: '',
+      canvas_repeat: '',
+      at: null,
+      size: null,
+      opacity: 1,
+    },
+    length: 1,
+  },
+  shadows: { length: 0 },
+  textStyle: null,
+  function: 'LINEAR_GRADIENT',
+  repeat: false,
+  angle: 90,
+  shape: 'circle',
+  image_url: '',
+  stops: { length: 0 },
+};
+
+describe('PaintedUsername', () => {
+  afterEach(() => {
+    act(() => {
+      chatScrollActivity.reset();
+    });
+  });
+
+  test('paints the name through the masked fill at rest', () => {
+    render(
+      <PaintedUsername
+        username='luke'
+        paint={GRADIENT_PAINT}
+        fallbackColor={TWITCH_COLOR}
+        showColon={false}
+      />,
+    );
+
+    expect(screen.getByTestId('masked-view')).toBeOnTheScreen();
+  });
+
+  test('holds a paint colour while the list is flinging', () => {
+    render(
+      <PaintedUsername
+        username='luke'
+        paint={GRADIENT_PAINT}
+        fallbackColor={TWITCH_COLOR}
+        showColon={false}
+      />,
+    );
+
+    act(() => {
+      chatScrollActivity.poke();
+    });
+
+    expect(screen.queryByTestId('masked-view')).toBeNull();
+    expect(screen.getByText('luke')).toHaveStyle({
+      color: 'rgba(0, 255, 0, 1.000)',
+    });
+  });
+
+  test('falls back to the chat colour for a paint with no colour of its own', () => {
+    render(
+      <PaintedUsername
+        username='luke'
+        paint={{
+          ...GRADIENT_PAINT,
+          layers: {
+            0: {
+              function: 'URL',
+              stops: { length: 0 },
+              angle: 0,
+              shape: 'circle',
+              repeat: false,
+              image_url: 'https://cdn.7tv.app/paint/abc/1x.webp',
+              canvas_repeat: '',
+              at: null,
+              size: null,
+              opacity: 1,
+            },
+            length: 1,
+          },
+        }}
+        fallbackColor={TWITCH_COLOR}
+        showColon={false}
+      />,
+    );
+
+    act(() => {
+      chatScrollActivity.poke();
+    });
+
+    expect(screen.getByText('luke')).toHaveStyle({ color: TWITCH_COLOR });
+  });
+});

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/__tests__/getPaintSolidColor.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/__tests__/getPaintSolidColor.test.ts
@@ -1,0 +1,109 @@
+import type { PaintData, PaintLayerData } from '@app/types/seventv/cosmetics';
+
+import { getPaintSolidColor } from '../getPaintSolidColor';
+
+function createLayer(overrides: Partial<PaintLayerData>): PaintLayerData {
+  return {
+    function: 'LINEAR_GRADIENT',
+    image_url: '',
+    stops: { length: 0 },
+    angle: 0,
+    shape: 'circle',
+    repeat: false,
+    canvas_repeat: '',
+    at: null,
+    size: null,
+    opacity: 1,
+    ...overrides,
+  };
+}
+
+function createPaint(overrides: Partial<PaintData>): PaintData {
+  return {
+    id: 'paint-1',
+    name: 'Paint',
+    color: null,
+    layers: { length: 0 },
+    shadows: { length: 0 },
+    textStyle: null,
+    function: 'LINEAR_GRADIENT',
+    repeat: false,
+    angle: 0,
+    shape: 'circle',
+    image_url: '',
+    stops: { length: 0 },
+    ...overrides,
+  };
+}
+
+describe('getPaintSolidColor', () => {
+  test('prefers the paint solid colour', () => {
+    const paint = createPaint({
+      color: 0x9c28a9ff,
+      layers: {
+        0: createLayer({
+          stops: { 0: { at: 0, color: 0x00ff00ff }, length: 1 },
+        }),
+        length: 1,
+      },
+    });
+
+    expect(getPaintSolidColor(paint)).toBe('rgba(156, 40, 169, 1.000)');
+  });
+
+  test('falls back to the mid-most stop of a colourless gradient', () => {
+    const paint = createPaint({
+      layers: {
+        0: createLayer({
+          stops: {
+            0: { at: 0, color: 0xff0000ff },
+            1: { at: 0.6, color: 0x00ff00ff },
+            2: { at: 1, color: 0x0000ffff },
+            length: 3,
+          },
+        }),
+        length: 1,
+      },
+    });
+
+    expect(getPaintSolidColor(paint)).toBe('rgba(0, 255, 0, 1.000)');
+  });
+
+  test('reads the topmost renderable layer, skipping transparent stops', () => {
+    const paint = createPaint({
+      layers: {
+        0: createLayer({
+          function: 'URL',
+          image_url: 'https://cdn.7tv.app/paint/abc/1x.webp',
+        }),
+        1: createLayer({
+          stops: {
+            0: { at: 0.5, color: 0x00ff0000 },
+            1: { at: 0.9, color: 0x00ff00ff },
+            length: 2,
+          },
+        }),
+        2: createLayer({
+          stops: { 0: { at: 0.5, color: 0x0000ffff }, length: 1 },
+        }),
+        length: 3,
+      },
+    });
+
+    expect(getPaintSolidColor(paint)).toBe('rgba(0, 255, 0, 1.000)');
+  });
+
+  test('gives no colour for a paint that only carries a texture', () => {
+    const paint = createPaint({
+      layers: {
+        0: createLayer({
+          function: 'URL',
+          image_url: 'https://cdn.7tv.app/paint/abc/1x.webp',
+        }),
+        length: 1,
+      },
+    });
+
+    expect(getPaintSolidColor(paint)).toBeNull();
+  });
+});

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/getPaintSolidColor.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/getPaintSolidColor.ts
@@ -1,0 +1,58 @@
+import { indexedCollectionToArray } from '@app/services/ws/util/indexedCollection';
+import type { PaintData, PaintStop } from '@app/types/seventv/cosmetics';
+import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
+import { sevenTvColorToRgba } from '@app/utils/color/sevenTvColorToRgba';
+
+import { getPaintLayers } from './getPaintLayers';
+import { isRenderablePaintLayer } from './isRenderablePaintLayer';
+
+// Paint-pure derivation, memoised on the paint object like the other paint
+// caches. WeakMap-keyed so entries drop with the paint; no eviction needed.
+const solidColorCache = new WeakMap<PaintData, string | null>();
+
+/**
+ * The one colour that stands in for a paint when its layer stack cannot be
+ * drawn: the paint's own colour, else the mid-most opaque gradient stop of its
+ * topmost renderable layer. Null when the paint has no colour of its own (a
+ * bare texture), leaving the caller's fallback in place.
+ */
+export function getPaintSolidColor(paint: PaintData): string | null {
+  const cached = solidColorCache.get(paint);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const color = computePaintSolidColor(paint);
+  solidColorCache.set(paint, color);
+  return color;
+}
+
+function computePaintSolidColor(paint: PaintData): string | null {
+  if (paint.color !== null) {
+    return sevenTvColorToCss(paint.color);
+  }
+
+  // getPaintLayers orders topmost first, which is the layer the eye reads.
+  for (const layer of getPaintLayers(paint)) {
+    if (!isRenderablePaintLayer(layer)) {
+      continue;
+    }
+    const stop = midStop(indexedCollectionToArray(layer.stops));
+    if (stop) {
+      return sevenTvColorToCss(stop.color);
+    }
+  }
+
+  return null;
+}
+
+function midStop(stops: PaintStop[]): PaintStop | null {
+  return stops.reduce<PaintStop | null>((best, stop) => {
+    if (sevenTvColorToRgba(stop.color).a === 0) {
+      return best;
+    }
+    if (!best || Math.abs(stop.at - 0.5) < Math.abs(best.at - 0.5)) {
+      return stop;
+    }
+    return best;
+  }, null);
+}

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/sharedPaintAnimationFrames.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/sharedPaintAnimationFrames.ts
@@ -8,6 +8,7 @@ import {
 import type { SkAnimatedImage, SkImage } from '@shopify/react-native-skia';
 import { Skia } from '@shopify/react-native-skia';
 
+import { chatScrollActiveShared } from '@app/components/Chat/util/chatScrollActiveShared';
 import { logger } from '@app/utils/logger';
 
 interface SharedPaintAnimationEntry {
@@ -114,6 +115,9 @@ export function useSharedPaintAnimationFrame(
   useFrameCallback(frameInfo => {
     const image = animatedImage.value;
     if (image == null) {
+      return;
+    }
+    if (chatScrollActiveShared.value) {
       return;
     }
     const duration = image.currentFrameDuration() || DEFAULT_FRAME_DURATION_MS;

--- a/src/components/Chat/util/chatScrollActiveShared.ts
+++ b/src/components/Chat/util/chatScrollActiveShared.ts
@@ -1,0 +1,13 @@
+import { makeMutable } from 'react-native-reanimated';
+
+import { chatScrollActivity } from './chatScrollActivity';
+
+/**
+ * UI-thread mirror of `chatScrollActivity`, for worklets that shed work during
+ * a fling without a React re-render.
+ */
+export const chatScrollActiveShared = makeMutable(false);
+
+chatScrollActivity.subscribe(active => {
+  chatScrollActiveShared.value = active;
+});


### PR DESCRIPTION
# Why

Painted 7TV usernames revert to the user's plain twitch chat colour the moment you drag the chat list, and come back ~150ms after it settles.

The fling shed in `PaintedUsername` swapped the paint for a solid `Text` in `paint.color`. Gradient paints carry `color: null`, which is most of them, so what actually got drawn was the twitch fallback.

# How

- Skia doesn't shed at all now. Its bitmaps are cached by `getPaintBitmaps`, so a fling costs one image draw, same as at rest. Shedding was worse than useless there: every visible painted row re-rendered twice per fling and each canvas unmounted and remounted, releasing and re-retaining its bitmaps. Those rows no longer subscribe to scroll activity.
- The hosted renderers (webview, masked view) still shed - that was FOAM-TV-MOBILE-BJ and the layer stack is genuinely expensive to composite mid-fling - but shed to a colour off the paint. New `getPaintSolidColor` takes `paint.color`, else the mid-most opaque gradient stop of the topmost renderable layer, else nothing and the old fallback stands. The paint's weight and transform carry over too, so glyph metrics don't shift.
- Pulled that renderer out into `PaintedUsernameHostedLayers` so the switch and the sheddable renderer are one component each.
- Skia rows staying mounted means animated paint textures would keep decoding on the UI thread through a fling, so `sharedPaintAnimationFrames` reads a shared-value mirror of the scroll signal and skips the decode. Same saving, no re-render.

Note the `native` renderer is still the remote-config default, so names there flatten to a solid colour mid-fling, just a paint-derived one rather than the twitch one. Full paint through a scroll needs the `skia` renderer.

# Test Plan

- `PaintedUsername.test.tsx`: masked fill at rest, paint colour held while flinging, twitch fallback for a texture-only paint.
- `getPaintSolidColor.test.ts`: solid colour wins, mid-most stop otherwise, topmost layer with transparent stops skipped, null for a bare texture.
- `bun x jest src/components/Chat src/store` - 853 pass. `tsc --noEmit` and eslint clean.
- On device, hold and drag chat in a channel with paint wearers: names keep their paint colour throughout instead of flashing to twitch colours.