### PR TITLE
fix(chat): match the reply header icon to the reference rendering

### DIFF
--- a/src/components/Chat/components/ChatMessage/RichChatMessage.styles.ts
+++ b/src/components/Chat/components/ChatMessage/RichChatMessage.styles.ts
@@ -217,10 +217,6 @@ export const styles = StyleSheet.create({
   },
   replyContextIcon: {
     marginRight: 4,
-    opacity: 0.8,
-  },
-  replyContextIconReplyToYou: {
-    opacity: 1,
   },
   replyContextTextReplyToYou: {
     color: CHAT_NOTICE_ACCENTS.replyToYou,

--- a/src/components/Chat/components/ChatMessage/__tests__/chatScale.test.ts
+++ b/src/components/Chat/components/ChatMessage/__tests__/chatScale.test.ts
@@ -20,6 +20,7 @@ describe('getChatScale', () => {
       emoteLineHeight: 34,
       emoteSize: 30,
       gap: 4,
+      metaIconSize: 12,
       replyEmoteLineHeight: 24,
       replyEmoteSize: 20,
       rowPaddingHorizontal: 8,
@@ -46,6 +47,17 @@ describe('getChatScale', () => {
       expect(compact.emoteSize).toBe(comfortable.emoteSize);
       expect(compact.badgeSize).toBe(comfortable.badgeSize);
       expect(compact.secondaryFontSize).toBe(comfortable.secondaryFontSize);
+      expect(compact.metaIconSize).toBe(comfortable.metaIconSize);
+    }
+  });
+
+  test('sizes meta icons to the secondary text beside them', () => {
+    for (const fontScale of FONT_SCALES) {
+      for (const density of DENSITIES) {
+        const scale = getChatScale(fontScale, density);
+
+        expect(scale.metaIconSize).toBe(scale.secondaryFontSize);
+      }
     }
   });
 

--- a/src/components/Chat/components/ChatMessage/chatScale.ts
+++ b/src/components/Chat/components/ChatMessage/chatScale.ts
@@ -51,6 +51,7 @@ export interface ChatScale {
   emoteLineHeight: number;
   emoteSize: number;
   gap: number;
+  metaIconSize: number;
   replyEmoteLineHeight: number;
   replyEmoteSize: number;
   rowPaddingHorizontal: number;
@@ -94,6 +95,7 @@ function buildChatScale(
     emoteLineHeight: emoteSize + emoteHeadroom,
     emoteSize,
     gap: Math.round(bodyFontSize * GAP_RATIO),
+    metaIconSize: secondaryFontSize,
     replyEmoteLineHeight: replyEmoteSize + emoteHeadroom,
     replyEmoteSize,
     rowPaddingHorizontal: ROW_PADDING_HORIZONTAL[density],

--- a/src/components/Chat/components/ChatMessage/renderers/ReplyingToHeader.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ReplyingToHeader.tsx
@@ -72,10 +72,10 @@ export function ReplyingToHeader({
     ? CHAT_NOTICE_ACCENTS.replyToYou
     : CHAT_SURFACE_COLORS.muted;
   const textStyles = getChatTextStyles(fontScale, compact);
-  const replyEmoteSize = getChatScale(
+  const { metaIconSize, replyEmoteSize } = getChatScale(
     fontScale,
     densityFromCompact(compact),
-  ).replyEmoteSize;
+  );
   const replyContextPrefixTextStyle = [
     textStyles.replyContext,
     styles.replyContextPrefixFlex,
@@ -90,7 +90,7 @@ export function ReplyingToHeader({
     <>
       <SymbolView
         name='text.bubble'
-        size={12}
+        size={metaIconSize}
         tintColor={replyContextIconColor}
         style={styles.replyContextIcon}
       />

--- a/src/components/Chat/components/ChatMessage/renderers/ReplyingToHeader.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ReplyingToHeader.tsx
@@ -89,13 +89,10 @@ export function ReplyingToHeader({
   const content = (
     <>
       <SymbolView
-        name='bubble.left.fill'
+        name='text.bubble'
         size={12}
         tintColor={replyContextIconColor}
-        style={[
-          styles.replyContextIcon,
-          isReplyingToCurrentUser && styles.replyContextIconReplyToYou,
-        ]}
+        style={styles.replyContextIcon}
       />
       <View style={styles.replyContextContent}>
         {canRenderInlineQuote ? (

--- a/src/components/Chat/components/ChatMessage/renderers/SharedChatSourceLabel.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/SharedChatSourceLabel.tsx
@@ -4,7 +4,12 @@ import { SymbolView } from '@app/components/ui/Icon/Icon';
 import { Text } from '@app/components/ui/Text/Text';
 import i18next from '@app/i18n/i18next';
 
-import { CHAT_SURFACE_COLORS, type ChatFontScale } from '../chatScale';
+import {
+  CHAT_SURFACE_COLORS,
+  type ChatFontScale,
+  densityFromCompact,
+  getChatScale,
+} from '../chatScale';
 import { getChatTextStyles } from '../chatText.styles';
 import { styles } from '../RichChatMessage.styles';
 
@@ -21,7 +26,7 @@ export function SharedChatSourceLabel({
     <View style={styles.sharedChatLabelRow}>
       <SymbolView
         name='bubble.left.and.bubble.right.fill'
-        size={12}
+        size={getChatScale(fontScale, densityFromCompact(compact)).metaIconSize}
         tintColor={CHAT_SURFACE_COLORS.muted}
       />
       <Text

--- a/src/components/ui/Icon/sfSymbolToAndroid.ts
+++ b/src/components/ui/Icon/sfSymbolToAndroid.ts
@@ -24,7 +24,6 @@ const MAP: Record<string, AndroidSymbol> = {
   'book.closed': 'book',
   'bubble.left.and.bubble.right': 'forum',
   'bubble.left.and.bubble.right.fill': 'forum',
-  'bubble.left.fill': 'chat',
   'chart.bar': 'bar_chart',
   'chart.bar.xaxis': 'insert_chart',
   checkmark: 'check',


### PR DESCRIPTION
# Why

Reply rows should read like the reference rendering: an outlined text-bubble glyph at full brightness next to the "Replying to @user: body" line, instead of the solid filled bubble at 0.8 opacity.

# How

- swapped the reply header icon from `bubble.left.fill` to `text.bubble` (already mapped to `chat_bubble` for Android)
- removed the 0.8 opacity dim so the icon sits at the same brightness as the header text, and dropped the now-redundant reply-to-you opacity override

# Test Plan

- compared before/after against the reference screenshot on the iPhone 17 Pro sim via the chat preferences preview - glyph and brightness now match
- RichChatMessage suite (40 tests) passes; tsc + eslint clean