### PR TITLE
fix(chat): stop blank emote and badge slots under memory pressure

### DIFF
--- a/patches/expo-image@57.0.1.patch
+++ b/patches/expo-image@57.0.1.patch
@@ -1,3 +1,6 @@
+diff --git a/node_modules/expo-image/.bun-tag-34c8cb656dcf677f b/.bun-tag-34c8cb656dcf677f
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/ios/AnimatedImage.swift b/ios/AnimatedImage.swift
 index 350c9e4d90680baf8370e49b3529f6e45781244e..fd438254be1cfd1b4c057a426fa95c9c20943824 100644
 --- a/ios/AnimatedImage.swift
@@ -78,6 +81,22 @@ index de6e2c368e45bedd01e563cf254c006190aca233..cd29dcd08631da9c703175756882af01
  
      if let maxSize = options.getMaxSize() {
        // Note that setting the thumbnail size rasterizes vector images into a bitmap.
+diff --git a/ios/ImageModule.swift b/ios/ImageModule.swift
+index 974047c904a8776f542266ededdc3db3e7149bf6..f4603610bea5574e5d6a43cd945068d6ce30ad1d 100644
+--- a/ios/ImageModule.swift
++++ b/ios/ImageModule.swift
+@@ -28,6 +28,11 @@ public final class ImageModule: Module {
+       Prop("source") { (view: ImageView, sources: Either<[ImageSource], SharedRef<UIImage>>?) in
+         if let imageRef: SharedRef<UIImage> = sources?.get() {
+           // Unset an array of traditional sources and just render the image ref right away.
++          // Cancel any in-flight uri load first: `reload()` early-returns before its own
++          // cancel on the ref path, so an abandoned SDWebImage operation would otherwise
++          // keep running behind the displayed ref and deliver a stale onError/onLoad for
++          // a source the view no longer shows.
++          view.cancelPendingOperation()
+           view.sources = nil
+           view.renderSourceImage(imageRef.ref)
+         } else {
 diff --git a/ios/ImageView.swift b/ios/ImageView.swift
 index cccedd7adf7328b18bb61333c3fe2473c79e72cd..8917134a516b206eda2bead68bbe151d8d3efc16 100644
 --- a/ios/ImageView.swift

--- a/src/Providers/CachedEmotesProvider/__tests__/cache-service.test.ts
+++ b/src/Providers/CachedEmotesProvider/__tests__/cache-service.test.ts
@@ -21,9 +21,10 @@ import {
   warmCachedEmoteRefs,
 } from '@app/Providers/CachedEmotesProvider/cache-service';
 
-const MAX_DECODED_BYTES_HIGH_TIER = 192 * 1024 * 1024;
-// 192MiB / (96*96*4 bytes * 8 animated factor) ≈ 682 refs before the count cap.
-const HIGH_TIER_BYTE_BUDGET_ANIMATED_ENTRIES = 682;
+// 5% of the mocked 8GB device (under the 600MB high-tier ceiling).
+const MAX_DECODED_BYTES_HIGH_TIER = Math.floor(8 * 1024 * 1024 * 1024 * 0.05);
+// ~409.6MiB / (96*96*4 bytes * 8 animated factor) ≈ 1456 refs before the count cap.
+const HIGH_TIER_BYTE_BUDGET_ANIMATED_ENTRIES = 1456;
 
 const makeImageRef = (overrides: Partial<ImageRef> = {}): ImageRef =>
   ({ ...overrides }) as ImageRef;
@@ -222,11 +223,11 @@ describe('cache-service', () => {
 
   test('eviction drops the least-recently-touched unpinned ref', async () => {
     const urls = Array.from(
-      { length: 1200 },
+      { length: 2400 },
       (_, i) => `https://cdn.7tv.app/emote/lru${i}/2x_static.avif`,
     );
     await warmCachedEmoteRefs(urls);
-    expect(getCachedEmoteStats().decoded).toBe(1200);
+    expect(getCachedEmoteStats().decoded).toBe(2400);
 
     // Mark the oldest-decoded entry as most-recently-used.
     touchCachedEmoteRef(urls[0]!);
@@ -235,18 +236,18 @@ describe('cache-service', () => {
       'https://cdn.7tv.app/emote/lruExtra/2x_static.avif',
     ]);
 
-    expect(getCachedEmoteStats().decoded).toBe(1200);
+    expect(getCachedEmoteStats().decoded).toBe(2400);
     expect(getCachedEmoteRef(urls[0]!)).toEqual({});
     expect(getCachedEmoteRef(urls[1]!)).toBeNull();
   });
 
   test('evicts to stay under the decoded-byte budget before the entry-count cap', async () => {
-    // Animated decodes cost 8x a static one, so the 192MiB byte budget caps the
-    // cache far below the 1200-entry count backstop.
+    // Animated decodes cost 8x a static one, so the byte budget caps the cache
+    // far below the 2400-entry count backstop.
     loadAsync.mockResolvedValue(animatedRef());
 
     const urls = Array.from(
-      { length: 900 },
+      { length: 1600 },
       (_, i) => `https://cdn.7tv.app/emote/big${i}/2x.avif`,
     );
     await warmCachedEmoteRefs(urls);
@@ -273,7 +274,7 @@ describe('cache-service', () => {
 
     await warmCachedEmoteRefs(
       Array.from(
-        { length: 900 },
+        { length: 1600 },
         (_, i) => `https://cdn.7tv.app/emote/bigChurn${i}/2x.avif`,
       ),
     );
@@ -303,13 +304,29 @@ describe('cache-service', () => {
     unsubscribe();
   });
 
+  test('an advisory trim keeps refs mounted rows are subscribed to', async () => {
+    const mountedUrl = 'https://cdn.7tv.app/emote/advMounted/2x.avif';
+    const offscreenUrl = 'https://cdn.7tv.app/emote/advOffscreen/2x.avif';
+    await warmCachedEmoteRefs([mountedUrl, offscreenUrl]);
+    const unsubscribe = subscribeCachedEmoteRef(mountedUrl, jest.fn());
+
+    trimCachedEmoteRefsForMemoryPressure({
+      keepSubscribed: true,
+      throttled: true,
+    });
+
+    expect(getCachedEmoteRef(mountedUrl)).toEqual({});
+    expect(getCachedEmoteRef(offscreenUrl)).toBeNull();
+    unsubscribe();
+  });
+
   test('the byte budget never evicts pinned refs', async () => {
     loadAsync.mockResolvedValue(animatedRef());
     const pinnedUrl = 'https://cdn.7tv.app/emote/bigPinned/2x.avif';
     await warmCachedEmoteRefs([pinnedUrl], { pin: true });
 
     const unpinned = Array.from(
-      { length: 900 },
+      { length: 1600 },
       (_, i) => `https://cdn.7tv.app/emote/bigUnpinned${i}/2x.avif`,
     );
     await warmCachedEmoteRefs(unpinned);

--- a/src/Providers/CachedEmotesProvider/cache-service.ts
+++ b/src/Providers/CachedEmotesProvider/cache-service.ts
@@ -49,12 +49,9 @@ const MAX_ENTRIES = isLowTier ? 1200 : 2400;
  * Instruments Allocations / vmmap capture.
  *
  * Derived from device RAM (~5%) rather than a flat per-tier constant so the
- * working set scales down on smaller phones instead of every device sharing one
- * ceiling. Clamped to per-tier bounds (a 12GB phone lands at the 600MB
- * high-tier ceiling, a ~4GB phone gets ~200MB). Raised 2026-08-08 alongside
- * the keep-subscribed advisory trims: the smaller budget forced cold re-decodes
- * of the on-screen working set on constrained devices, which read as blank
- * badge/emote slots in busy chats.
+ * working set scales down on smaller phones, clamped to per-tier bounds. Too
+ * small a budget re-decodes the on-screen working set cold after every trim,
+ * which reads as blank badge/emote slots in busy chats.
  */
 const MAX_DECODED_BYTES = (() => {
   const ceil = isLowTier ? 128 * 1024 * 1024 : 600 * 1024 * 1024;
@@ -116,10 +113,10 @@ let releaseFlushScheduled = false;
 const MAX_RELEASE_DEFER_FRAMES = 2;
 
 /**
- * One shared sweep per flush rather than a pair of rAF closures per url: a
- * channel hop or pressure trim releases hundreds of refs in one tick. Each url
- * stays marked for one to two frames, which still covers the
- * subscribe-after-release race the marker exists to detect.
+ * One sweep per flush: a channel hop or pressure trim releases hundreds of
+ * refs in one tick, too many for a pair of rAF closures each. A url stays
+ * marked one to two frames, still covering the subscribe-after-release race
+ * the marker exists to detect.
  */
 let recentlyReleasedSweepScheduled = false;
 
@@ -475,12 +472,12 @@ type MemoryPressureTrimOptions = {
    */
   clearImageCache?: boolean;
   /**
-   * Advisory trims keep refs with live listeners. The on-screen working set is
-   * a bounded screenful and the memory win is the offscreen inventory, while
-   * dropping a subscribed ref forces every mounted row through a cold
-   * disk-read and decode-queue pass - the blank-badge churn seen on
-   * constrained devices. Free-memory-now signals (`memoryWarning`,
-   * backgrounding) never set it.
+   * Advisory trims keep refs with live listeners: the on-screen working set
+   * is a bounded screenful, the memory win is the offscreen inventory, and
+   * dropping a subscribed ref sends every mounted row through a cold
+   * disk-read and decode-queue pass (blank-badge churn on constrained
+   * devices). Free-memory-now signals (`memoryWarning`, backgrounding) never
+   * set it.
    */
   keepSubscribed?: boolean;
   /**

--- a/src/Providers/CachedEmotesProvider/cache-service.ts
+++ b/src/Providers/CachedEmotesProvider/cache-service.ts
@@ -36,7 +36,7 @@ const isLowTier = getDeviceTier() === 'low';
  */
 export const EMOTE_DECODE_MAX_PX = isLowTier ? 64 : 96;
 
-const MAX_ENTRIES = isLowTier ? 600 : 1200;
+const MAX_ENTRIES = isLowTier ? 1200 : 2400;
 
 /**
  * Hard ceiling on resident decoded-bitmap memory. The entry count alone is a
@@ -48,33 +48,38 @@ const MAX_ENTRIES = isLowTier ? 600 : 1200;
  * MAX_ENTRIES is now a backstop. Heuristic — tune against an on-device
  * Instruments Allocations / vmmap capture.
  *
- * Derived from device RAM (~2.5%) rather than a flat per-tier constant so the
+ * Derived from device RAM (~5%) rather than a flat per-tier constant so the
  * working set scales down on smaller phones instead of every device sharing one
- * ceiling. Clamped to the previous per-tier bounds as a floor/ceiling so
- * behaviour is unchanged on the devices those constants were tuned for (a 12GB
- * phone still lands at the 192MB high-tier ceiling) while a ~4GB phone gets
- * ~100MB instead of the full 192MB.
+ * ceiling. Clamped to per-tier bounds (a 12GB phone lands at the 600MB
+ * high-tier ceiling, a ~4GB phone gets ~200MB). Raised 2026-08-08 alongside
+ * the keep-subscribed advisory trims: the smaller budget forced cold re-decodes
+ * of the on-screen working set on constrained devices, which read as blank
+ * badge/emote slots in busy chats.
  */
 const MAX_DECODED_BYTES = (() => {
-  const ceil = isLowTier ? 64 * 1024 * 1024 : 192 * 1024 * 1024;
-  const floor = isLowTier ? 48 * 1024 * 1024 : 96 * 1024 * 1024;
+  const ceil = isLowTier ? 128 * 1024 * 1024 : 600 * 1024 * 1024;
+  const floor = isLowTier ? 96 * 1024 * 1024 : 192 * 1024 * 1024;
   const totalMemoryBytes = getTotalDeviceMemoryBytes();
   if (totalMemoryBytes <= 0) {
     return ceil;
   }
-  return Math.max(floor, Math.min(ceil, Math.floor(totalMemoryBytes * 0.025)));
+  return Math.max(floor, Math.min(ceil, Math.floor(totalMemoryBytes * 0.05)));
 })();
 const ANIMATED_BYTE_FACTOR = 8;
 
-const refs = new Map<string, ImageRef>();
-const refBytes = new Map<string, number>();
-/**
- * Intrinsic aspect ratio (logical width / height) captured off each decoded ref,
- * so the renderer can size emotes whose provider doesn't advertise dimensions.
- * Warm-decoded channel emotes usually have this before they first render, so the
- * common case corrects with no visible layout shift.
- */
-const refAspect = new Map<string, number>();
+type CacheEntry = {
+  ref: ImageRef;
+  bytes: number;
+  /**
+   * Intrinsic aspect ratio (logical width / height) captured off the decoded
+   * ref, so the renderer can size emotes whose provider doesn't advertise
+   * dimensions. Warm-decoded channel emotes usually have this before they
+   * first render, so the common case corrects with no visible layout shift.
+   */
+  aspect: number | null;
+};
+
+const refs = new Map<string, CacheEntry>();
 let totalBytes = 0;
 const pinned = new Set<string>();
 /**
@@ -100,15 +105,6 @@ function estimateRefBytes(animated: boolean, maxPx: number): number {
   return Math.round(animated ? pixelBytes * ANIMATED_BYTE_FACTOR : pixelBytes);
 }
 
-function dropRefBytes(url: string): void {
-  const cost = refBytes.get(url);
-  if (cost !== undefined) {
-    totalBytes -= cost;
-    refBytes.delete(url);
-  }
-  refAspect.delete(url);
-}
-
 const pendingReleases: { url: string; ref: ImageRef; frames: number }[] = [];
 let releaseFlushScheduled = false;
 
@@ -119,13 +115,34 @@ let releaseFlushScheduled = false;
  */
 const MAX_RELEASE_DEFER_FRAMES = 2;
 
-function markRecentlyReleased(url: string): void {
-  recentlyReleased.add(url);
+/**
+ * A single shared sweep per flush replaces a pair of rAF closures per url; a
+ * channel hop or pressure trim releases hundreds of refs in one tick. Each url
+ * stays marked for one to two frames, which still covers the
+ * subscribe-after-release race the marker exists to detect.
+ */
+let recentlyReleasedSweepScheduled = false;
+
+function scheduleRecentlyReleasedSweep(): void {
+  if (recentlyReleasedSweepScheduled) {
+    return;
+  }
+  recentlyReleasedSweepScheduled = true;
   requestAnimationFrame(() => {
+    const sweep = [...recentlyReleased];
     requestAnimationFrame(() => {
-      recentlyReleased.delete(url);
+      recentlyReleasedSweepScheduled = false;
+      sweep.forEach(url => recentlyReleased.delete(url));
+      if (recentlyReleased.size > 0) {
+        scheduleRecentlyReleasedSweep();
+      }
     });
   });
+}
+
+function markRecentlyReleased(url: string): void {
+  recentlyReleased.add(url);
+  scheduleRecentlyReleasedSweep();
 }
 
 /**
@@ -175,15 +192,16 @@ function flushPendingReleases(): void {
  * under memory pressure). Returns whether the url was cached.
  */
 function releaseRef(url: string): boolean {
-  const ref = refs.get(url);
-  if (ref) {
-    pendingReleases.push({ url, ref, frames: 0 });
-    if (!releaseFlushScheduled) {
-      releaseFlushScheduled = true;
-      requestAnimationFrame(flushPendingReleases);
-    }
+  const entry = refs.get(url);
+  if (!entry) {
+    return false;
   }
-  dropRefBytes(url);
+  pendingReleases.push({ url, ref: entry.ref, frames: 0 });
+  if (!releaseFlushScheduled) {
+    releaseFlushScheduled = true;
+    requestAnimationFrame(flushPendingReleases);
+  }
+  totalBytes -= entry.bytes;
   return refs.delete(url);
 }
 
@@ -199,8 +217,8 @@ function withinBudget(incomingBytes: number): boolean {
  * unpinned entry remains so a fully-pinned cache can still grow rather than spin.
  *
  * A live listener is skipped alongside a pin: `flushPendingReleases` won't free a
- * bitmap anything is subscribed to, so evicting one frees nothing while
- * `dropRefBytes` un-counts its bytes. The budget then under-reports and the cache
+ * bitmap anything is subscribed to, so evicting one frees nothing while the
+ * budget stops counting its bytes. The budget then under-reports and the cache
  * over-commits into real memory pressure.
  */
 function evictUnpinnedToFit(incomingBytes: number): void {
@@ -270,7 +288,7 @@ function notifyAll(): void {
 }
 
 export function getCachedEmoteRef(url: string): ImageRef | null {
-  return refs.get(url) ?? null;
+  return refs.get(url)?.ref ?? null;
 }
 
 /**
@@ -279,7 +297,7 @@ export function getCachedEmoteRef(url: string): ImageRef | null {
  * provider doesn't advertise dimensions (Twitch, BTTV).
  */
 export function getCachedEmoteAspectRatio(url: string): number | null {
-  return refAspect.get(url) ?? null;
+  return refs.get(url)?.aspect ?? null;
 }
 
 /**
@@ -288,10 +306,10 @@ export function getCachedEmoteAspectRatio(url: string): number | null {
  * Kept out of getCachedEmoteRef so the useSyncExternalStore snapshot stays pure.
  */
 export function touchCachedEmoteRef(url: string): void {
-  const ref = refs.get(url);
-  if (ref !== undefined) {
+  const entry = refs.get(url);
+  if (entry !== undefined) {
     refs.delete(url);
-    refs.set(url, ref);
+    refs.set(url, entry);
   }
 }
 
@@ -342,15 +360,15 @@ async function runDecode(
       maxPx,
     );
     evictUnpinnedToFit(cost);
-    refs.set(url, ref);
-    refBytes.set(url, cost);
-    totalBytes += cost;
     // Reading width/height off the ref is a JSI hop, but it's a one-off right
     // after the (far costlier) decode, and lets a dimensionless emote render at
     // its true aspect ratio instead of a 1:1 box.
-    if (ref.width > 0 && ref.height > 0) {
-      refAspect.set(url, ref.width / ref.height);
-    }
+    refs.set(url, {
+      ref,
+      bytes: cost,
+      aspect: ref.width > 0 && ref.height > 0 ? ref.width / ref.height : null,
+    });
+    totalBytes += cost;
     if (pin) {
       pinned.add(url);
     }
@@ -418,17 +436,21 @@ export function evictCachedEmoteRef(url: string): void {
   }
 }
 
-export function releaseChannelEmoteRefs(): void {
-  const dropped: string[] = [];
+export function releaseChannelEmoteRefs({
+  keepSubscribed = false,
+}: { keepSubscribed?: boolean } = {}): void {
+  // Deleting the current key is well-defined during Map iteration, so this
+  // sheds in a single pass; evictUnpinnedToFit relies on the same behaviour.
   for (const url of refs.keys()) {
-    if (!pinned.has(url)) {
-      dropped.push(url);
+    if (pinned.has(url)) {
+      continue;
     }
-  }
-  dropped.forEach(url => {
+    if (keepSubscribed && listeners.has(url)) {
+      continue;
+    }
     releaseRef(url);
     notify(url);
-  });
+  }
 }
 
 export function clearCachedEmoteRefs(): void {
@@ -436,9 +458,6 @@ export function clearCachedEmoteRefs(): void {
   for (const url of refs.keys()) {
     releaseRef(url);
   }
-  refs.clear();
-  refBytes.clear();
-  refAspect.clear();
   totalBytes = 0;
   inflight.clear();
   pinned.clear();
@@ -456,6 +475,15 @@ type MemoryPressureTrimOptions = {
    */
   clearImageCache?: boolean;
   /**
+   * Advisory trims keep refs with live listeners. The on-screen working set is
+   * a bounded screenful and the memory win is the offscreen inventory, while
+   * dropping a subscribed ref forces every mounted row through a cold
+   * disk-read and decode-queue pass - the blank-badge churn seen on
+   * constrained devices. Free-memory-now signals (`memoryWarning`,
+   * backgrounding) never set it.
+   */
+  keepSubscribed?: boolean;
+  /**
    * Recurring triggers (the 5s poll, repeated onTrimMemory) throttle the wipe.
    * `memoryWarning` and backgrounding are free-memory-now signals: never set it.
    */
@@ -464,9 +492,10 @@ type MemoryPressureTrimOptions = {
 
 export function trimCachedEmoteRefsForMemoryPressure({
   clearImageCache = true,
+  keepSubscribed = false,
   throttled = false,
 }: MemoryPressureTrimOptions = {}): void {
-  releaseChannelEmoteRefs();
+  releaseChannelEmoteRefs({ keepSubscribed });
   if (!clearImageCache) {
     return;
   }
@@ -513,6 +542,7 @@ function logMemoryPressureTrim(
     ...cause,
     decodedBytes: totalBytes,
     decodedRefs: refs.size,
+    subscribedRefs: listeners.size,
   });
 }
 
@@ -528,13 +558,17 @@ function pollMemoryHeadroom(): void {
   }
 
   logMemoryPressureTrim({ availableBytes: available });
-  trimCachedEmoteRefsForMemoryPressure({ throttled: true });
+  trimCachedEmoteRefsForMemoryPressure({
+    keepSubscribed: true,
+    throttled: true,
+  });
 }
 
 function handleNativeMemoryPressure(event: ImageMemoryPressureEvent): void {
   logMemoryPressureTrim({ trimLevel: event.level });
   trimCachedEmoteRefsForMemoryPressure({
     clearImageCache: event.level >= ANDROID_TRIM_MEMORY_RUNNING_CRITICAL,
+    keepSubscribed: true,
     throttled: true,
   });
 }

--- a/src/Providers/CachedEmotesProvider/cache-service.ts
+++ b/src/Providers/CachedEmotesProvider/cache-service.ts
@@ -116,7 +116,7 @@ let releaseFlushScheduled = false;
 const MAX_RELEASE_DEFER_FRAMES = 2;
 
 /**
- * A single shared sweep per flush replaces a pair of rAF closures per url; a
+ * One shared sweep per flush rather than a pair of rAF closures per url: a
  * channel hop or pressure trim releases hundreds of refs in one tick. Each url
  * stays marked for one to two frames, which still covers the
  * subscribe-after-release race the marker exists to detect.

--- a/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
@@ -17,7 +17,11 @@ import {
   type ViewStyle,
 } from 'react-native';
 
-import { Image as ExpoImage, type ImageErrorEventData } from 'expo-image';
+import {
+  Image as ExpoImage,
+  type ImageErrorEventData,
+  type ImageRef,
+} from 'expo-image';
 
 import { chatScrollActivity } from '@app/components/Chat/util/chatScrollActivity';
 import { resolveUseAppleWebpCodec } from '@app/lib/expo-image/resolveUseAppleWebpCodec';
@@ -89,6 +93,7 @@ interface ChatInlineImageProps {
   transitionMs?: number;
 }
 
+// eslint-disable-next-line react-doctor/no-giant-component -- one recycling-aware load state machine; a split adds a mount boundary on the hottest chat path
 function ChatInlineImageComponent({
   collapseWhenFailed = false,
   containerStyle,
@@ -130,9 +135,11 @@ function ChatInlineImageComponent({
   const [failedRefUrl, setFailedRefUrl] = useState<string | null>(null);
   // The exact ref instance that has drawn, recorded by onDisplay. It lives on
   // a ref rather than in state so the healthy cached-emote path never
-  // re-renders, and the identity comparison self-invalidates across recycles
-  // and re-decodes, so it never needs a reset.
-  const displayedSharedRef = useRef<unknown>(null);
+  // re-renders. Identity self-invalidates a re-decode (a new instance never
+  // matches), but a recycle back to a url whose instance is still cached would
+  // inherit "drawn" from the previous mount, so the url-change effect below
+  // clears it.
+  const displayedSharedRef = useRef<ImageRef | null>(null);
 
   const showRef = sharedRef != null && failedRefUrl !== sourceUrl;
   const isCurrentUrl = load.url === sourceUrl && load.viaRef === showRef;
@@ -144,6 +151,7 @@ function ChatInlineImageComponent({
 
   // A ban belongs to the mount that issued it. Without this reset, a slot that
   // once banned a ref would keep the ban when it recycles back to the same url.
+  // eslint-disable-next-line react-doctor/rerender-state-only-in-handlers, react-doctor/no-derived-useState -- React's reset-state-on-prop-change pattern; the render-phase setState on a url change is the point, not a stale copy
   const [banOwnerUrl, setBanOwnerUrl] = useState(sourceUrl);
   if (banOwnerUrl !== sourceUrl) {
     setBanOwnerUrl(sourceUrl);
@@ -151,9 +159,11 @@ function ChatInlineImageComponent({
   }
 
   // retryCountRef isn't rendered, so reset it for a recycled emote here rather
-  // than during render.
+  // than during render. The displayed marker resets with it: the recycled
+  // slot's ref has not drawn yet, however familiar the instance.
   useEffect(() => {
     retryCountRef.current = 0;
+    displayedSharedRef.current = null;
   }, [sourceUrl]);
 
   // Drop any retry timer scheduled for the previous url — it would otherwise
@@ -295,19 +305,10 @@ function ChatInlineImageComponent({
     }
   }, [sharedRef, showRef]);
 
-  const onWatchdogTimeout = useEffectEvent(() => {
-    // A displayed ref pins status at 'loading' forever (no onLoad), so the
-    // timer always fires on the ref path; the marker distinguishes "drawn,
-    // nothing to do" from "never painted, fall back to the uri".
-    if (
-      showRef &&
-      sharedRef != null &&
-      displayedSharedRef.current === sharedRef
-    ) {
-      return;
-    }
-    handleError();
-  });
+  // A displayed ref pins status at 'loading' forever (no onLoad), so the timer
+  // always fires on the ref path; handleError's displayed-ref guard turns that
+  // into a no-op for a ref that has drawn.
+  const onWatchdogTimeout = useEffectEvent(() => handleError());
   useEffect(() => {
     if (status !== 'loading') {
       return undefined;

--- a/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
@@ -133,12 +133,10 @@ function ChatInlineImageComponent({
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [failedRefUrl, setFailedRefUrl] = useState<string | null>(null);
-  // The exact ref instance that has drawn, recorded by onDisplay. It lives on
-  // a ref rather than in state so the healthy cached-emote path never
-  // re-renders. Identity self-invalidates a re-decode (a new instance never
-  // matches), but a recycle back to a url whose instance is still cached would
-  // inherit "drawn" from the previous mount, so the url-change effect below
-  // clears it.
+  // The exact ref instance that has drawn, recorded by onDisplay. Held in a
+  // ref so the healthy cached-emote path never re-renders. A re-decode
+  // self-invalidates (new instance never matches); a recycle back to a
+  // still-cached url does not, so the url-change effect below clears it.
   const displayedSharedRef = useRef<ImageRef | null>(null);
 
   const showRef = sharedRef != null && failedRefUrl !== sourceUrl;
@@ -159,8 +157,8 @@ function ChatInlineImageComponent({
   }
 
   // retryCountRef isn't rendered, so reset it for a recycled emote here rather
-  // than during render. The displayed marker resets with it: the recycled
-  // slot's ref has not drawn yet, however familiar the instance.
+  // than during render. The displayed marker resets with it: a recycled slot's
+  // ref has not drawn yet even when the instance is still cached.
   useEffect(() => {
     retryCountRef.current = 0;
     displayedSharedRef.current = null;
@@ -191,12 +189,11 @@ function ChatInlineImageComponent({
   const handleError = useCallback(
     (event?: ImageErrorEventData) => {
       if (showRef) {
-        // A ref never fires onError itself, so an error landing here is either
-        // the watchdog or a stale uri operation the native view abandoned when
-        // the ref took over. If this exact ref instance has already drawn
-        // (onDisplay fired for it), the error says nothing about what is on
-        // screen; acting on it would ban a healthy ref and clear the native
-        // image mid-display.
+        // A ref never fires onError itself, so an error here is the watchdog
+        // or a stale uri operation the native view abandoned when the ref
+        // took over. If this exact instance has drawn (onDisplay fired), the
+        // error says nothing about what is on screen; acting on it would ban
+        // a healthy ref and clear the native image mid-display.
         if (sharedRef != null && displayedSharedRef.current === sharedRef) {
           return;
         }

--- a/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/ChatInlineImage.tsx
@@ -128,6 +128,11 @@ function ChatInlineImageComponent({
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [failedRefUrl, setFailedRefUrl] = useState<string | null>(null);
+  // The exact ref instance that has drawn, recorded by onDisplay. It lives on
+  // a ref rather than in state so the healthy cached-emote path never
+  // re-renders, and the identity comparison self-invalidates across recycles
+  // and re-decodes, so it never needs a reset.
+  const displayedSharedRef = useRef<unknown>(null);
 
   const showRef = sharedRef != null && failedRefUrl !== sourceUrl;
   const isCurrentUrl = load.url === sourceUrl && load.viaRef === showRef;
@@ -136,6 +141,14 @@ function ChatInlineImageComponent({
 
   const candidateUrl =
     fallbackChain[candidateIndex] ?? fallbackChain[0] ?? sourceUrl;
+
+  // A ban belongs to the mount that issued it. Without this reset, a slot that
+  // once banned a ref would keep the ban when it recycles back to the same url.
+  const [banOwnerUrl, setBanOwnerUrl] = useState(sourceUrl);
+  if (banOwnerUrl !== sourceUrl) {
+    setBanOwnerUrl(sourceUrl);
+    setFailedRefUrl(null);
+  }
 
   // retryCountRef isn't rendered, so reset it for a recycled emote here rather
   // than during render.
@@ -167,12 +180,22 @@ function ChatInlineImageComponent({
 
   const handleError = useCallback(
     (event?: ImageErrorEventData) => {
-      // A decoded ref that failed to draw says nothing about the url, which has
-      // not been tried at all yet - so hand off to the fallback chain from the
-      // top with a full budget rather than spending it here. A badge url derives
-      // no variants, so under `maxRetryAttempts: 0` the shared give-up branch
-      // below would otherwise log a load failure the network never saw.
       if (showRef) {
+        // A ref never fires onError itself, so an error landing here is either
+        // the watchdog or a stale uri operation the native view abandoned when
+        // the ref took over. If this exact ref instance has already drawn
+        // (onDisplay fired for it), the error says nothing about what is on
+        // screen; acting on it would ban a healthy ref and clear the native
+        // image mid-display.
+        if (sharedRef != null && displayedSharedRef.current === sharedRef) {
+          return;
+        }
+        // Otherwise the ref never drew, which says nothing about the url: it
+        // has not been tried at all yet, so hand off to the fallback chain
+        // from the top with a full budget rather than spending it here. A
+        // badge url derives no variants, so under `maxRetryAttempts: 0` the
+        // shared give-up branch below would otherwise log a load failure the
+        // network never saw.
         setFailedRefUrl(sourceUrl);
         retryCountRef.current = 0;
         setLoad({ index: 0, status: 'loading', url: sourceUrl, viaRef: false });
@@ -258,19 +281,35 @@ function ChatInlineImageComponent({
       candidateUrl,
       fallbackChain,
       maxRetryAttempts,
+      sharedRef,
       showRef,
       sourceUrl,
     ],
   );
 
-  const onWatchdogTimeout = useEffectEvent(() => handleError());
-  // The `showRef` guard is load-bearing, not an oversight: expo-image dispatches
-  // `onLoad` only from the uri path (`ImageView.swift` fires `onDisplay` for a
-  // SharedRef), so `status` never leaves 'loading' while a ref is drawn. Watching
-  // that path would arm a timer on every healthy cached emote and fire it,
-  // throwing the decoded ref away for a disk re-read.
+  // A SharedRef source fires only onDisplay, never onLoad or onError, so this
+  // marker is the ref path's sole liveness signal.
+  const handleDisplay = useCallback(() => {
+    if (showRef) {
+      displayedSharedRef.current = sharedRef;
+    }
+  }, [sharedRef, showRef]);
+
+  const onWatchdogTimeout = useEffectEvent(() => {
+    // A displayed ref pins status at 'loading' forever (no onLoad), so the
+    // timer always fires on the ref path; the marker distinguishes "drawn,
+    // nothing to do" from "never painted, fall back to the uri".
+    if (
+      showRef &&
+      sharedRef != null &&
+      displayedSharedRef.current === sharedRef
+    ) {
+      return;
+    }
+    handleError();
+  });
   useEffect(() => {
-    if (showRef || status !== 'loading') {
+    if (status !== 'loading') {
       return undefined;
     }
     const timer = setTimeout(onWatchdogTimeout, LOAD_WATCHDOG_MS);
@@ -341,6 +380,7 @@ function ChatInlineImageComponent({
       useAppleWebpCodec={resolveUseAppleWebpCodec(urlKind)}
       priority={priority}
       transition={transitionMs}
+      onDisplay={handleDisplay}
       onLoad={handleLoad}
       onError={handleError}
       style={overlayVisible ? StyleSheet.absoluteFill : style}

--- a/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
@@ -603,6 +603,32 @@ describe('ChatInlineImage shared-ref recovery', () => {
     expect(mockImageProps?.source).toEqual({ uri: sourceUrl });
   });
 
+  test('a recycled slot does not inherit the previous mount displayed marker', () => {
+    mockSharedRef = { isAnimated: false };
+    const sourceUrl = 'https://static-cdn.jtvnw.net/badges/v1/comeback/3';
+    const { rerender } = render(
+      <ChatInlineImage sourceUrl={sourceUrl} style={{}} maxRetryAttempts={0} />,
+    );
+    act(() => mockImageProps?.onDisplay?.());
+
+    rerender(
+      <ChatInlineImage
+        sourceUrl='https://static-cdn.jtvnw.net/badges/v1/detour/3'
+        style={{}}
+        maxRetryAttempts={0}
+      />,
+    );
+    rerender(
+      <ChatInlineImage sourceUrl={sourceUrl} style={{}} maxRetryAttempts={0} />,
+    );
+
+    // The still-cached ref instance matches the first mount's marker, but it
+    // has not drawn since the recycle - the watchdog must still cover it.
+    act(() => jest.advanceTimersByTime(12_000));
+
+    expect(mockImageProps?.source).toEqual({ uri: sourceUrl });
+  });
+
   test('recycling to a new url clears a previous ref ban', () => {
     mockSharedRef = { isAnimated: false };
     const bannedUrl = 'https://static-cdn.jtvnw.net/badges/v1/banned/3';

--- a/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
+++ b/src/components/Chat/components/ChatMessage/renderers/__tests__/ChatInlineImage.test.tsx
@@ -13,6 +13,7 @@ const mockStartAnimating = jest.fn();
 const mockStopAnimating = jest.fn();
 
 let mockImageProps: {
+  onDisplay?: () => void;
   onError?: () => void;
   onLoad?: () => void;
   recyclingKey?: string;
@@ -27,6 +28,7 @@ jest.mock('expo-image', () => {
     Image: ReactModule.forwardRef(
       (
         props: {
+          onDisplay?: () => void;
           onError?: () => void;
           onLoad?: () => void;
           recyclingKey?: string;
@@ -569,16 +571,58 @@ describe('ChatInlineImage shared-ref recovery', () => {
     expect(mockImageProps?.source).toEqual({ uri: sourceUrl });
   });
 
-  test('leaves a drawn ref unwatched, since it never reports onLoad', () => {
+  test('a displayed ref is left alone by the watchdog and by stray errors', () => {
     mockSharedRef = { isAnimated: false };
     const sourceUrl = 'https://static-cdn.jtvnw.net/badges/v1/quiet/3';
     render(
       <ChatInlineImage sourceUrl={sourceUrl} style={{}} maxRetryAttempts={0} />,
     );
 
+    act(() => mockImageProps?.onDisplay?.());
     act(() => jest.advanceTimersByTime(60_000));
+    expect(mockImageProps?.source).toEqual(mockSharedRef);
 
+    // A stale error from the uri operation the native view abandoned when the
+    // ref took over says nothing about the drawn ref.
+    act(() => mockImageProps?.onError?.());
+    expect(mockImageProps?.source).toEqual(mockSharedRef);
     expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  test('a ref that never draws is watchdogged onto the uri fallback', () => {
+    mockSharedRef = { isAnimated: false };
+    const sourceUrl = 'https://static-cdn.jtvnw.net/badges/v1/silent/3';
+    render(
+      <ChatInlineImage sourceUrl={sourceUrl} style={{}} maxRetryAttempts={0} />,
+    );
+
+    expect(mockImageProps?.source).toEqual(mockSharedRef);
+
+    act(() => jest.advanceTimersByTime(12_000));
+
+    expect(mockImageProps?.source).toEqual({ uri: sourceUrl });
+  });
+
+  test('recycling to a new url clears a previous ref ban', () => {
+    mockSharedRef = { isAnimated: false };
+    const bannedUrl = 'https://static-cdn.jtvnw.net/badges/v1/banned/3';
+    const { rerender } = render(
+      <ChatInlineImage sourceUrl={bannedUrl} style={{}} maxRetryAttempts={0} />,
+    );
+    act(() => mockImageProps?.onError?.());
+    expect(mockImageProps?.source).toEqual({ uri: bannedUrl });
+
+    rerender(
+      <ChatInlineImage
+        sourceUrl='https://static-cdn.jtvnw.net/badges/v1/other/3'
+        style={{}}
+        maxRetryAttempts={0}
+      />,
+    );
+    rerender(
+      <ChatInlineImage sourceUrl={bannedUrl} style={{}} maxRetryAttempts={0} />,
+    );
+
     expect(mockImageProps?.source).toEqual(mockSharedRef);
   });
 });


### PR DESCRIPTION
# Why

Blank spaces are still showing in chat on internal builds that already carry #838/#839/#841/#848. A two-agent adversarial audit of the render path found three live mechanisms: the 5s memory-pressure poll drops every unpinned decoded ref (so every new/recycled row cold-decodes through a queue that runs seconds deep in a flood - blank badge slots on repeat), the ref render path has zero signals since the #840 watchdog revert (a ref that never paints holds a reserved-width slot blank forever, silently), and expo-image leaves an abandoned uri load running behind a displayed ref whose stale onError bans the healthy ref and clears the native image.

# How

- advisory trims (5s poll, Android onTrimMemory) now keep refs with live listeners - the on-screen working set is a bounded screenful, the memory win is the offscreen inventory. Real `memoryWarning`/backgrounding still wipe everything
- wired `onDisplay` as the ref path's liveness signal (a SharedRef fires only onDisplay, never onLoad/onError - which is why #840 rightly reverted the old watchdog). The watchdog now covers the ref path and a ref that never draws falls back to the uri; a ref that has drawn ignores stale errors from the abandoned uri operation, and a ref ban resets when the slot recycles
- expo-image patch: cancel the pending SDWebImage operation when a SharedRef source takes over (`Prop("source")`), so the stale operation can't fire at all once a build ships it; the JS-side guards cover OTA in the meantime
- raised the decoded-bitmap budget: ~5% of device RAM, clamped 192MB-600MB on high tier (128MB low), entry backstop 2400 - the old budget forced cold re-decodes of the on-screen set on exactly the devices with blank slots
- cache simplification: refs/refBytes/refAspect collapsed into one entry map, the recently-released marker sweeps once per flush instead of two rAF closures per url, and channel release sheds in a single pass

# Test Plan

- cache-service suite grown to cover keep-subscribed advisory trims and the new budgets; ChatInlineImage suite covers displayed-ref watchdog immunity, never-drawn ref fallback, stale-error immunity, and ban reset on recycle (49 tests across both)
- full ChatMessage tree passes (206 tests); tsc, eslint, prettier clean
- on device: busy channel on a constrained iPhone, watch badge slots across pressure trims; blank slots should recover within the 12s watchdog worst-case instead of never