### PR TITLE
feat(chat): dev-gated debug details in user, emote and badge sheets

### DIFF
--- a/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
+++ b/src/components/Chat/__tests__/Chat.recentMessages.test.tsx
@@ -397,6 +397,7 @@ const setPreferences = (showRecentMessages = true) => {
     analyticsEnabled: true,
     sharedChatEnabled: true,
     enhancedVideoStability: false,
+    chatDebugTools: false,
     sevenTvPaintRenderer: 'native',
     chatDelay: 'off',
     update: jest.fn(),

--- a/src/components/Chat/components/BadgePreviewSheet/BadgePreviewSheet.tsx
+++ b/src/components/Chat/components/BadgePreviewSheet/BadgePreviewSheet.tsx
@@ -16,11 +16,16 @@ import {
 } from '@app/components/BottomSheet/BottomSheet';
 /* eslint-disable react-native/sort-styles */
 import { Button } from '@app/components/Button/Button';
+import { ChatDebugSection } from '@app/components/Chat/components/ChatDebugSection';
 import { computeSheetHeight } from '@app/components/Chat/util/computeSheetHeight';
 import { Image } from '@app/components/Image/Image';
 import { SymbolView, type SymbolViewProps } from '@app/components/ui/Icon/Icon';
 import { Text } from '@app/components/ui/Text/Text';
 import { useSaveImageToGallery } from '@app/hooks/useSaveImageToGallery';
+import {
+  getChatDebugBadgeDetails,
+  getChatDebugBadgeSources,
+} from '@app/store/chat/actions/chatDebugLog';
 import { theme } from '@app/styles/themes';
 import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
 import { openLinkInBrowser } from '@app/utils/browser/openLinkInBrowser';
@@ -224,6 +229,16 @@ function BadgePreviewSheetComponent(props: Props) {
               </Button>
             ))}
           </View>
+
+          <ChatDebugSection
+            build={() => ({
+              payload: {
+                badge: selectedBadge,
+                badgeDetails: getChatDebugBadgeDetails(selectedBadge),
+                badgeSources: getChatDebugBadgeSources(),
+              },
+            })}
+          />
         </ScrollView>
       </View>
     </BottomSheet>

--- a/src/components/Chat/components/ChatDebugLogRecorder.tsx
+++ b/src/components/Chat/components/ChatDebugLogRecorder.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+import {
+  acquireChatDebugLog,
+  clearChatDebugLog,
+  releaseChatDebugLog,
+} from '@app/store/chat/actions/chatDebugLog';
+import { useDevToolsAccess } from '@app/utils/devTools/devToolsGate';
+
+export function ChatDebugLogRecorder({ channelId }: { channelId: string }) {
+  const enabled = useDevToolsAccess() === 'enabled';
+
+  useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+    acquireChatDebugLog();
+    return () => releaseChatDebugLog();
+  }, [enabled]);
+
+  useEffect(() => {
+    clearChatDebugLog();
+  }, [channelId]);
+
+  return null;
+}

--- a/src/components/Chat/components/ChatDebugLogRecorder.tsx
+++ b/src/components/Chat/components/ChatDebugLogRecorder.tsx
@@ -2,16 +2,20 @@ import { useEffect } from 'react';
 
 import {
   acquireChatDebugLog,
-  clearChatDebugLog,
   releaseChatDebugLog,
 } from '@app/store/chat/actions/chatDebugLog';
 
-export function ChatDebugLogRecorder({ channelId }: { channelId: string }) {
+export function ChatDebugLogRecorder({
+  channelId,
+  channelName,
+}: {
+  channelId: string;
+  channelName: string;
+}) {
   useEffect(() => {
-    acquireChatDebugLog();
-    clearChatDebugLog();
-    return () => releaseChatDebugLog();
-  }, [channelId]);
+    acquireChatDebugLog(channelId, channelName);
+    return () => releaseChatDebugLog(channelId, channelName);
+  }, [channelId, channelName]);
 
   return null;
 }

--- a/src/components/Chat/components/ChatDebugLogRecorder.tsx
+++ b/src/components/Chat/components/ChatDebugLogRecorder.tsx
@@ -9,11 +9,8 @@ import {
 export function ChatDebugLogRecorder({ channelId }: { channelId: string }) {
   useEffect(() => {
     acquireChatDebugLog();
-    return () => releaseChatDebugLog();
-  }, []);
-
-  useEffect(() => {
     clearChatDebugLog();
+    return () => releaseChatDebugLog();
   }, [channelId]);
 
   return null;

--- a/src/components/Chat/components/ChatDebugLogRecorder.tsx
+++ b/src/components/Chat/components/ChatDebugLogRecorder.tsx
@@ -5,18 +5,12 @@ import {
   clearChatDebugLog,
   releaseChatDebugLog,
 } from '@app/store/chat/actions/chatDebugLog';
-import { useDevToolsAccess } from '@app/utils/devTools/devToolsGate';
 
 export function ChatDebugLogRecorder({ channelId }: { channelId: string }) {
-  const enabled = useDevToolsAccess() === 'enabled';
-
   useEffect(() => {
-    if (!enabled) {
-      return undefined;
-    }
     acquireChatDebugLog();
     return () => releaseChatDebugLog();
-  }, [enabled]);
+  }, []);
 
   useEffect(() => {
     clearChatDebugLog();

--- a/src/components/Chat/components/ChatDebugSection.tsx
+++ b/src/components/Chat/components/ChatDebugSection.tsx
@@ -37,9 +37,9 @@ export function ChatDebugSection({ build }: ChatDebugSectionProps) {
     const clipboardPayload = data.ircLines
       ? `${payloadJson}\n\n${data.ircLines.map(entry => entry.line).join('\n')}`
       : payloadJson;
-    void Clipboard.setStringAsync(clipboardPayload).then(() =>
-      toast.success(t('debug.copied')),
-    );
+    Clipboard.setStringAsync(clipboardPayload)
+      .then(() => toast.success(t('debug.copied')))
+      .catch(() => toast.error(t('debug.copyFailed')));
   };
 
   return (
@@ -73,9 +73,9 @@ export function ChatDebugSection({ build }: ChatDebugSectionProps) {
           {data.ircLines.length === 0 ? (
             <Text style={styles.empty}>{t('debug.ircLinesEmpty')}</Text>
           ) : (
-            data.ircLines.map(entry => (
+            data.ircLines.map((entry, index) => (
               <Text
-                key={`${entry.receivedAt}_${entry.line}`}
+                key={`${entry.receivedAt}_${index}`}
                 selectable
                 style={styles.mono}
                 variant='mono'

--- a/src/components/Chat/components/ChatDebugSection.tsx
+++ b/src/components/Chat/components/ChatDebugSection.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
@@ -25,8 +24,7 @@ interface ChatDebugSectionProps {
 export function ChatDebugSection({ build }: ChatDebugSectionProps) {
   const { t } = useTranslation('chat');
   const chatDebugTools = usePreference('chatDebugTools');
-  const enabled = isDevToolsEnabled && chatDebugTools;
-  const data = useMemo(() => (enabled ? build() : null), [enabled, build]);
+  const data = isDevToolsEnabled && chatDebugTools ? build() : null;
 
   if (!data) {
     return null;

--- a/src/components/Chat/components/ChatDebugSection.tsx
+++ b/src/components/Chat/components/ChatDebugSection.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, View } from 'react-native';
+import { type StyleProp, StyleSheet, View, type ViewStyle } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
 import * as Clipboard from 'expo-clipboard';
@@ -19,9 +19,10 @@ export interface ChatDebugSectionData {
 
 interface ChatDebugSectionProps {
   build: () => ChatDebugSectionData;
+  style?: StyleProp<ViewStyle>;
 }
 
-export function ChatDebugSection({ build }: ChatDebugSectionProps) {
+export function ChatDebugSection({ build, style }: ChatDebugSectionProps) {
   const { t } = useTranslation('chat');
   const chatDebugTools = usePreference('chatDebugTools');
   const data = isDevToolsEnabled && chatDebugTools ? build() : null;
@@ -41,7 +42,7 @@ export function ChatDebugSection({ build }: ChatDebugSectionProps) {
   };
 
   return (
-    <View style={styles.card} testID='chat-debug-section'>
+    <View style={[styles.card, style]} testID='chat-debug-section'>
       <View style={styles.headerRow}>
         <Text style={styles.title} weight='semibold'>
           {t('debug.title')}

--- a/src/components/Chat/components/ChatDebugSection.tsx
+++ b/src/components/Chat/components/ChatDebugSection.tsx
@@ -1,0 +1,145 @@
+import { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import * as Clipboard from 'expo-clipboard';
+import { toast } from 'sonner-native';
+
+import { Button } from '@app/components/Button/Button';
+import { SymbolView } from '@app/components/ui/Icon/Icon';
+import { Text } from '@app/components/ui/Text/Text';
+import type { ChatDebugIrcLine } from '@app/store/chat/actions/chatDebugLog';
+import { usePreference } from '@app/store/preferenceStore';
+import { theme } from '@app/styles/themes';
+import { useDevToolsAccess } from '@app/utils/devTools/devToolsGate';
+
+export interface ChatDebugSectionData {
+  payload: Record<string, unknown>;
+  ircLines?: ChatDebugIrcLine[];
+}
+
+interface ChatDebugSectionProps {
+  build: () => ChatDebugSectionData;
+}
+
+export function ChatDebugSection({ build }: ChatDebugSectionProps) {
+  const chatDebugTools = usePreference('chatDebugTools');
+  if (!chatDebugTools) {
+    return null;
+  }
+  return <GatedChatDebugSection build={build} />;
+}
+
+function GatedChatDebugSection({ build }: ChatDebugSectionProps) {
+  const { t } = useTranslation('chat');
+  const enabled = useDevToolsAccess() === 'enabled';
+  const data = useMemo(() => (enabled ? build() : null), [enabled, build]);
+
+  if (!data) {
+    return null;
+  }
+
+  const payloadJson = JSON.stringify(data.payload, null, 2);
+  const handleCopy = () => {
+    const clipboardPayload = data.ircLines
+      ? `${payloadJson}\n\n${data.ircLines.map(entry => entry.line).join('\n')}`
+      : payloadJson;
+    void Clipboard.setStringAsync(clipboardPayload).then(() =>
+      toast.success(t('debug.copied')),
+    );
+  };
+
+  return (
+    <View style={styles.card} testID='chat-debug-section'>
+      <View style={styles.headerRow}>
+        <Text style={styles.title} weight='semibold'>
+          {t('debug.title')}
+        </Text>
+        <Button
+          label={t('debug.copy')}
+          style={styles.copyButton}
+          onPress={handleCopy}
+        >
+          <SymbolView
+            name='doc.on.doc'
+            size={13}
+            tintColor={theme.color.textSecondary.dark}
+          />
+        </Button>
+      </View>
+
+      <Text selectable style={styles.mono} variant='mono'>
+        {payloadJson}
+      </Text>
+
+      {data.ircLines ? (
+        <>
+          <Text style={styles.subheading} weight='semibold'>
+            {t('debug.ircLines')}
+          </Text>
+          {data.ircLines.length === 0 ? (
+            <Text style={styles.empty}>{t('debug.ircLinesEmpty')}</Text>
+          ) : (
+            data.ircLines.map(entry => (
+              <Text
+                key={`${entry.receivedAt}_${entry.line}`}
+                selectable
+                style={styles.mono}
+                variant='mono'
+              >
+                {entry.dropped ? `[${t('debug.dropped')}] ` : ''}
+                {entry.line}
+              </Text>
+            ))
+          )}
+        </>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: 'rgba(255,255,255,0.06)',
+    borderCurve: 'continuous',
+    borderRadius: theme.borderRadius16,
+    gap: theme.space8,
+    padding: theme.space12,
+  },
+  copyButton: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(255,255,255,0.09)',
+    borderCurve: 'continuous',
+    borderRadius: theme.borderRadius999,
+    height: 26,
+    justifyContent: 'center',
+    width: 26,
+  },
+  empty: {
+    color: theme.color.textSecondary.dark,
+    fontSize: theme.fontSize12,
+  },
+  headerRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  mono: {
+    color: theme.color.textSecondary.dark,
+    fontSize: theme.fontSize11,
+    lineHeight: theme.fontSize11 * 1.45,
+  },
+  subheading: {
+    color: theme.color.textSecondary.dark,
+    fontSize: theme.fontSize11,
+    letterSpacing: 0.2,
+    marginTop: theme.space4,
+    textTransform: 'uppercase',
+  },
+  title: {
+    color: theme.color.textSecondary.dark,
+    fontSize: theme.fontSize11,
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+  },
+});

--- a/src/components/Chat/components/ChatDebugSection.tsx
+++ b/src/components/Chat/components/ChatDebugSection.tsx
@@ -11,7 +11,7 @@ import { Text } from '@app/components/ui/Text/Text';
 import type { ChatDebugIrcLine } from '@app/store/chat/actions/chatDebugLog';
 import { usePreference } from '@app/store/preferenceStore';
 import { theme } from '@app/styles/themes';
-import { useDevToolsAccess } from '@app/utils/devTools/devToolsGate';
+import { isDevToolsEnabled } from '@app/utils/devTools/isDevToolsEnabled';
 
 export interface ChatDebugSectionData {
   payload: Record<string, unknown>;
@@ -23,16 +23,9 @@ interface ChatDebugSectionProps {
 }
 
 export function ChatDebugSection({ build }: ChatDebugSectionProps) {
-  const chatDebugTools = usePreference('chatDebugTools');
-  if (!chatDebugTools) {
-    return null;
-  }
-  return <GatedChatDebugSection build={build} />;
-}
-
-function GatedChatDebugSection({ build }: ChatDebugSectionProps) {
   const { t } = useTranslation('chat');
-  const enabled = useDevToolsAccess() === 'enabled';
+  const chatDebugTools = usePreference('chatDebugTools');
+  const enabled = isDevToolsEnabled && chatDebugTools;
   const data = useMemo(() => (enabled ? build() : null), [enabled, build]);
 
   if (!data) {

--- a/src/components/Chat/components/ChatOverlayLayer.tsx
+++ b/src/components/Chat/components/ChatOverlayLayer.tsx
@@ -26,6 +26,7 @@ import { UserActionSheet } from './UserActionSheet';
 export interface ChatOverlayLayerProps {
   canModerateChat: boolean;
   channelId: string;
+  channelName: string;
   currentUserId?: string;
   hiddenUsers: string[];
   highlightedUsers: string[];
@@ -56,6 +57,7 @@ export interface ChatOverlayLayerProps {
 export const ChatOverlayLayer = memo(function ChatOverlayLayer({
   canModerateChat,
   channelId,
+  channelName,
   currentUserId,
   hiddenUsers,
   highlightedUsers,
@@ -146,7 +148,7 @@ export const ChatOverlayLayer = memo(function ChatOverlayLayer({
   return (
     <>
       {isDevToolsEnabled && chatDebugTools ? (
-        <ChatDebugLogRecorder channelId={channelId} />
+        <ChatDebugLogRecorder channelId={channelId} channelName={channelName} />
       ) : null}
 
       {isEmoteSheetMounted ? (

--- a/src/components/Chat/components/ChatOverlayLayer.tsx
+++ b/src/components/Chat/components/ChatOverlayLayer.tsx
@@ -9,6 +9,7 @@ import { useChatOverlayState } from '@app/store/chat/react/overlaySelectors';
 import type { ChatMessageType } from '@app/store/chat/types/constants';
 import { usePreference } from '@app/store/preferenceStore';
 import { normaliseChatUsername } from '@app/utils/chat/chatUsernames/normaliseChatUsername';
+import { isDevToolsEnabled } from '@app/utils/devTools/isDevToolsEnabled';
 
 import { ActionSheet } from './ActionSheet/ActionSheet';
 import { BadgePreviewSheet } from './BadgePreviewSheet/BadgePreviewSheet';
@@ -144,7 +145,9 @@ export const ChatOverlayLayer = memo(function ChatOverlayLayer({
 
   return (
     <>
-      {chatDebugTools ? <ChatDebugLogRecorder channelId={channelId} /> : null}
+      {isDevToolsEnabled && chatDebugTools ? (
+        <ChatDebugLogRecorder channelId={channelId} />
+      ) : null}
 
       {isEmoteSheetMounted ? (
         <EmoteSheet

--- a/src/components/Chat/components/ChatOverlayLayer.tsx
+++ b/src/components/Chat/components/ChatOverlayLayer.tsx
@@ -7,10 +7,12 @@ import {
 import { openChatUserActions } from '@app/store/chat/actions/chatOverlays';
 import { useChatOverlayState } from '@app/store/chat/react/overlaySelectors';
 import type { ChatMessageType } from '@app/store/chat/types/constants';
+import { usePreference } from '@app/store/preferenceStore';
 import { normaliseChatUsername } from '@app/utils/chat/chatUsernames/normaliseChatUsername';
 
 import { ActionSheet } from './ActionSheet/ActionSheet';
 import { BadgePreviewSheet } from './BadgePreviewSheet/BadgePreviewSheet';
+import { ChatDebugLogRecorder } from './ChatDebugLogRecorder';
 import type { MessageActionData } from './ChatMessage/RichChatMessage.types';
 import { ChattersSheet } from './ChattersSheet/ChattersSheet';
 import { EmotePreviewSheet } from './EmotePreviewSheet/EmotePreviewSheet';
@@ -85,6 +87,8 @@ export const ChatOverlayLayer = memo(function ChatOverlayLayer({
     selectedUser,
   } = useChatOverlayState(channelId);
 
+  const chatDebugTools = usePreference('chatDebugTools');
+
   const {
     handleActionSheetBanUser,
     handleActionSheetCopy,
@@ -140,6 +144,8 @@ export const ChatOverlayLayer = memo(function ChatOverlayLayer({
 
   return (
     <>
+      {chatDebugTools ? <ChatDebugLogRecorder channelId={channelId} /> : null}
+
       {isEmoteSheetMounted ? (
         <EmoteSheet
           isPresented

--- a/src/components/Chat/components/EmotePreviewSheet/EmotePreviewSheet.tsx
+++ b/src/components/Chat/components/EmotePreviewSheet/EmotePreviewSheet.tsx
@@ -16,11 +16,16 @@ import {
 } from '@app/components/BottomSheet/BottomSheet';
 /* eslint-disable react-native/sort-styles */
 import { Button } from '@app/components/Button/Button';
+import { ChatDebugSection } from '@app/components/Chat/components/ChatDebugSection';
 import { computeSheetHeight } from '@app/components/Chat/util/computeSheetHeight';
 import { Image } from '@app/components/Image/Image';
 import { SymbolView, type SymbolViewProps } from '@app/components/ui/Icon/Icon';
 import { Text } from '@app/components/ui/Text/Text';
 import { useSaveImageToGallery } from '@app/hooks/useSaveImageToGallery';
+import {
+  getChatDebugEmoteDetails,
+  getChatDebugEmoteSources,
+} from '@app/store/chat/actions/chatDebugLog';
 import { usePreference } from '@app/store/preferenceStore';
 import { theme } from '@app/styles/themes';
 import { openLinkInBrowser } from '@app/utils/browser/openLinkInBrowser';
@@ -292,6 +297,16 @@ function EmotePreviewSheetComponent(props: Props) {
               </Button>
             ))}
           </View>
+
+          <ChatDebugSection
+            build={() => ({
+              payload: {
+                emote: selectedEmote,
+                emoteDetails: getChatDebugEmoteDetails(selectedEmote),
+                emoteSources: getChatDebugEmoteSources(),
+              },
+            })}
+          />
         </ScrollView>
       </View>
     </BottomSheet>

--- a/src/components/Chat/components/UserActionSheet.tsx
+++ b/src/components/Chat/components/UserActionSheet.tsx
@@ -13,12 +13,17 @@ import {
   type SnapPoint,
 } from '@app/components/BottomSheet/BottomSheet';
 import { Button } from '@app/components/Button/Button';
+import { ChatDebugSection } from '@app/components/Chat/components/ChatDebugSection';
 import type {
   ChatModerationAccessFlags,
   UserActionVisibilityFlags,
 } from '@app/components/Chat/types/chatUiFlags';
 import { SymbolView, type SymbolViewProps } from '@app/components/ui/Icon/Icon';
 import { Text } from '@app/components/ui/Text/Text';
+import {
+  getChatDebugIrcLinesForLogin,
+  getChatDebugUserSnapshot,
+} from '@app/store/chat/actions/chatDebugLog';
 import { chatStore$ } from '@app/store/chat/observables/chatStore';
 import { theme } from '@app/styles/themes';
 import { normaliseChatUsername } from '@app/utils/chat/chatUsernames/normaliseChatUsername';
@@ -365,6 +370,13 @@ function UserActionSheetComponent({
               </Button>
             ))}
           </View>
+
+          <ChatDebugSection
+            build={() => ({
+              payload: getChatDebugUserSnapshot(login, username, userId),
+              ircLines: getChatDebugIrcLinesForLogin(login || username),
+            })}
+          />
         </ScrollView>
       </View>
     </BottomSheet>

--- a/src/components/Chat/components/UserActionSheet.tsx
+++ b/src/components/Chat/components/UserActionSheet.tsx
@@ -376,6 +376,7 @@ function UserActionSheetComponent({
               payload: getChatDebugUserSnapshot(login, username, userId),
               ircLines: getChatDebugIrcLinesForLogin(login || username),
             })}
+            style={styles.debugSection}
           />
         </ScrollView>
       </View>
@@ -439,6 +440,9 @@ const styles = StyleSheet.create({
   },
   actionTextDanger: {
     color: theme.colorRed,
+  },
+  debugSection: {
+    marginTop: theme.space8,
   },
   doneButton: {
     alignItems: 'center',

--- a/src/components/Chat/components/__tests__/ChatOverlayLayer.moderation.test.tsx
+++ b/src/components/Chat/components/__tests__/ChatOverlayLayer.moderation.test.tsx
@@ -58,6 +58,7 @@ function renderOverlayLayer() {
     <ChatOverlayLayer
       canModerateChat
       channelId={CHANNEL_ID}
+      channelName='channel'
       currentUserId='mod-1'
       hiddenUsers={[]}
       highlightedUsers={[]}

--- a/src/components/Chat/hooks/useChatSurface.ts
+++ b/src/components/Chat/hooks/useChatSurface.ts
@@ -202,6 +202,7 @@ export function useChatSurface({
   const overlayProps: ChatOverlayLayerProps = {
     canModerateChat,
     channelId,
+    channelName,
     currentUserId: user?.id,
     hiddenUsers,
     highlightedUsers,

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -192,6 +192,14 @@ const en = {
       imageSaved: 'Badge saved to gallery',
       imageSaveFailed: 'Could not save badge',
     },
+    debug: {
+      title: 'Debug',
+      copy: 'Copy debug info',
+      copied: 'Debug info copied',
+      ircLines: 'Raw IRC lines',
+      ircLinesEmpty: 'No captured IRC lines for this user',
+      dropped: 'DROPPED',
+    },
     emoteSheet: {
       searchEmotes: 'Search emotes',
       noEmotesFound: 'No emotes found',
@@ -668,6 +676,9 @@ const en = {
     enhancedVideoStability: 'Enhanced Video Stability',
     enhancedVideoStabilityDescription:
       'Automatically refresh the player to recover from silent stalls, video errors, and high latency',
+    chatDebugTools: 'Chat Debug Tools',
+    chatDebugToolsDescription:
+      'Capture raw IRC lines and show debug details in the chat user, emote, and badge sheets',
     developerTools: 'Developer Tools',
     debug: 'Debug',
     debugDescription: 'Manual debug helpers and experiments',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -196,6 +196,7 @@ const en = {
       title: 'Debug',
       copy: 'Copy debug info',
       copied: 'Debug info copied',
+      copyFailed: 'Could not copy debug info',
       ircLines: 'Raw IRC lines',
       ircLinesEmpty: 'No captured IRC lines for this user',
       dropped: 'DROPPED',

--- a/src/screens/Preferences/__tests__/ChatPreferenceScreen.test.tsx
+++ b/src/screens/Preferences/__tests__/ChatPreferenceScreen.test.tsx
@@ -49,6 +49,7 @@ const mockPreferences: Preferences = {
   analyticsEnabled: true,
   sharedChatEnabled: true,
   enhancedVideoStability: false,
+  chatDebugTools: false,
   sevenTvPaintRenderer: 'native',
 };
 

--- a/src/screens/SettingsScreen/SettingsDevtoolsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsDevtoolsScreen.tsx
@@ -19,6 +19,7 @@ import {
 import { useScrollToTop } from '@app/hooks/useScrollToTop';
 import { usePreferences } from '@app/store/preferenceStore';
 import { theme } from '@app/styles/themes';
+import { isDevToolsEnabled } from '@app/utils/devTools/isDevToolsEnabled';
 
 import { FormNavigationRow } from './components/FormNavigationRow';
 
@@ -85,13 +86,15 @@ export function SettingsDevtoolsScreen() {
               <NativeText>{t('enhancedVideoStability')}</NativeText>
               <NativeText>{t('enhancedVideoStabilityDescription')}</NativeText>
             </Toggle>
-            <Toggle
-              isOn={chatDebugTools}
-              onIsOnChange={value => update({ chatDebugTools: value })}
-            >
-              <NativeText>{t('chatDebugTools')}</NativeText>
-              <NativeText>{t('chatDebugToolsDescription')}</NativeText>
-            </Toggle>
+            {isDevToolsEnabled ? (
+              <Toggle
+                isOn={chatDebugTools}
+                onIsOnChange={value => update({ chatDebugTools: value })}
+              >
+                <NativeText>{t('chatDebugTools')}</NativeText>
+                <NativeText>{t('chatDebugToolsDescription')}</NativeText>
+              </Toggle>
+            ) : null}
           </Section>
 
           <Section title={t('developerTools')}>
@@ -203,13 +206,15 @@ export function SettingsDevtoolsScreen() {
             value={enhancedVideoStability}
             onValueChange={value => update({ enhancedVideoStability: value })}
           />
-          <SettingsToggleRow
-            title={t('chatDebugTools')}
-            subtitle={t('chatDebugToolsDescription')}
-            icon={{ icon: 'ladybug', color: theme.colorTeal }}
-            value={chatDebugTools}
-            onValueChange={value => update({ chatDebugTools: value })}
-          />
+          {isDevToolsEnabled ? (
+            <SettingsToggleRow
+              title={t('chatDebugTools')}
+              subtitle={t('chatDebugToolsDescription')}
+              icon={{ icon: 'ladybug', color: theme.colorTeal }}
+              value={chatDebugTools}
+              onValueChange={value => update({ chatDebugTools: value })}
+            />
+          ) : null}
         </SettingsSection>
 
         <SettingsSection title={t('developerTools')}>

--- a/src/screens/SettingsScreen/SettingsDevtoolsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsDevtoolsScreen.tsx
@@ -29,6 +29,7 @@ export function SettingsDevtoolsScreen() {
     disableStream,
     sharedChatEnabled,
     enhancedVideoStability,
+    chatDebugTools,
     update,
   } = usePreferences();
   const scrollRef = useRef<ScrollView>(null);
@@ -83,6 +84,13 @@ export function SettingsDevtoolsScreen() {
             >
               <NativeText>{t('enhancedVideoStability')}</NativeText>
               <NativeText>{t('enhancedVideoStabilityDescription')}</NativeText>
+            </Toggle>
+            <Toggle
+              isOn={chatDebugTools}
+              onIsOnChange={value => update({ chatDebugTools: value })}
+            >
+              <NativeText>{t('chatDebugTools')}</NativeText>
+              <NativeText>{t('chatDebugToolsDescription')}</NativeText>
             </Toggle>
           </Section>
 
@@ -194,6 +202,13 @@ export function SettingsDevtoolsScreen() {
             icon={{ icon: 'wand.and.stars', color: theme.colorBlue }}
             value={enhancedVideoStability}
             onValueChange={value => update({ enhancedVideoStability: value })}
+          />
+          <SettingsToggleRow
+            title={t('chatDebugTools')}
+            subtitle={t('chatDebugToolsDescription')}
+            icon={{ icon: 'ladybug', color: theme.colorTeal }}
+            value={chatDebugTools}
+            onValueChange={value => update({ chatDebugTools: value })}
           />
         </SettingsSection>
 

--- a/src/services/twitch-chat-service.ts
+++ b/src/services/twitch-chat-service.ts
@@ -6,6 +6,7 @@ import { useAuthContext } from '@app/context/AuthContext';
 import { useLazyRef } from '@app/hooks/useLazyRef';
 import { useSyncRef } from '@app/hooks/useSyncRef';
 import { isE2EMode } from '@app/services/api/clients';
+import { recordChatDebugIrcLine } from '@app/store/chat/actions/chatDebugLog';
 import { usePreference } from '@app/store/preferenceStore';
 import { UserNoticeTags } from '@app/types/chat/irc-tags/usernotice';
 import { subscribeToAppStateTransitions } from '@app/utils/appState/appStateTransitions';
@@ -605,9 +606,11 @@ export function useTwitchChat(options: UseTwitchChatOptions = {}) {
         // Replay is unaffected - it flows through the recent-messages path,
         // never this socket.
         if (isPrivmsgLine(line) && !shouldProcessLiveMessage()) {
+          recordChatDebugIrcLine(line, true);
           continue;
         }
 
+        recordChatDebugIrcLine(line);
         const ircMessage = parseIrcMessage(line);
         if (ircMessage) {
           handleIrcMessage(ircMessage);

--- a/src/store/__tests__/preferenceStore.test.tsx
+++ b/src/store/__tests__/preferenceStore.test.tsx
@@ -50,6 +50,7 @@ const basePreferences = {
   analyticsEnabled: true,
   sharedChatEnabled: true,
   enhancedVideoStability: false,
+  chatDebugTools: false,
   sevenTvPaintRenderer: 'native',
 } as const satisfies Preferences;
 

--- a/src/store/chat/actions/__tests__/chatDebugLog.test.ts
+++ b/src/store/chat/actions/__tests__/chatDebugLog.test.ts
@@ -1,0 +1,135 @@
+import {
+  acquireChatDebugLog,
+  clearChatDebugLog,
+  getChatDebugIrcLines,
+  getChatDebugIrcLinesForLogin,
+  isChatDebugLogEnabled,
+  recordChatDebugIrcLine,
+  releaseChatDebugLog,
+} from '../chatDebugLog';
+
+const privmsg = (login: string, body: string) =>
+  `@badge-info=;badges=moderator/1;color=#FF0000;display-name=${login};id=abc;user-id=123 :${login}!${login}@${login}.tmi.twitch.tv PRIVMSG #channel :${body}`;
+
+describe('chatDebugLog', () => {
+  beforeEach(() => {
+    acquireChatDebugLog();
+    clearChatDebugLog();
+  });
+
+  afterEach(() => {
+    while (isChatDebugLogEnabled()) {
+      releaseChatDebugLog();
+    }
+  });
+
+  test('records lines newest first', () => {
+    recordChatDebugIrcLine('first');
+    recordChatDebugIrcLine('second');
+
+    expect(getChatDebugIrcLines().map(entry => entry.line)).toEqual([
+      'second',
+      'first',
+    ]);
+  });
+
+  test('marks flood-dropped lines', () => {
+    recordChatDebugIrcLine(privmsg('someuser', 'hello'), true);
+
+    const [entry] = getChatDebugIrcLines();
+    expect(entry?.dropped).toBe(true);
+  });
+
+  test('ignores records once every recorder releases and wipes the buffer', () => {
+    recordChatDebugIrcLine('kept');
+    releaseChatDebugLog();
+
+    expect(isChatDebugLogEnabled()).toBe(false);
+    expect(getChatDebugIrcLines()).toEqual([]);
+
+    recordChatDebugIrcLine('ignored');
+    expect(getChatDebugIrcLines()).toEqual([]);
+  });
+
+  test('keeps recording while another recorder is still acquired', () => {
+    acquireChatDebugLog();
+    recordChatDebugIrcLine('first');
+    releaseChatDebugLog();
+
+    expect(isChatDebugLogEnabled()).toBe(true);
+    recordChatDebugIrcLine('second');
+    expect(getChatDebugIrcLines().map(entry => entry.line)).toEqual([
+      'second',
+      'first',
+    ]);
+  });
+
+  test('bounds the buffer to the most recent lines', () => {
+    for (let index = 0; index < 300; index += 1) {
+      recordChatDebugIrcLine(`line-${index}`);
+    }
+
+    const lines = getChatDebugIrcLines();
+    expect(lines).toHaveLength(250);
+    expect(lines[0]?.line).toBe('line-299');
+    expect(lines[249]?.line).toBe('line-50');
+  });
+
+  test('filters lines by sender prefix', () => {
+    recordChatDebugIrcLine(privmsg('alice', 'one'));
+    recordChatDebugIrcLine(privmsg('bob', 'two'));
+    recordChatDebugIrcLine(privmsg('alice', 'three'));
+
+    const lines = getChatDebugIrcLinesForLogin('Alice').map(
+      entry => entry.line,
+    );
+    expect(lines).toEqual([privmsg('alice', 'three'), privmsg('alice', 'one')]);
+  });
+
+  test('matches usernotices through the login tag', () => {
+    const usernotice =
+      '@badge-info=;login=alice;msg-id=resub;system-msg=resubbed :tmi.twitch.tv USERNOTICE #channel';
+    recordChatDebugIrcLine(usernotice);
+
+    expect(
+      getChatDebugIrcLinesForLogin('@alice').map(entry => entry.line),
+    ).toEqual([usernotice]);
+  });
+
+  test('matches clearchat moderation lines through the trailing login param', () => {
+    const clearchat =
+      '@ban-duration=600;room-id=1;target-user-id=2;tmi-sent-ts=3 :tmi.twitch.tv CLEARCHAT #channel :alice';
+    recordChatDebugIrcLine(clearchat);
+    recordChatDebugIrcLine(privmsg('bob', 'unrelated'));
+
+    expect(
+      getChatDebugIrcLinesForLogin('alice').map(entry => entry.line),
+    ).toEqual([clearchat]);
+  });
+
+  test('matches a login tag in final position before the prefix', () => {
+    const usernotice =
+      '@msg-id=resub;login=alice :tmi.twitch.tv USERNOTICE #channel :welcome back';
+    recordChatDebugIrcLine(usernotice);
+
+    expect(
+      getChatDebugIrcLinesForLogin('alice').map(entry => entry.line),
+    ).toEqual([usernotice]);
+  });
+
+  test('caps per-login results at the requested limit', () => {
+    for (let index = 0; index < 15; index += 1) {
+      recordChatDebugIrcLine(privmsg('alice', `msg-${index}`));
+    }
+
+    expect(getChatDebugIrcLinesForLogin('alice')).toHaveLength(10);
+    expect(getChatDebugIrcLinesForLogin('alice', 3)).toHaveLength(3);
+  });
+
+  test('returns nothing for an empty login', () => {
+    recordChatDebugIrcLine(privmsg('alice', 'one'));
+
+    expect(getChatDebugIrcLinesForLogin('')).toEqual([]);
+    expect(getChatDebugIrcLinesForLogin(undefined)).toEqual([]);
+  });
+});

--- a/src/store/chat/actions/__tests__/chatDebugLog.test.ts
+++ b/src/store/chat/actions/__tests__/chatDebugLog.test.ts
@@ -128,6 +128,15 @@ describe('chatDebugLog', () => {
     expect(getChatDebugIrcLinesForLogin('bob')).toHaveLength(3);
   });
 
+  test('never matches identity markers quoted inside reply tag values', () => {
+    recordChatDebugIrcLine(
+      '@reply-parent-msg-body=check\\s!alice@example.com\\sand\\s@login=alice;color=#FFF :bob!bob@bob.tmi.twitch.tv PRIVMSG #channel :hi',
+    );
+
+    expect(getChatDebugIrcLinesForLogin('alice')).toEqual([]);
+    expect(getChatDebugIrcLinesForLogin('bob')).toHaveLength(1);
+  });
+
   test('matches a display name whose spaces are tag-escaped', () => {
     const usernotice =
       '@display-name=Alice\\sSmith;msg-id=resub :tmi.twitch.tv USERNOTICE #channel :hi';

--- a/src/store/chat/actions/__tests__/chatDebugLog.test.ts
+++ b/src/store/chat/actions/__tests__/chatDebugLog.test.ts
@@ -1,6 +1,7 @@
+import { chatStore$ } from '@app/store/chat/observables/chatStore';
+
 import {
   acquireChatDebugLog,
-  clearChatDebugLog,
   getChatDebugIrcLines,
   getChatDebugIrcLinesForLogin,
   isChatDebugLogEnabled,
@@ -8,26 +9,27 @@ import {
   releaseChatDebugLog,
 } from '../chatDebugLog';
 
+const CHANNEL_ID = 'channel-1';
+
 const privmsg = (login: string, body: string) =>
   `@badge-info=;badges=moderator/1;color=#FF0000;display-name=${login};id=abc;user-id=123 :${login}!${login}@${login}.tmi.twitch.tv PRIVMSG #channel :${body}`;
 
 describe('chatDebugLog', () => {
   beforeEach(() => {
-    acquireChatDebugLog();
-    clearChatDebugLog();
+    chatStore$.currentChannelId.set(CHANNEL_ID);
+    acquireChatDebugLog(CHANNEL_ID, 'channel');
   });
 
   afterEach(() => {
-    while (isChatDebugLogEnabled()) {
-      releaseChatDebugLog();
-    }
+    releaseChatDebugLog(CHANNEL_ID, 'channel');
+    chatStore$.currentChannelId.set(null);
   });
 
   test('records lines newest first', () => {
     recordChatDebugIrcLine('first');
     recordChatDebugIrcLine('second');
 
-    expect(getChatDebugIrcLines().map(entry => entry.line)).toEqual([
+    expect(getChatDebugIrcLines(CHANNEL_ID).map(entry => entry.line)).toEqual([
       'second',
       'first',
     ]);
@@ -36,32 +38,67 @@ describe('chatDebugLog', () => {
   test('marks flood-dropped lines', () => {
     recordChatDebugIrcLine(privmsg('someuser', 'hello'), true);
 
-    const [entry] = getChatDebugIrcLines();
+    const [entry] = getChatDebugIrcLines(CHANNEL_ID);
     expect(entry?.dropped).toBe(true);
   });
 
   test('ignores records once every recorder releases and wipes the buffer', () => {
     recordChatDebugIrcLine('kept');
-    releaseChatDebugLog();
+    releaseChatDebugLog(CHANNEL_ID, 'channel');
 
     expect(isChatDebugLogEnabled()).toBe(false);
-    expect(getChatDebugIrcLines()).toEqual([]);
+    expect(getChatDebugIrcLines(CHANNEL_ID)).toEqual([]);
 
     recordChatDebugIrcLine('ignored');
-    expect(getChatDebugIrcLines()).toEqual([]);
+    expect(getChatDebugIrcLines(CHANNEL_ID)).toEqual([]);
   });
 
   test('keeps recording while another recorder is still acquired', () => {
-    acquireChatDebugLog();
+    acquireChatDebugLog(CHANNEL_ID, 'channel');
     recordChatDebugIrcLine('first');
-    releaseChatDebugLog();
+    releaseChatDebugLog(CHANNEL_ID, 'channel');
 
     expect(isChatDebugLogEnabled()).toBe(true);
     recordChatDebugIrcLine('second');
-    expect(getChatDebugIrcLines().map(entry => entry.line)).toEqual([
+    expect(getChatDebugIrcLines(CHANNEL_ID).map(entry => entry.line)).toEqual([
       'second',
       'first',
     ]);
+  });
+
+  test('scopes captures per channel so stacked screens do not wipe or pollute each other', () => {
+    const otherLine = ':bob!bob@bob.tmi.twitch.tv PRIVMSG #other :two';
+    recordChatDebugIrcLine(privmsg('alice', 'one'));
+
+    acquireChatDebugLog('channel-2', 'other');
+    recordChatDebugIrcLine(otherLine);
+
+    expect(getChatDebugIrcLines(CHANNEL_ID).map(entry => entry.line)).toEqual([
+      privmsg('alice', 'one'),
+    ]);
+    expect(getChatDebugIrcLines('channel-2').map(entry => entry.line)).toEqual([
+      otherLine,
+    ]);
+
+    releaseChatDebugLog('channel-2', 'other');
+    expect(getChatDebugIrcLines('channel-2')).toEqual([]);
+    expect(getChatDebugIrcLines(CHANNEL_ID)).toHaveLength(1);
+  });
+
+  test('drops lines for channels with no active recorder', () => {
+    recordChatDebugIrcLine(':bob!bob@bob.tmi.twitch.tv PRIVMSG #other :hi');
+
+    expect(getChatDebugIrcLines(CHANNEL_ID)).toEqual([]);
+  });
+
+  test('records channel-less socket lines into every active capture', () => {
+    acquireChatDebugLog('channel-2', 'other');
+    recordChatDebugIrcLine(':tmi.twitch.tv GLOBALUSERSTATE');
+
+    expect(getChatDebugIrcLines(CHANNEL_ID)).toHaveLength(1);
+    expect(getChatDebugIrcLines('channel-2')).toHaveLength(1);
+
+    releaseChatDebugLog('channel-2', 'other');
   });
 
   test('bounds the buffer to the most recent lines', () => {
@@ -69,7 +106,7 @@ describe('chatDebugLog', () => {
       recordChatDebugIrcLine(`line-${index}`);
     }
 
-    const lines = getChatDebugIrcLines();
+    const lines = getChatDebugIrcLines(CHANNEL_ID);
     expect(lines).toHaveLength(250);
     expect(lines[0]?.line).toBe('line-299');
     expect(lines[249]?.line).toBe('line-50');

--- a/src/store/chat/actions/__tests__/chatDebugLog.test.ts
+++ b/src/store/chat/actions/__tests__/chatDebugLog.test.ts
@@ -117,6 +117,27 @@ describe('chatDebugLog', () => {
     ).toEqual([usernotice]);
   });
 
+  test('never matches on message-body text that mimics identity markers', () => {
+    recordChatDebugIrcLine(privmsg('bob', 'check !alice@example.com'));
+    recordChatDebugIrcLine(
+      privmsg('bob', '@badges=;display-name=alice;color=#FFF'),
+    );
+    recordChatDebugIrcLine(privmsg('bob', 'lol CLEARCHAT incoming :alice'));
+
+    expect(getChatDebugIrcLinesForLogin('alice')).toEqual([]);
+    expect(getChatDebugIrcLinesForLogin('bob')).toHaveLength(3);
+  });
+
+  test('matches a display name whose spaces are tag-escaped', () => {
+    const usernotice =
+      '@display-name=Alice\\sSmith;msg-id=resub :tmi.twitch.tv USERNOTICE #channel :hi';
+    recordChatDebugIrcLine(usernotice);
+
+    expect(
+      getChatDebugIrcLinesForLogin('Alice Smith').map(entry => entry.line),
+    ).toEqual([usernotice]);
+  });
+
   test('caps per-login results at the requested limit', () => {
     for (let index = 0; index < 15; index += 1) {
       recordChatDebugIrcLine(privmsg('alice', `msg-${index}`));

--- a/src/store/chat/actions/chatDebugLog.ts
+++ b/src/store/chat/actions/chatDebugLog.ts
@@ -1,0 +1,279 @@
+import { getBadge, getPaint } from '@app/store/chat/actions/cosmetics';
+import { getMissingBadgeIds } from '@app/store/chat/actions/missingBadges';
+import { chatStore$ } from '@app/store/chat/observables/chatStore';
+import type { SanitisedEmote } from '@app/types/emote';
+import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
+import { normaliseChatUsername } from '@app/utils/chat/chatUsernames/normaliseChatUsername';
+
+export interface ChatDebugIrcLine {
+  line: string;
+  receivedAt: number;
+  dropped: boolean;
+}
+
+const MAX_DEBUG_IRC_LINES = 250;
+
+let activeRecorders = 0;
+const ircLines: ChatDebugIrcLine[] = [];
+
+export function acquireChatDebugLog(): void {
+  activeRecorders += 1;
+}
+
+export function releaseChatDebugLog(): void {
+  activeRecorders = Math.max(0, activeRecorders - 1);
+  if (activeRecorders === 0) {
+    ircLines.length = 0;
+  }
+}
+
+export function isChatDebugLogEnabled(): boolean {
+  return activeRecorders > 0;
+}
+
+export function recordChatDebugIrcLine(line: string, dropped = false): void {
+  if (activeRecorders === 0) {
+    return;
+  }
+  ircLines.push({ line, receivedAt: Date.now(), dropped });
+  if (ircLines.length > MAX_DEBUG_IRC_LINES) {
+    ircLines.splice(0, ircLines.length - MAX_DEBUG_IRC_LINES);
+  }
+}
+
+export function clearChatDebugLog(): void {
+  ircLines.length = 0;
+}
+
+export function getChatDebugIrcLines(): ChatDebugIrcLine[] {
+  return ircLines.slice().reverse();
+}
+
+export function getChatDebugIrcLinesForLogin(
+  login: string | null | undefined,
+  limit = 10,
+): ChatDebugIrcLine[] {
+  const target = normaliseChatUsername(login);
+  if (!target) {
+    return [];
+  }
+  const escaped = target.replace(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+  const tagPattern = new RegExp(`[@;](?:login|display-name)=${escaped}(?:;| )`);
+
+  const matches: ChatDebugIrcLine[] = [];
+  for (let index = ircLines.length - 1; index >= 0; index -= 1) {
+    const entry = ircLines[index];
+    if (!entry) {
+      continue;
+    }
+    const line = entry.line.toLowerCase();
+    if (
+      line.includes(`!${target}@`) ||
+      tagPattern.test(line) ||
+      (line.includes(' clearchat ') && line.endsWith(`:${target}`))
+    ) {
+      matches.push(entry);
+      if (matches.length >= limit) {
+        break;
+      }
+    }
+  }
+  return matches;
+}
+
+function getCurrentChannelCache() {
+  const channelId = chatStore$.currentChannelId.peek();
+  if (!channelId) {
+    return { channelId: null, cache: undefined };
+  }
+  return {
+    channelId,
+    cache: chatStore$.persisted.channelCaches[channelId]?.peek(),
+  };
+}
+
+function formatCacheAge(lastUpdated: number | undefined): string {
+  return lastUpdated ? new Date(lastUpdated).toISOString() : 'never';
+}
+
+export function getChatDebugEmoteSources(): Record<string, unknown> {
+  const { channelId, cache } = getCurrentChannelCache();
+  if (!cache) {
+    return { channelId, cacheLoaded: false };
+  }
+  return {
+    channelId,
+    lastUpdated: formatCacheAge(cache.lastUpdated),
+    sevenTvEmoteSetId: cache.sevenTvEmoteSetId ?? null,
+    twitchChannel: cache.twitchChannelEmotes.length,
+    twitchGlobal: cache.twitchGlobalEmotes.length,
+    twitchSubscriber: cache.twitchSubscriberEmotes.length,
+    sevenTvChannel: cache.sevenTvChannelEmotes.length,
+    sevenTvGlobal: cache.sevenTvGlobalEmotes.length,
+    sevenTvPersonalUsers: Object.keys(cache.sevenTvPersonalEmotes).length,
+    bttvChannel: cache.bttvChannelEmotes.length,
+    bttvGlobal: cache.bttvGlobalEmotes.length,
+    ffzChannel: cache.ffzChannelEmotes.length,
+    ffzGlobal: cache.ffzGlobalEmotes.length,
+  };
+}
+
+export function getChatDebugEmoteDetails(emote: {
+  id?: string;
+  name?: string;
+}): Record<string, unknown> {
+  const { cache } = getCurrentChannelCache();
+  if (!cache) {
+    return { foundInCache: false, cacheLoaded: false };
+  }
+
+  const lists: [string, SanitisedEmote[]][] = [
+    ['sevenTvChannel', cache.sevenTvChannelEmotes],
+    ['sevenTvGlobal', cache.sevenTvGlobalEmotes],
+    ...Object.entries(cache.sevenTvPersonalEmotes).map(
+      ([ownerId, emotes]): [string, SanitisedEmote[]] => [
+        `sevenTvPersonal:${ownerId}`,
+        emotes,
+      ],
+    ),
+    ['bttvChannel', cache.bttvChannelEmotes],
+    ['bttvGlobal', cache.bttvGlobalEmotes],
+    ['ffzChannel', cache.ffzChannelEmotes],
+    ['ffzGlobal', cache.ffzGlobalEmotes],
+    ['twitchChannel', cache.twitchChannelEmotes],
+    ['twitchGlobal', cache.twitchGlobalEmotes],
+    ['twitchSubscriber', cache.twitchSubscriberEmotes],
+  ];
+
+  type Found = {
+    foundInCache: true;
+    sourceList: string;
+    cachedEmote: SanitisedEmote;
+  };
+  const byId = new Map<string, Found>();
+  const byName = new Map<string, Found>();
+  for (const [sourceList, emotes] of lists) {
+    for (const cachedEmote of emotes) {
+      const found: Found = { foundInCache: true, sourceList, cachedEmote };
+      if (!byId.has(cachedEmote.id)) {
+        byId.set(cachedEmote.id, found);
+      }
+      if (!byName.has(cachedEmote.name)) {
+        byName.set(cachedEmote.name, found);
+      }
+    }
+  }
+
+  return (
+    (emote.id ? byId.get(emote.id) : undefined) ??
+    (emote.name ? byName.get(emote.name) : undefined) ?? {
+      foundInCache: false,
+      cacheLoaded: true,
+    }
+  );
+}
+
+export function getChatDebugBadgeDetails(
+  badge: SanitisedBadgeSet,
+): Record<string, unknown> {
+  if (badge.provider !== '7tv') {
+    return { provider: badge.provider ?? 'twitch' };
+  }
+  const definition = chatStore$.badges[badge.id]?.peek();
+  const wearerCount = Object.values(chatStore$.userBadgeIds.peek()).filter(
+    badgeId => badgeId === badge.id,
+  ).length;
+  return {
+    provider: '7tv',
+    definitionLoaded: Boolean(definition),
+    definition: definition ?? null,
+    wearerCount,
+    isMissingDefinition: getMissingBadgeIds().includes(badge.id),
+  };
+}
+
+export function getChatDebugBadgeSources(): Record<string, unknown> {
+  const { channelId, cache } = getCurrentChannelCache();
+  if (!cache) {
+    return { channelId, cacheLoaded: false };
+  }
+  return {
+    channelId,
+    badgesLastUpdated: formatCacheAge(cache.badgesLastUpdated),
+    twitchChannel: cache.twitchChannelBadges.length,
+    twitchGlobal: cache.twitchGlobalBadges.length,
+    ffzChannel: cache.ffzChannelBadges.length,
+    ffzGlobal: cache.ffzGlobalBadges.length,
+    sevenTvPersonalUsers: Object.keys(cache.sevenTvPersonalBadges).length,
+    sevenTvBadgeDefinitions: Object.keys(chatStore$.badges.peek()).length,
+    sevenTvBadgeWearers: Object.keys(chatStore$.userBadgeIds.peek()).length,
+    missingSevenTvBadgeIds: getMissingBadgeIds(),
+  };
+}
+
+export function getChatDebugUserSnapshot(
+  login: string | null | undefined,
+  username: string | null | undefined,
+  userId: string | null | undefined,
+): Record<string, unknown> {
+  const target =
+    normaliseChatUsername(login) || normaliseChatUsername(username);
+
+  const paintId = userId
+    ? (chatStore$.userPaintIds[userId]?.peek() ?? null)
+    : null;
+  const badgeId = userId
+    ? (chatStore$.userBadgeIds[userId]?.peek() ?? null)
+    : null;
+
+  let latestMessage;
+  if (target) {
+    const messages = chatStore$.messages.peek();
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (!message) {
+        continue;
+      }
+      const messageLogin = normaliseChatUsername(
+        message.userstate?.login ||
+          message.userstate?.username ||
+          message.sender,
+      );
+      if (messageLogin === target) {
+        latestMessage = message;
+        break;
+      }
+    }
+  }
+
+  const { cache } = getCurrentChannelCache();
+  const personalEmotes =
+    userId && cache ? (cache.sevenTvPersonalEmotes[userId] ?? []) : [];
+  const personalBadges =
+    userId && cache ? (cache.sevenTvPersonalBadges[userId] ?? []) : [];
+
+  return {
+    login: target || null,
+    userId: userId ?? null,
+    sevenTvPaintId: paintId,
+    sevenTvPaintName: paintId ? (getPaint(paintId)?.name ?? null) : null,
+    sevenTvBadgeId: badgeId,
+    sevenTvBadgeTitle: badgeId ? (getBadge(badgeId)?.title ?? null) : null,
+    sevenTvPersonalEmotes: personalEmotes.map(emote => emote.name),
+    sevenTvPersonalBadges: personalBadges.map(badge => badge.title),
+    latestMessage: latestMessage
+      ? {
+          messageId: latestMessage.message_id,
+          resolvedBadges: latestMessage.badges.map(badge => ({
+            id: badge.id,
+            set: badge.set,
+            title: badge.title,
+            type: badge.type,
+            provider: badge.provider ?? 'twitch',
+            url: badge.url,
+          })),
+          userstate: latestMessage.userstate,
+        }
+      : null,
+  };
+}

--- a/src/store/chat/actions/chatDebugLog.ts
+++ b/src/store/chat/actions/chatDebugLog.ts
@@ -13,49 +13,96 @@ export interface ChatDebugIrcLine {
 
 const MAX_DEBUG_IRC_LINES = 250;
 
-let activeRecorders = 0;
-const ircLines: ChatDebugIrcLine[] = [];
+/**
+ * Captures are scoped per channel so stacked stream screens cannot wipe or
+ * pollute each other's buffer. Buffers key off the app channel id (what
+ * `chatStore$.currentChannelId` holds) but inbound lines only carry the IRC
+ * `#login`, so `channelIdsByLogin` bridges the two at record time.
+ */
+const recorderCounts = new Map<string, number>();
+const channelIdsByLogin = new Map<string, string>();
+const buffers = new Map<string, ChatDebugIrcLine[]>();
 
-export function acquireChatDebugLog(): void {
-  activeRecorders += 1;
+export function acquireChatDebugLog(
+  channelId: string,
+  channelName: string,
+): void {
+  recorderCounts.set(channelId, (recorderCounts.get(channelId) ?? 0) + 1);
+  channelIdsByLogin.set(normaliseChatUsername(channelName), channelId);
 }
 
-export function releaseChatDebugLog(): void {
-  activeRecorders = Math.max(0, activeRecorders - 1);
-  if (activeRecorders === 0) {
-    ircLines.length = 0;
+export function releaseChatDebugLog(
+  channelId: string,
+  channelName: string,
+): void {
+  const next = (recorderCounts.get(channelId) ?? 1) - 1;
+  if (next > 0) {
+    recorderCounts.set(channelId, next);
+    return;
+  }
+  recorderCounts.delete(channelId);
+  buffers.delete(channelId);
+  const login = normaliseChatUsername(channelName);
+  if (channelIdsByLogin.get(login) === channelId) {
+    channelIdsByLogin.delete(login);
   }
 }
 
 export function isChatDebugLogEnabled(): boolean {
-  return activeRecorders > 0;
+  return recorderCounts.size > 0;
+}
+
+function getLineChannelLogin(line: string): string | null {
+  const { rest } = splitIrcLine(line);
+  const hashIndex = rest.indexOf('#');
+  if (hashIndex === -1) {
+    return null;
+  }
+  const end = rest.indexOf(' ', hashIndex);
+  return rest.slice(hashIndex + 1, end === -1 ? undefined : end).toLowerCase();
+}
+
+function appendToBuffer(channelId: string, entry: ChatDebugIrcLine): void {
+  let buffer = buffers.get(channelId);
+  if (!buffer) {
+    buffer = [];
+    buffers.set(channelId, buffer);
+  }
+  buffer.push(entry);
+  if (buffer.length > MAX_DEBUG_IRC_LINES) {
+    buffer.splice(0, buffer.length - MAX_DEBUG_IRC_LINES);
+  }
 }
 
 export function recordChatDebugIrcLine(line: string, dropped = false): void {
-  if (activeRecorders === 0) {
+  if (recorderCounts.size === 0) {
     return;
   }
-  ircLines.push({ line, receivedAt: Date.now(), dropped });
-  if (ircLines.length > MAX_DEBUG_IRC_LINES) {
-    ircLines.splice(0, ircLines.length - MAX_DEBUG_IRC_LINES);
+  const entry: ChatDebugIrcLine = { line, receivedAt: Date.now(), dropped };
+  const login = getLineChannelLogin(line);
+  if (login !== null) {
+    const channelId = channelIdsByLogin.get(login);
+    if (channelId !== undefined) {
+      appendToBuffer(channelId, entry);
+    }
+    return;
+  }
+  // Channel-less lines (auth numerics, GLOBALUSERSTATE) are socket-wide.
+  for (const channelId of recorderCounts.keys()) {
+    appendToBuffer(channelId, entry);
   }
 }
 
-export function clearChatDebugLog(): void {
-  ircLines.length = 0;
-}
-
-export function getChatDebugIrcLines(): ChatDebugIrcLine[] {
-  return ircLines.slice().reverse();
+export function getChatDebugIrcLines(channelId: string): ChatDebugIrcLine[] {
+  return (buffers.get(channelId) ?? []).slice().reverse();
 }
 
 /**
  * User-typed text reaches a line in two places: the trailing parameter (the
  * message body) and tag values like reply-parent-msg-body. Tag values escape
  * raw ';' and space, so the tags token ends at the first space and real tags
- * always split on ';'. That keeps the matchers below anchored to actual tag
- * keys and the sender prefix instead of firing on lookalike text inside a
- * body.
+ * always split on ';', which lets the login matchers anchor to real tag keys
+ * and the sender prefix instead of user-typed lookalikes.
  */
 function splitIrcLine(line: string): {
   tags: string | null;
@@ -109,9 +156,11 @@ export function getChatDebugIrcLinesForLogin(
     `(?:^@|;)(?:login|display-name)=${escaped}(?:;|$)`,
   );
 
+  const channelId = chatStore$.currentChannelId.peek();
+  const lines = channelId ? (buffers.get(channelId) ?? []) : [];
   const matches: ChatDebugIrcLine[] = [];
-  for (let index = ircLines.length - 1; index >= 0; index -= 1) {
-    const entry = ircLines[index];
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const entry = lines[index];
     if (!entry) {
       continue;
     }

--- a/src/store/chat/actions/chatDebugLog.ts
+++ b/src/store/chat/actions/chatDebugLog.ts
@@ -49,6 +49,36 @@ export function getChatDebugIrcLines(): ChatDebugIrcLine[] {
   return ircLines.slice().reverse();
 }
 
+/**
+ * Head is everything before the trailing parameter (the message body), so the
+ * matchers below can never fire on body text a user typed.
+ */
+function splitIrcLine(line: string): { head: string; trailing: string | null } {
+  let cursor = 0;
+  if (line.startsWith('@')) {
+    const tagEnd = line.indexOf(' ');
+    if (tagEnd === -1) {
+      return { head: line, trailing: null };
+    }
+    cursor = tagEnd + 1;
+  }
+  if (line.startsWith(':', cursor)) {
+    const prefixEnd = line.indexOf(' ', cursor);
+    if (prefixEnd === -1) {
+      return { head: line, trailing: null };
+    }
+    cursor = prefixEnd + 1;
+  }
+  const trailingStart = line.indexOf(' :', cursor);
+  if (trailingStart === -1) {
+    return { head: line, trailing: null };
+  }
+  return {
+    head: line.slice(0, trailingStart),
+    trailing: line.slice(trailingStart + 2),
+  };
+}
+
 export function getChatDebugIrcLinesForLogin(
   login: string | null | undefined,
   limit = 10,
@@ -57,8 +87,12 @@ export function getChatDebugIrcLinesForLogin(
   if (!target) {
     return [];
   }
-  const escaped = target.replace(/[$()*+.?[\\\]^{|}]/g, '\\$&');
-  const tagPattern = new RegExp(`[@;](?:login|display-name)=${escaped}(?:;| )`);
+  const escaped = target
+    .replace(/[$()*+.?[\\\]^{|}]/g, '\\$&')
+    .replace(/ /g, '\\\\s');
+  const tagPattern = new RegExp(
+    `[@;](?:login|display-name)=${escaped}(?:;| |$)`,
+  );
 
   const matches: ChatDebugIrcLine[] = [];
   for (let index = ircLines.length - 1; index >= 0; index -= 1) {
@@ -66,11 +100,11 @@ export function getChatDebugIrcLinesForLogin(
     if (!entry) {
       continue;
     }
-    const line = entry.line.toLowerCase();
+    const { head, trailing } = splitIrcLine(entry.line.toLowerCase());
     if (
-      line.includes(`!${target}@`) ||
-      tagPattern.test(line) ||
-      (line.includes(' clearchat ') && line.endsWith(`:${target}`))
+      head.includes(`!${target}@`) ||
+      tagPattern.test(head) ||
+      (head.includes(' clearchat ') && trailing === target)
     ) {
       matches.push(entry);
       if (matches.length >= limit) {

--- a/src/store/chat/actions/chatDebugLog.ts
+++ b/src/store/chat/actions/chatDebugLog.ts
@@ -50,31 +50,46 @@ export function getChatDebugIrcLines(): ChatDebugIrcLine[] {
 }
 
 /**
- * Head is everything before the trailing parameter (the message body), so the
- * matchers below can never fire on body text a user typed.
+ * User-typed text reaches a line in two places: the trailing parameter (the
+ * message body) and tag values like reply-parent-msg-body. Tag values escape
+ * raw ';' and space, so the tags token ends at the first space and real tags
+ * always split on ';'. That keeps the matchers below anchored to actual tag
+ * keys and the sender prefix instead of firing on lookalike text inside a
+ * body.
  */
-function splitIrcLine(line: string): { head: string; trailing: string | null } {
+function splitIrcLine(line: string): {
+  tags: string | null;
+  prefix: string | null;
+  rest: string;
+  trailing: string | null;
+} {
   let cursor = 0;
+  let tags: string | null = null;
   if (line.startsWith('@')) {
     const tagEnd = line.indexOf(' ');
     if (tagEnd === -1) {
-      return { head: line, trailing: null };
+      return { tags: line, prefix: null, rest: '', trailing: null };
     }
+    tags = line.slice(0, tagEnd);
     cursor = tagEnd + 1;
   }
+  let prefix: string | null = null;
   if (line.startsWith(':', cursor)) {
     const prefixEnd = line.indexOf(' ', cursor);
     if (prefixEnd === -1) {
-      return { head: line, trailing: null };
+      return { tags, prefix: line.slice(cursor), rest: '', trailing: null };
     }
+    prefix = line.slice(cursor, prefixEnd);
     cursor = prefixEnd + 1;
   }
   const trailingStart = line.indexOf(' :', cursor);
   if (trailingStart === -1) {
-    return { head: line, trailing: null };
+    return { tags, prefix, rest: line.slice(cursor), trailing: null };
   }
   return {
-    head: line.slice(0, trailingStart),
+    tags,
+    prefix,
+    rest: line.slice(cursor, trailingStart),
     trailing: line.slice(trailingStart + 2),
   };
 }
@@ -91,7 +106,7 @@ export function getChatDebugIrcLinesForLogin(
     .replace(/[$()*+.?[\\\]^{|}]/g, '\\$&')
     .replace(/ /g, '\\\\s');
   const tagPattern = new RegExp(
-    `[@;](?:login|display-name)=${escaped}(?:;| |$)`,
+    `(?:^@|;)(?:login|display-name)=${escaped}(?:;|$)`,
   );
 
   const matches: ChatDebugIrcLine[] = [];
@@ -100,11 +115,13 @@ export function getChatDebugIrcLinesForLogin(
     if (!entry) {
       continue;
     }
-    const { head, trailing } = splitIrcLine(entry.line.toLowerCase());
+    const { tags, prefix, rest, trailing } = splitIrcLine(
+      entry.line.toLowerCase(),
+    );
     if (
-      head.includes(`!${target}@`) ||
-      tagPattern.test(head) ||
-      (head.includes(' clearchat ') && trailing === target)
+      prefix?.startsWith(`:${target}!`) ||
+      (tags !== null && tagPattern.test(tags)) ||
+      (rest.startsWith('clearchat ') && trailing === target)
     ) {
       matches.push(entry);
       if (matches.length >= limit) {
@@ -179,32 +196,19 @@ export function getChatDebugEmoteDetails(emote: {
     ['twitchSubscriber', cache.twitchSubscriberEmotes],
   ];
 
-  type Found = {
-    foundInCache: true;
-    sourceList: string;
-    cachedEmote: SanitisedEmote;
-  };
-  const byId = new Map<string, Found>();
-  const byName = new Map<string, Found>();
+  let nameMatch: Record<string, unknown> | undefined;
   for (const [sourceList, emotes] of lists) {
     for (const cachedEmote of emotes) {
-      const found: Found = { foundInCache: true, sourceList, cachedEmote };
-      if (!byId.has(cachedEmote.id)) {
-        byId.set(cachedEmote.id, found);
+      if (emote.id && cachedEmote.id === emote.id) {
+        return { foundInCache: true, sourceList, cachedEmote };
       }
-      if (!byName.has(cachedEmote.name)) {
-        byName.set(cachedEmote.name, found);
+      if (!nameMatch && emote.name && cachedEmote.name === emote.name) {
+        nameMatch = { foundInCache: true, sourceList, cachedEmote };
       }
     }
   }
 
-  return (
-    (emote.id ? byId.get(emote.id) : undefined) ??
-    (emote.name ? byName.get(emote.name) : undefined) ?? {
-      foundInCache: false,
-      cacheLoaded: true,
-    }
-  );
+  return nameMatch ?? { foundInCache: false, cacheLoaded: true };
 }
 
 export function getChatDebugBadgeDetails(

--- a/src/store/preferenceStore.ts
+++ b/src/store/preferenceStore.ts
@@ -100,6 +100,7 @@ export interface Preferences {
   analyticsEnabled: boolean;
   sharedChatEnabled: boolean;
   enhancedVideoStability: boolean;
+  chatDebugTools: boolean;
   sevenTvPaintRenderer: SevenTvPaintRenderer;
 }
 
@@ -149,6 +150,7 @@ export const preferencesSchema = z.object({
   analyticsEnabled: z.boolean(),
   sharedChatEnabled: z.boolean(),
   enhancedVideoStability: z.boolean(),
+  chatDebugTools: z.boolean(),
   sevenTvPaintRenderer: z.enum(['off', 'native', 'skia', 'webview']),
 }) satisfies z.ZodType<Preferences>;
 
@@ -196,6 +198,7 @@ export const initialPreferences: Preferences = {
   analyticsEnabled: true,
   sharedChatEnabled: true,
   enhancedVideoStability: false,
+  chatDebugTools: isDevToolsEnabled,
   sevenTvPaintRenderer: 'native',
 };
 

--- a/src/store/preferences/__tests__/preferenceStore.test.tsx
+++ b/src/store/preferences/__tests__/preferenceStore.test.tsx
@@ -47,6 +47,7 @@ const basePreferences = {
   analyticsEnabled: true,
   sharedChatEnabled: true,
   enhancedVideoStability: false,
+  chatDebugTools: false,
   sevenTvPaintRenderer: 'native',
 } as const satisfies Preferences;
 


### PR DESCRIPTION
# Why

When emotes, badges or paints go missing in chat there's currently no way to see what the app actually received or resolved without attaching a debugger. This adds a debug surface to the sheets we already open when investigating: tap the user, emote or badge and the data is right there.

# How

- new `chatDebugLog` module (plain module state in `store/chat/actions/`, same pattern as the other hot chat caches): a bounded buffer (250 lines per channel) of raw inbound IRC lines recorded in the socket loop, including flood-dropped lines marked `DROPPED`. Captures are scoped per channel - recorders register the IRC login so lines route by their `#channel` token, stacked stream screens can't wipe or pollute each other, and a buffer is dropped when its channel's last recorder releases
- `ChatDebugSection` card at the bottom of the three sheets, JSON payload + copy button:
  - user sheet: last 10 raw IRC lines for that login (sender prefix, `login=`/`display-name=` tags, and CLEARCHAT trailing param so bans/timeouts show), 7tv paint/badge bindings, personal emotes/badges, and the latest message's userstate next to the badges that actually resolved for it
  - emote sheet: the tapped part, the full cached emote record + which source list it resolved from (`foundInCache: false` = stale cache), per-provider counts + cache timestamps
  - badge sheet: full badge set, 7tv definition/wearer/missing-entitlement state, per-provider counts
- the login matchers only look at the sender prefix and the tags token, never tag values or the message body, so a reply quoting `!alice@` or a body pasting `login=alice` can't pollute another user's capture
- everything sits behind the build-time `isDevToolsEnabled` flag (dev/internal/e2e builds only - remote-config admins on production builds don't get this one) plus a new **Chat Debug Tools** toggle in the devtools settings screen (`chatDebugTools` preference, default on for devtools builds). In production the recorder never mounts and the sheet sections render nothing
- recent-messages replay never touches the socket, so raw lines only cover live traffic; the store snapshots still work for historical rows

# Test Plan

- `chatDebugLog.test.ts`: ordering, 250-line bound, refcounted release/wipe, dropped marking, login matching incl. USERNOTICE tags, CLEARCHAT, final-position tags, reply-tag lookalikes, limits
- updated preference fixtures for the new key; `tsc`, eslint, prettier clean; affected suites pass
- on device: toggle Chat Debug Tools in Settings → Dev Tools, open a chat, tap a user/emote/badge - debug card shows at the bottom of the sheet; toggle off - card gone and buffer wiped
