### PR TITLE
fix(chat): stop dead badges and transparent paints leaving blank slots

### DIFF
--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsername.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsername.tsx
@@ -8,6 +8,7 @@ import { chatStore$ } from '@app/store/chat/observables/chatStore';
 import { usePaintRenderer } from '@app/store/preferenceStore';
 import { theme } from '@app/styles/themes';
 import type { PaintData } from '@app/types/seventv/cosmetics';
+import { isVisibleSevenTvColor } from '@app/utils/color/isVisibleSevenTvColor';
 import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
 
 import { chatLineMetrics } from '../chatScale';
@@ -124,8 +125,9 @@ function PaintedUsernameComponent({
     );
   }
 
-  const solidFallback =
-    paint.color === null ? fallbackColor : sevenTvColorToCss(paint.color);
+  const solidFallback = isVisibleSevenTvColor(paint.color)
+    ? sevenTvColorToCss(paint.color)
+    : fallbackColor;
 
   const flatUsernameStyle = StyleSheet.flatten(usernameTextStyle);
   const isModerated = flatUsernameStyle?.textDecorationLine === 'line-through';

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameFill.tsx
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/PaintedUsernameFill.tsx
@@ -2,6 +2,7 @@ import { type StyleProp, StyleSheet, TextStyle, View } from 'react-native';
 
 import { Text } from '@app/components/ui/Text/Text';
 import type { PaintData } from '@app/types/seventv/cosmetics';
+import { isVisibleSevenTvColor } from '@app/utils/color/isVisibleSevenTvColor';
 import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
 
 import { PaintLayerBackground } from './PaintLayerBackground';
@@ -28,8 +29,9 @@ export function PaintedUsernameFill({
 }: PaintedUsernameFillProps) {
   const layers = getPaintLayers(paint).filter(isRenderablePaintLayer);
   const keyedLayers = withPaintLayerKeys([...layers].reverse());
-  const baseColor =
-    paint.color === null ? fallbackColor : sevenTvColorToCss(paint.color);
+  const baseColor = isVisibleSevenTvColor(paint.color)
+    ? sevenTvColorToCss(paint.color)
+    : fallbackColor;
 
   /**
    * Each layer span carries its own base-colour backing, so the plain base

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintCss/buildPaintCssDeclarations.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintCss/buildPaintCssDeclarations.ts
@@ -6,6 +6,7 @@ import type {
   PaintLayerData,
   PaintStop,
 } from '@app/types/seventv/cosmetics';
+import { isVisibleSevenTvColor } from '@app/utils/color/isVisibleSevenTvColor';
 import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
 import { sevenTvColorToRgba } from '@app/utils/color/sevenTvColorToRgba';
 
@@ -96,7 +97,9 @@ export function buildPaintCssDeclarations(
     : [];
 
   return {
-    color: paint.color === null ? 'inherit' : sevenTvColorToCss(paint.color),
+    color: isVisibleSevenTvColor(paint.color)
+      ? sevenTvColorToCss(paint.color)
+      : 'inherit',
     backgroundImage: layers.map(layer => layer.image).join(', ') || 'none',
     backgroundPosition:
       layers.map(layer => layer.position).join(', ') || '0% 0%',

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/__tests__/getPaintSolidColor.test.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/__tests__/getPaintSolidColor.test.ts
@@ -106,4 +106,26 @@ describe('getPaintSolidColor', () => {
 
     expect(getPaintSolidColor(paint)).toBeNull();
   });
+
+  test('skips a fully transparent paint colour and uses the mid-most opaque stop', () => {
+    const paint = createPaint({
+      color: 0x9c28a900,
+      layers: {
+        0: createLayer({
+          stops: {
+            0: { at: 0, color: 0xff0000ff },
+            1: { at: 0.5, color: 0x00ff00ff },
+            length: 2,
+          },
+        }),
+        length: 1,
+      },
+    });
+
+    expect(getPaintSolidColor(paint)).toBe('rgba(0, 255, 0, 1.000)');
+  });
+
+  test('gives no colour for a transparent paint colour with no stops behind it', () => {
+    expect(getPaintSolidColor(createPaint({ color: 0x9c28a900 }))).toBeNull();
+  });
 });

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/getPaintSolidColor.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/paintLayer/getPaintSolidColor.ts
@@ -1,7 +1,7 @@
 import { indexedCollectionToArray } from '@app/services/ws/util/indexedCollection';
 import type { PaintData, PaintStop } from '@app/types/seventv/cosmetics';
+import { isVisibleSevenTvColor } from '@app/utils/color/isVisibleSevenTvColor';
 import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
-import { sevenTvColorToRgba } from '@app/utils/color/sevenTvColorToRgba';
 
 import { getPaintLayers } from './getPaintLayers';
 import { isRenderablePaintLayer } from './isRenderablePaintLayer';
@@ -27,7 +27,7 @@ export function getPaintSolidColor(paint: PaintData): string | null {
 }
 
 function computePaintSolidColor(paint: PaintData): string | null {
-  if (paint.color !== null) {
+  if (isVisibleSevenTvColor(paint.color)) {
     return sevenTvColorToCss(paint.color);
   }
 
@@ -47,7 +47,7 @@ function computePaintSolidColor(paint: PaintData): string | null {
 
 function midStop(stops: PaintStop[]): PaintStop | null {
   return stops.reduce<PaintStop | null>((best, stop) => {
-    if (sevenTvColorToRgba(stop.color).a === 0) {
+    if (!isVisibleSevenTvColor(stop.color)) {
       return best;
     }
     if (!best || Math.abs(stop.at - 0.5) < Math.abs(best.at - 0.5)) {

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/skiaPaintedUsernameRasterizer.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/skiaPaintedUsernameRasterizer.ts
@@ -714,8 +714,11 @@ function paintRevision(paint: PaintData): number {
 }
 
 function paintBitmapCacheKey(opts: RasterizePaintedUsernameOptions): string {
-  const fallbackPart =
-    opts.paint.color === null ? `|${opts.fallbackColor}` : '';
+  // Must match drawPaintedUsername: whenever the render falls back, the
+  // fallback colour is part of what got rasterised.
+  const fallbackPart = isVisibleSevenTvColor(opts.paint.color)
+    ? ''
+    : `|${opts.fallbackColor}`;
   return `${opts.paint.id}|${paintRevision(opts.paint)}|${opts.displayUsername}|${opts.fontSize}|${opts.pixelRatio}${fallbackPart}`;
 }
 

--- a/src/components/Chat/components/ChatMessage/CosmeticUsername/util/skiaPaintedUsernameRasterizer.ts
+++ b/src/components/Chat/components/ChatMessage/CosmeticUsername/util/skiaPaintedUsernameRasterizer.ts
@@ -24,6 +24,7 @@ import type {
   PaintStop,
   PaintTextStroke,
 } from '@app/types/seventv/cosmetics';
+import { isVisibleSevenTvColor } from '@app/utils/color/isVisibleSevenTvColor';
 import { sevenTvColorToCss } from '@app/utils/color/sevenTvColorToCss';
 import {
   cachePaintBitmaps,
@@ -379,7 +380,9 @@ function drawPaintedUsername(
 
   const basePaint = Skia.Paint();
   basePaint.setColor(
-    paint.color === null ? Skia.Color(fallbackColor) : skColor(paint.color),
+    isVisibleSevenTvColor(paint.color)
+      ? skColor(paint.color)
+      : Skia.Color(fallbackColor),
   );
 
   const gradientsToDraw = (

--- a/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
@@ -68,6 +68,14 @@ interface ChatInlineImageProps {
   priority?: 'low' | 'normal' | 'high';
   resizeMode?: 'contain' | 'cover' | 'stretch';
   /**
+   * When `true`, a dead url renders nothing rather than an empty box of
+   * `style`'s size. Use for assets laid out inline beside text (badges), where
+   * a slot that draws nothing reads as a hole in the row.
+   *
+   * @default false
+   */
+  collapseWhenFailed?: boolean;
+  /**
    * When `false`, no shimmer is rendered while the image is loading — the slot
    * just stays empty until the image resolves or is given up on. Use for tiny
    * assets (badges) where a pulsing box is more distracting than helpful.
@@ -82,6 +90,7 @@ interface ChatInlineImageProps {
 }
 
 function ChatInlineImageComponent({
+  collapseWhenFailed = false,
   containerStyle,
   maxRetryAttempts = MAX_RELOAD_ATTEMPTS,
   priority = 'high',
@@ -297,6 +306,10 @@ function ChatInlineImageComponent({
       unsubscribeScroll();
     };
   }, [rowVisibility, animated]);
+
+  if (collapseWhenFailed && status === 'failed') {
+    return null;
+  }
 
   // Show the shimmer only while there's nothing real to display yet. Keyed off
   // showRef so a ref we hold but can't draw (it failed, or the cache released it

--- a/src/components/Chat/components/ChatMessage/renderers/ChatMessageBadges.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatMessageBadges.tsx
@@ -55,6 +55,7 @@ export function ChatMessageBadges({
             badgeStyle,
             Boolean(moderationNotice) && styles.moderatedBadge,
           ]}
+          collapseWhenFailed
           maxRetryAttempts={0}
           showLoadingShimmer={false}
         />

--- a/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
@@ -17,10 +17,12 @@ let mockImageProps: {
   onLoad?: () => void;
   recyclingKey?: string;
   source?: unknown;
+  testID?: string;
 } | null = null;
 
 jest.mock('expo-image', () => {
   const ReactModule = require('react');
+  const { View } = require('react-native');
   return {
     Image: ReactModule.forwardRef(
       (
@@ -29,6 +31,7 @@ jest.mock('expo-image', () => {
           onLoad?: () => void;
           recyclingKey?: string;
           source?: unknown;
+          testID?: string;
         },
         ref: unknown,
       ) => {
@@ -37,7 +40,7 @@ jest.mock('expo-image', () => {
           startAnimating: mockStartAnimating,
           stopAnimating: mockStopAnimating,
         }));
-        return null;
+        return ReactModule.createElement(View, { testID: props.testID });
       },
     ),
   };
@@ -418,6 +421,66 @@ describe('ChatInlineImage maxRetryAttempts', () => {
     // The warning fires immediately because retries are disabled.
     expect(warnMock).toHaveBeenCalledTimes(1);
     expect(warnMock.mock.calls[0]?.[0]).toEqual('chat.emote.load_failed');
+  });
+});
+
+describe('ChatInlineImage collapseWhenFailed', () => {
+  beforeEach(() => {
+    mockSharedRef = null;
+    mockImageProps = null;
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders nothing once a dead url is given up on, so the slot reserves no width', () => {
+    render(
+      <ChatInlineImage
+        collapseWhenFailed
+        maxRetryAttempts={0}
+        showLoadingShimmer={false}
+        sourceUrl='https://static-cdn.jtvnw.net/badges/v1/dead/1'
+        style={{ height: 18, marginRight: 4, width: 18 }}
+        testID='chat-badge'
+      />,
+    );
+
+    expect(screen.getByTestId('chat-badge')).toBeOnTheScreen();
+
+    act(() => mockImageProps?.onError?.());
+
+    expect(screen.queryByTestId('chat-badge')).not.toBeOnTheScreen();
+  });
+
+  test('keeps the box while the url is still loading', () => {
+    render(
+      <ChatInlineImage
+        collapseWhenFailed
+        maxRetryAttempts={0}
+        showLoadingShimmer={false}
+        sourceUrl='https://static-cdn.jtvnw.net/badges/v1/slow/1'
+        style={{ height: 18, width: 18 }}
+        testID='chat-badge'
+      />,
+    );
+
+    expect(screen.getByTestId('chat-badge')).toBeOnTheScreen();
+  });
+
+  test('keeps the sized box when the flag is absent', () => {
+    render(
+      <ChatInlineImage
+        maxRetryAttempts={0}
+        showLoadingShimmer={false}
+        sourceUrl='https://static-cdn.jtvnw.net/badges/v1/dead/1'
+        style={{ height: 18, width: 18 }}
+        testID='chat-badge'
+      />,
+    );
+
+    act(() => mockImageProps?.onError?.());
+
+    expect(screen.getByTestId('chat-badge')).toBeOnTheScreen();
   });
 });
 

--- a/src/components/Chat/util/chatRowItemType.ts
+++ b/src/components/Chat/util/chatRowItemType.ts
@@ -1,5 +1,4 @@
 import { getChatBodyInfo } from '@app/components/Chat/util/richChatMessage/getChatBodyInfo';
-import { hasUserPaint } from '@app/store/chat/actions/cosmetics';
 import type { AnyChatMessageType } from '@app/store/chat/types/constants';
 import type { ChatBodyVariant } from '@app/utils/chat/deriveChatBody/types';
 import { isRenderableChatMessage } from '@app/utils/chat/messageIdentity/isRenderableChatMessage';
@@ -71,14 +70,14 @@ function getUserChatRowItemType(
     flags.push('shared');
   }
 
-  const userId = item.userstate?.['user-id'];
-  if (hasUserPaint(userId)) {
-    flags.push('paint');
-  }
-
   return flags.length > 0 ? `user_chat-${flags.join('-')}` : 'user_chat';
 }
 
+/**
+ * The row's recycling identity, which the list treats as fixed once the row is
+ * placed. Every flag must come from the message itself, never from
+ * asynchronously resolved state such as a 7TV paint.
+ */
 export function getChatRowItemType(
   item: AnyChatMessageType,
   options?: ChatRowItemTypeOptions,

--- a/src/store/chat/actions/cosmetics.ts
+++ b/src/store/chat/actions/cosmetics.ts
@@ -455,10 +455,9 @@ export const getUserPaintId = (ttvUserId: string): string | undefined =>
 let userPaintFlagInvalidatorAttached = false;
 
 /**
- * getChatRowItemType calls `hasUserPaint` once per visible row on every list
- * data change, so the paints/userPaintIds traversal below is cached per user
- * id: a binding change invalidates just that user, a paint definition change
- * clears the cache wholesale.
+ * A binding change invalidates just that user, a paint definition change clears
+ * the cache wholesale. `useEnsureSevenTvCosmetics` is the only reader, once per
+ * user card, so the cache is far larger than that path needs.
  */
 function ensureUserPaintFlagInvalidator(): void {
   if (userPaintFlagInvalidatorAttached) {

--- a/src/utils/color/__tests__/isVisibleSevenTvColor.test.ts
+++ b/src/utils/color/__tests__/isVisibleSevenTvColor.test.ts
@@ -1,0 +1,20 @@
+import { isVisibleSevenTvColor } from '../isVisibleSevenTvColor';
+
+describe('isVisibleSevenTvColor', () => {
+  test('accepts an opaque colour', () => {
+    expect(isVisibleSevenTvColor(0x9c28a9ff)).toBe(true);
+  });
+
+  test('accepts a partially transparent colour', () => {
+    expect(isVisibleSevenTvColor(0x9c28a901)).toBe(true);
+  });
+
+  test('rejects a fully transparent colour, which would draw nothing', () => {
+    expect(isVisibleSevenTvColor(0x9c28a900)).toBe(false);
+  });
+
+  test('rejects an absent colour', () => {
+    expect(isVisibleSevenTvColor(null)).toBe(false);
+    expect(isVisibleSevenTvColor(undefined)).toBe(false);
+  });
+});

--- a/src/utils/color/isVisibleSevenTvColor.ts
+++ b/src/utils/color/isVisibleSevenTvColor.ts
@@ -1,0 +1,14 @@
+import { SevenTvColor } from '@app/types/seventv/cosmetics';
+
+import { sevenTvColorToRgba } from './sevenTvColorToRgba';
+
+/**
+ * A fully transparent 7TV colour is a real value rather than an absent one, so
+ * a caller that treats only `null` as "no colour" paints `rgba(r, g, b, 0)` and
+ * draws nothing.
+ */
+export function isVisibleSevenTvColor(
+  color: SevenTvColor | null | undefined,
+): color is SevenTvColor {
+  return color != null && sevenTvColorToRgba(color).a > 0;
+}


### PR DESCRIPTION
# Why

Two of the blank spots in chat turned out to be separate bugs:

- A badge whose url is dead still rendered a sized `ExpoImage`. It reserved `badgeSize + badgeGap` and drew nothing, so the row got a hole where the badge should be.
- A 7TV paint colour with alpha 0 is a real value, not an absent one. Four sites only checked `paint.color === null`, so those paints painted usernames in `rgba(r, g, b, 0)`.

This does **not** fix the black bars between messages. That one is upstream, see below.

# How

`ChatInlineImage` gets `collapseWhenFailed`, which `ChatMessageBadges` passes. Badges already use `maxRetryAttempts={0}` with a single-url fallback chain, so the first `onError` lands on `status: 'failed'` and the slot now renders nothing.

New `isVisibleSevenTvColor` guards alpha as well as null. All four colour sites go through it, including the two that actually paint the base fill (`PaintedUsernameFill` and the Skia rasterizer) - my first pass only fixed the shed text and left the default renderer still drawing blank.

Also dropped the paint flag from `getChatRowItemType`. Paints resolve asynchronously, so it made a row change recycling identity after the list had already placed it, which is not valid for a function the list treats as pure.

# Test Plan

`bun run test` (331 suites, 9971 tests), `bun run ts:check`, `bun run lint` all pass. New tests cover the collapsed badge slot, the transparent-paint fallback, and `isVisibleSevenTvColor`.

Verified on the iOS simulator in a busy channel (`deme`) by force-colouring every row and diffing frames against the accessibility tree.

## Still open: black bars between messages

Not fixed here. LegendList reserves layout space for items it never asks us to render:

```
[probe] window 592..599 rendered=6 dataLen=600 NEVER_RENDERED=[594,595]
```

Those indices sit mid-window with rendered neighbours either side. Ruled out: the skeleton fallback, container-pool starvation, `estimatedItemSize`, `dataKey`, LegendList 3.0.4 vs 3.3.3, and `recycleItems`. Rate is ~9% of frames. Needs an upstream issue.

## Follow-up

`userPaintFlags` in `store/chat/actions/cosmetics.ts` was sized for the per-row caller this PR removes. Its only reader now is `useEnsureSevenTvCosmetics`, once per user card, so the cache and its invalidator can probably go.