### PR TITLE
fix(chat): make badge render keys collision-proof

### DIFF
--- a/src/components/Chat/components/ChatMessage/renderers/ChatMessageBadges.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatMessageBadges.tsx
@@ -39,7 +39,7 @@ export function ChatMessageBadges({
 
     renderedBadges.push(
       <ChatMessagePressable
-        key={`${normalizedBadge.set}-${normalizedBadge.id}-${normalizedBadge.type}-${normalizedBadge.url}`}
+        key={`${renderedBadges.length}\u001f${normalizedBadge.set}\u001f${normalizedBadge.id}\u001f${normalizedBadge.type}\u001f${normalizedBadge.url}`}
         onPress={onBadgePress ? () => onBadgePress(normalizedBadge) : undefined}
       >
         <ChatInlineImage


### PR DESCRIPTION
# Why

Review finding on #849: the badge render key joined `set-id-type-url` with hyphens. Verified against main and it's real on two counts. An identical badge appearing twice in one row's list produces duplicate React keys (dedup upstream isn't guaranteed across providers on the shared-chat path), and hyphenated field values can alias two different badges into one key.

# How

One line: key on the rendered position plus the same normalized fields, separated with `u001f` (the separator chat keys already use) instead of hyphen-joined. Badge lists are per-message and immutable after commit, so the position is stable across re-renders.

# Test Plan

- `bun x jest src/components/Chat/components/ChatMessage` - 204 pass.
- `tsc --noEmit` and eslint clean.
