### PR TITLE
refactor(store): halve the persisted chat blob, hoist globals, session-scope hot writes

### DIFF
--- a/src/components/Chat/hooks/__tests__/useChatRowRenderer.test.tsx
+++ b/src/components/Chat/hooks/__tests__/useChatRowRenderer.test.tsx
@@ -56,9 +56,6 @@ jest.mock('@app/store/chat/observables/chatStore', () => ({
     },
     paints: { onChange: jest.fn() },
     userPaintIds: { onChange: jest.fn() },
-    sessionCaches: {
-      userPaintFlags: { peek: jest.fn(() => ({})) },
-    },
   },
 }));
 

--- a/src/store/chat/__tests__/channelLoad.test.ts
+++ b/src/store/chat/__tests__/channelLoad.test.ts
@@ -23,6 +23,7 @@ import {
   clearCache,
   clearPersonalEmotesCache,
   clearSubscriberProfilesCache,
+  getUserPersonalEmotes,
   invalidateChatResourceCaches,
   loadChannelResources,
   resolveSubscriberChannelProfiles,
@@ -433,8 +434,7 @@ describe('loadChannelResources cache fallback', () => {
     });
 
     expect(mockGetPersonalEmoteSet).toHaveBeenCalledWith(twitchUserId);
-    const cache = chatStore$.persisted.channelCaches.peek()[channelId];
-    expect(ids(cache!.sevenTvPersonalEmotes[twitchUserId] ?? [])).toEqual([
+    expect(ids(getUserPersonalEmotes(twitchUserId, channelId))).toEqual([
       'personal-emote',
     ]);
   });

--- a/src/store/chat/__tests__/channelLoad.test.ts
+++ b/src/store/chat/__tests__/channelLoad.test.ts
@@ -34,7 +34,7 @@ import { clearGlobalResourceCache } from '../actions/channelResources';
 import { clearMessages } from '../actions/messages';
 import { chatStore$ } from '../observables/chatStore';
 import type { SubscriberChannelProfile } from '../types/constants';
-import { emptyEmoteData } from '../types/constants';
+import { emptyEmoteData, emptyGlobalCacheData } from '../types/constants';
 
 jest.mock('@legendapp/state/persist', () => ({
   configureObservablePersistence: jest.fn(),
@@ -285,6 +285,7 @@ describe('loadChannelResources cache fallback', () => {
     jest.clearAllMocks();
     jest.spyOn(Date, 'now').mockReturnValue(10_000);
     chatStore$.persisted.channelCaches.set({});
+    chatStore$.persisted.globalCaches.set({ ...emptyGlobalCacheData });
     chatStore$.currentChannelId.set(null);
     chatStore$.loadingState.set('IDLE');
     clearPersonalEmotesCache();
@@ -328,15 +329,19 @@ describe('loadChannelResources cache fallback', () => {
         ...emptyEmoteData,
         badgesLastUpdated: 2_000,
         bttvChannelEmotes: [bttvEmote('bttv-channel-cached')],
-        bttvGlobalEmotes: [bttvEmote('bttv-global-cached', 'Global BTTV')],
         ffzChannelBadges: [badge('ffz-channel-badge-cached')],
         ffzChannelEmotes: [ffzEmote('ffz-channel-cached')],
-        ffzGlobalBadges: [badge('ffz-global-badge-cached')],
-        ffzGlobalEmotes: [ffzEmote('ffz-global-cached', 'Global FFZ')],
         lastUpdated: 1_000,
         sevenTvChannelEmotes: [sevenTvEmote('seven-channel-cached')],
         sevenTvEmoteSetId: 'cached-seven-set',
       },
+    });
+    chatStore$.persisted.globalCaches.set({
+      ...emptyGlobalCacheData,
+      bttvGlobalEmotes: [bttvEmote('bttv-global-cached', 'Global BTTV')],
+      ffzGlobalBadges: [badge('ffz-global-badge-cached')],
+      ffzGlobalEmotes: [ffzEmote('ffz-global-cached', 'Global FFZ')],
+      lastUpdated: 1_000,
     });
 
     mockGetEmoteSetId.mockRejectedValue(new Error('TimeoutError'));
@@ -363,37 +368,104 @@ describe('loadChannelResources cache fallback', () => {
       'cached-seven-set',
     );
     expect(ids(cache!.sevenTvChannelEmotes)).toEqual(['seven-channel-cached']);
-    expect(ids(cache!.bttvGlobalEmotes)).toEqual(['bttv-global-cached']);
     expect(cache!.bttvChannelEmotes).toEqual([]);
     expect(ids(cache!.ffzChannelEmotes)).toEqual(['ffz-channel-cached']);
-    expect(ids(cache!.ffzGlobalEmotes)).toEqual(['ffz-global-cached']);
     expect(ids(cache!.ffzChannelBadges)).toEqual(['ffz-channel-badge-cached']);
-    expect(ids(cache!.ffzGlobalBadges)).toEqual(['ffz-global-badge-cached']);
     expect(cache!.lastUpdated).toBe(1_000);
     expect(cache!.badgesLastUpdated).toBe(2_000);
+
+    const globalCache = chatStore$.persisted.globalCaches.peek();
+    expect(ids(globalCache.bttvGlobalEmotes)).toEqual(['bttv-global-cached']);
+    expect(ids(globalCache.ffzGlobalEmotes)).toEqual(['ffz-global-cached']);
+    expect(ids(globalCache.ffzGlobalBadges)).toEqual([
+      'ffz-global-badge-cached',
+    ]);
+    expect(ids(globalCache.twitchGlobalEmotes)).toEqual(['twitch-global-new']);
+    expect(globalCache.lastUpdated).toBe(1_000);
   });
 
   test('keeps cached badge slices when stale badge refresh requests reject', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(3_700_000);
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
         ...emptyEmoteData,
-        badgesLastUpdated: 0,
-        ffzGlobalBadges: [badge('ffz-global-badge-cached')],
-        lastUpdated: 9_000,
+        badgesLastUpdated: 9_000,
+        ffzChannelBadges: [badge('ffz-channel-badge-cached')],
+        lastUpdated: 3_650_000,
+        sevenTvEmoteSetId: 'cached-seven-set',
         twitchChannelEmotes: [twitchEmote('existing-emote')],
       },
     });
+    chatStore$.persisted.globalCaches.set({
+      ...emptyGlobalCacheData,
+      lastUpdated: 3_650_000,
+      sevenTvGlobalEmotes: [sevenTvEmote('seven-global-cached')],
+    });
 
-    mockGetFfzGlobalBadges.mockRejectedValue(new Error('TimeoutError'));
+    mockGetFfzChannelBadges.mockRejectedValue(new Error('TimeoutError'));
 
     await expect(loadChannelResources({ channelId })).resolves.toBe(true);
 
     const cache = chatStore$.persisted.channelCaches.peek()[channelId];
     expect(cache).toBeDefined();
 
-    expect(ids(cache!.ffzGlobalBadges)).toEqual(['ffz-global-badge-cached']);
-    expect(cache!.badgesLastUpdated).toBe(0);
-    expect(cache!.lastUpdated).toBe(9_000);
+    expect(mockListTwitchChannelBadges).toHaveBeenCalledTimes(1);
+    expect(ids(cache!.ffzChannelBadges)).toEqual(['ffz-channel-badge-cached']);
+    expect(cache!.badgesLastUpdated).toBe(9_000);
+    expect(cache!.lastUpdated).toBe(3_650_000);
+    expect(mockGetFfzGlobalBadges).not.toHaveBeenCalled();
+  });
+
+  test('refreshes a stale global slot from the cached path without refetching channel slices', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(3_700_000);
+    chatStore$.persisted.channelCaches.set({
+      [channelId]: {
+        ...emptyEmoteData,
+        badgesLastUpdated: 3_650_000,
+        lastUpdated: 3_650_000,
+        sevenTvEmoteSetId: 'cached-seven-set',
+        twitchChannelEmotes: [twitchEmote('existing-emote')],
+      },
+    });
+    chatStore$.persisted.globalCaches.set({
+      ...emptyGlobalCacheData,
+      ffzGlobalBadges: [badge('ffz-global-badge-cached')],
+      lastUpdated: 9_000,
+      sevenTvGlobalEmotes: [sevenTvEmote('seven-global-cached')],
+    });
+
+    mockGetFfzGlobalBadges.mockRejectedValue(new Error('TimeoutError'));
+
+    await expect(loadChannelResources({ channelId })).resolves.toBe(true);
+
+    const globalCache = chatStore$.persisted.globalCaches.peek();
+    expect(ids(globalCache.bttvGlobalEmotes)).toEqual(['bttv-global-new']);
+    expect(ids(globalCache.twitchGlobalEmotes)).toEqual(['twitch-global-new']);
+    expect(ids(globalCache.ffzGlobalBadges)).toEqual([
+      'ffz-global-badge-cached',
+    ]);
+    expect(globalCache.lastUpdated).toBe(9_000);
+    expect(mockGetChannelEmotes).not.toHaveBeenCalled();
+    expect(mockListTwitchChannelBadges).not.toHaveBeenCalled();
+
+    const cache = chatStore$.persisted.channelCaches.peek()[channelId];
+    expect(cache!.lastUpdated).toBe(3_650_000);
+  });
+
+  test('a full load writes the global slices to the shared slot only', async () => {
+    await expect(loadChannelResources({ channelId })).resolves.toBe(true);
+
+    const globalCache = chatStore$.persisted.globalCaches.peek();
+    expect(ids(globalCache.twitchGlobalEmotes)).toEqual(['twitch-global-new']);
+    expect(ids(globalCache.bttvGlobalEmotes)).toEqual(['bttv-global-new']);
+    expect(ids(globalCache.ffzGlobalEmotes)).toEqual(['ffz-global-new']);
+    expect(ids(globalCache.ffzGlobalBadges)).toEqual(['ffz-global-badge-new']);
+    expect(globalCache.lastUpdated).toBe(10_000);
+
+    const cache = chatStore$.persisted.channelCaches.peek()[channelId];
+    expect(cache).toBeDefined();
+    expect('twitchGlobalEmotes' in cache!).toBe(false);
+    expect('ffzGlobalBadges' in cache!).toBe(false);
   });
 
   test('invalidating the resource caches stale-stamps the channel and drops memoised global fetches', async () => {
@@ -454,22 +526,25 @@ describe('loadChannelResources cache fallback', () => {
     const cache = chatStore$.persisted.channelCaches.peek()[channelId];
     expect(cache).toBeDefined();
     expect(cache!.sevenTvChannelEmotes).toEqual([]);
-    expect(cache!.bttvGlobalEmotes).toEqual([]);
     expect(cache!.bttvChannelEmotes).toEqual([]);
     expect(cache!.ffzChannelEmotes).toEqual([]);
-    expect(cache!.ffzGlobalEmotes).toEqual([]);
     expect(cache!.ffzChannelBadges).toEqual([]);
-    expect(cache!.ffzGlobalBadges).toEqual([]);
     expect(cache!.twitchChannelEmotes).toEqual<SanitisedEmote[]>([
       twitchEmote('twitch-channel-new'),
-    ]);
-    expect(cache!.twitchGlobalEmotes).toEqual<SanitisedEmote[]>([
-      twitchEmote('twitch-global-new', 'Twitch Global'),
     ]);
     // A first load with failed slices must stay stale-stamped so the next
     // join retries the holes instead of serving them for the cache duration.
     expect(cache!.lastUpdated).toBe(0);
     expect(cache!.badgesLastUpdated).toBe(0);
+
+    const globalCache = chatStore$.persisted.globalCaches.peek();
+    expect(globalCache.bttvGlobalEmotes).toEqual([]);
+    expect(globalCache.ffzGlobalEmotes).toEqual([]);
+    expect(globalCache.ffzGlobalBadges).toEqual([]);
+    expect(globalCache.twitchGlobalEmotes).toEqual<SanitisedEmote[]>([
+      twitchEmote('twitch-global-new', 'Twitch Global'),
+    ]);
+    expect(globalCache.lastUpdated).toBe(0);
   });
 
   test('posts a system message naming the providers whose fetch failed', async () => {
@@ -503,11 +578,15 @@ describe('loadChannelResources cache fallback', () => {
       [channelId]: {
         ...emptyEmoteData,
         badgesLastUpdated: 2_000,
-        bttvGlobalEmotes: [bttvEmote('bttv-global-cached', 'Global BTTV')],
-        ffzGlobalBadges: [badge('ffz-global-badge-cached')],
         lastUpdated: 9_000,
         twitchChannelEmotes: [twitchEmote('existing-emote')],
       },
+    });
+    chatStore$.persisted.globalCaches.set({
+      ...emptyGlobalCacheData,
+      bttvGlobalEmotes: [bttvEmote('bttv-global-cached', 'Global BTTV')],
+      ffzGlobalBadges: [badge('ffz-global-badge-cached')],
+      lastUpdated: 9_000,
     });
 
     mockGetBttvGlobalEmotes.mockRejectedValue(new Error('TimeoutError'));
@@ -537,10 +616,14 @@ describe('loadChannelResources cache fallback', () => {
       [channelId]: {
         ...emptyEmoteData,
         badgesLastUpdated: 0,
-        ffzGlobalBadges: [badge('ffz-global-badge-cached')],
         lastUpdated: 9_000,
         twitchChannelEmotes: [twitchEmote('existing-emote')],
       },
+    });
+    chatStore$.persisted.globalCaches.set({
+      ...emptyGlobalCacheData,
+      ffzGlobalBadges: [badge('ffz-global-badge-cached')],
+      lastUpdated: 9_000,
     });
 
     mockGetFfzGlobalBadges.mockRejectedValue(new Error('TimeoutError'));

--- a/src/store/chat/__tests__/channelLoad.test.ts
+++ b/src/store/chat/__tests__/channelLoad.test.ts
@@ -34,7 +34,10 @@ import { clearGlobalResourceCache } from '../actions/channelResources';
 import { clearMessages } from '../actions/messages';
 import { chatStore$ } from '../observables/chatStore';
 import type { SubscriberChannelProfile } from '../types/constants';
-import { emptyEmoteData, emptyGlobalCacheData } from '../types/constants';
+import {
+  makeEmptyEmoteData,
+  makeEmptyGlobalCacheData,
+} from '../types/constants';
 
 jest.mock('@legendapp/state/persist', () => ({
   configureObservablePersistence: jest.fn(),
@@ -285,7 +288,7 @@ describe('loadChannelResources cache fallback', () => {
     jest.clearAllMocks();
     jest.spyOn(Date, 'now').mockReturnValue(10_000);
     chatStore$.persisted.channelCaches.set({});
-    chatStore$.persisted.globalCaches.set({ ...emptyGlobalCacheData });
+    chatStore$.persisted.globalCaches.set(makeEmptyGlobalCacheData());
     chatStore$.currentChannelId.set(null);
     chatStore$.loadingState.set('IDLE');
     clearPersonalEmotesCache();
@@ -326,7 +329,7 @@ describe('loadChannelResources cache fallback', () => {
   test('keeps cached provider slices when full refresh provider requests reject', async () => {
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         badgesLastUpdated: 2_000,
         bttvChannelEmotes: [bttvEmote('bttv-channel-cached')],
         ffzChannelBadges: [badge('ffz-channel-badge-cached')],
@@ -337,7 +340,7 @@ describe('loadChannelResources cache fallback', () => {
       },
     });
     chatStore$.persisted.globalCaches.set({
-      ...emptyGlobalCacheData,
+      ...makeEmptyGlobalCacheData(),
       bttvGlobalEmotes: [bttvEmote('bttv-global-cached', 'Global BTTV')],
       ffzGlobalBadges: [badge('ffz-global-badge-cached')],
       ffzGlobalEmotes: [ffzEmote('ffz-global-cached', 'Global FFZ')],
@@ -388,7 +391,7 @@ describe('loadChannelResources cache fallback', () => {
     jest.spyOn(Date, 'now').mockReturnValue(3_700_000);
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         badgesLastUpdated: 9_000,
         ffzChannelBadges: [badge('ffz-channel-badge-cached')],
         lastUpdated: 3_650_000,
@@ -397,7 +400,7 @@ describe('loadChannelResources cache fallback', () => {
       },
     });
     chatStore$.persisted.globalCaches.set({
-      ...emptyGlobalCacheData,
+      ...makeEmptyGlobalCacheData(),
       lastUpdated: 3_650_000,
       sevenTvGlobalEmotes: [sevenTvEmote('seven-global-cached')],
     });
@@ -420,7 +423,7 @@ describe('loadChannelResources cache fallback', () => {
     jest.spyOn(Date, 'now').mockReturnValue(3_700_000);
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         badgesLastUpdated: 3_650_000,
         lastUpdated: 3_650_000,
         sevenTvEmoteSetId: 'cached-seven-set',
@@ -428,7 +431,7 @@ describe('loadChannelResources cache fallback', () => {
       },
     });
     chatStore$.persisted.globalCaches.set({
-      ...emptyGlobalCacheData,
+      ...makeEmptyGlobalCacheData(),
       ffzGlobalBadges: [badge('ffz-global-badge-cached')],
       lastUpdated: 9_000,
       sevenTvGlobalEmotes: [sevenTvEmote('seven-global-cached')],
@@ -576,14 +579,14 @@ describe('loadChannelResources cache fallback', () => {
     clearMessages();
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         badgesLastUpdated: 2_000,
         lastUpdated: 9_000,
         twitchChannelEmotes: [twitchEmote('existing-emote')],
       },
     });
     chatStore$.persisted.globalCaches.set({
-      ...emptyGlobalCacheData,
+      ...makeEmptyGlobalCacheData(),
       bttvGlobalEmotes: [bttvEmote('bttv-global-cached', 'Global BTTV')],
       ffzGlobalBadges: [badge('ffz-global-badge-cached')],
       lastUpdated: 9_000,
@@ -614,14 +617,14 @@ describe('loadChannelResources cache fallback', () => {
     jest.spyOn(Date, 'now').mockReturnValue(3_700_000);
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         badgesLastUpdated: 0,
         lastUpdated: 9_000,
         twitchChannelEmotes: [twitchEmote('existing-emote')],
       },
     });
     chatStore$.persisted.globalCaches.set({
-      ...emptyGlobalCacheData,
+      ...makeEmptyGlobalCacheData(),
       ffzGlobalBadges: [badge('ffz-global-badge-cached')],
       lastUpdated: 9_000,
     });
@@ -657,7 +660,7 @@ describe('loadChannelResources cache fallback', () => {
     chatStore$.cosmeticsCacheVersion.set(3);
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         lastUpdated: 9_000,
         twitchChannelEmotes: [twitchEmote('existing-emote')],
       },
@@ -695,7 +698,7 @@ describe('resolveSubscriberChannelProfiles', () => {
   test('resolves and stores profiles for owner ids without one', async () => {
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         twitchSubscriberEmotes: [
           { ...twitchEmote('emote1', 'Twitch Subscriber'), owner_id: '100' },
           { ...twitchEmote('emote2', 'Twitch Subscriber'), owner_id: '200' },
@@ -732,7 +735,7 @@ describe('resolveSubscriberChannelProfiles', () => {
   test('skips the lookup when every owner id already has a profile', async () => {
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         twitchSubscriberEmotes: [
           { ...twitchEmote('emote1', 'Twitch Subscriber'), owner_id: '100' },
         ],
@@ -753,7 +756,7 @@ describe('resolveSubscriberChannelProfiles', () => {
   test('keeps existing profiles when the profile lookup fails', async () => {
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         twitchSubscriberEmotes: [
           { ...twitchEmote('emote1', 'Twitch Subscriber'), owner_id: '100' },
         ],
@@ -783,7 +786,7 @@ describe('resolveSubscriberChannelProfiles', () => {
   test('excludes non-numeric owner ids from the profile lookup', async () => {
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         twitchSubscriberEmotes: [
           { ...twitchEmote('emote1', 'Twitch Subscriber'), owner_id: 'twitch' },
           { ...twitchEmote('emote2', 'Twitch Subscriber'), owner_id: '100' },
@@ -800,7 +803,7 @@ describe('resolveSubscriberChannelProfiles', () => {
   test('skips the lookup entirely when only sentinel owner ids exist', async () => {
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         twitchSubscriberEmotes: [
           { ...twitchEmote('emote1', 'Twitch Subscriber'), owner_id: 'twitch' },
         ],
@@ -816,7 +819,7 @@ describe('resolveSubscriberChannelProfiles', () => {
     const seedCache = () => {
       chatStore$.persisted.channelCaches.set({
         [channelId]: {
-          ...emptyEmoteData,
+          ...makeEmptyEmoteData(),
           twitchSubscriberEmotes: [
             { ...twitchEmote('emote1', 'Twitch Subscriber'), owner_id: '100' },
           ],
@@ -836,7 +839,7 @@ describe('resolveSubscriberChannelProfiles', () => {
     const seedCache = () => {
       chatStore$.persisted.channelCaches.set({
         [channelId]: {
-          ...emptyEmoteData,
+          ...makeEmptyEmoteData(),
           twitchSubscriberEmotes: [
             { ...twitchEmote('emote1', 'Twitch Subscriber'), owner_id: '100' },
           ],
@@ -872,7 +875,7 @@ describe('resolveSubscriberChannelProfiles', () => {
     const seedCache = () => {
       chatStore$.persisted.channelCaches.set({
         [channelId]: {
-          ...emptyEmoteData,
+          ...makeEmptyEmoteData(),
           twitchSubscriberEmotes: [
             { ...twitchEmote('emote1', 'Twitch Subscriber'), owner_id: '100' },
           ],
@@ -921,11 +924,11 @@ describe('resolveSubscriberChannelProfiles', () => {
     ];
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         twitchSubscriberEmotes: subscriberEmotes,
       },
       '999': {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         twitchSubscriberEmotes: subscriberEmotes,
       },
     });
@@ -954,7 +957,7 @@ describe('switchSevenTvEmoteSet', () => {
     jest.clearAllMocks();
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         badgesLastUpdated: 1_000,
         lastUpdated: 1_000,
         sevenTvChannelEmotes: [sevenTvEmote('emote-a')],
@@ -1010,7 +1013,7 @@ describe('updateSevenTvEmotes', () => {
   const seed = (channelEmotes: SevenTvSanitisedEmote[]) => {
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...emptyEmoteData,
+        ...makeEmptyEmoteData(),
         badgesLastUpdated: 1_000,
         lastUpdated: 1_000,
         sevenTvChannelEmotes: channelEmotes,

--- a/src/store/chat/__tests__/channelLoad.test.ts
+++ b/src/store/chat/__tests__/channelLoad.test.ts
@@ -325,17 +325,9 @@ describe('loadChannelResources cache fallback', () => {
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
         ...emptyEmoteData,
-        badges: [badge('ffz-global-badge-cached')],
         badgesLastUpdated: 2_000,
         bttvChannelEmotes: [bttvEmote('bttv-channel-cached')],
         bttvGlobalEmotes: [bttvEmote('bttv-global-cached', 'Global BTTV')],
-        emotes: [
-          sevenTvEmote('seven-channel-cached'),
-          bttvEmote('bttv-global-cached', 'Global BTTV'),
-          bttvEmote('bttv-channel-cached'),
-          ffzEmote('ffz-channel-cached'),
-          ffzEmote('ffz-global-cached', 'Global FFZ'),
-        ],
         ffzChannelBadges: [badge('ffz-channel-badge-cached')],
         ffzChannelEmotes: [ffzEmote('ffz-channel-cached')],
         ffzGlobalBadges: [badge('ffz-global-badge-cached')],
@@ -376,8 +368,6 @@ describe('loadChannelResources cache fallback', () => {
     expect(ids(cache!.ffzGlobalEmotes)).toEqual(['ffz-global-cached']);
     expect(ids(cache!.ffzChannelBadges)).toEqual(['ffz-channel-badge-cached']);
     expect(ids(cache!.ffzGlobalBadges)).toEqual(['ffz-global-badge-cached']);
-    expect(ids(cache!.emotes)).toContain('bttv-global-cached');
-    expect(ids(cache!.emotes)).not.toContain('bttv-channel-cached');
     expect(cache!.lastUpdated).toBe(1_000);
     expect(cache!.badgesLastUpdated).toBe(2_000);
   });
@@ -386,9 +376,7 @@ describe('loadChannelResources cache fallback', () => {
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
         ...emptyEmoteData,
-        badges: [badge('ffz-global-badge-cached')],
         badgesLastUpdated: 0,
-        emotes: [twitchEmote('existing-emote')],
         ffzGlobalBadges: [badge('ffz-global-badge-cached')],
         lastUpdated: 9_000,
         twitchChannelEmotes: [twitchEmote('existing-emote')],
@@ -403,7 +391,6 @@ describe('loadChannelResources cache fallback', () => {
     expect(cache).toBeDefined();
 
     expect(ids(cache!.ffzGlobalBadges)).toEqual(['ffz-global-badge-cached']);
-    expect(ids(cache!.badges)).toEqual(['ffz-global-badge-cached']);
     expect(cache!.badgesLastUpdated).toBe(0);
     expect(cache!.lastUpdated).toBe(9_000);
   });
@@ -473,8 +460,10 @@ describe('loadChannelResources cache fallback', () => {
     expect(cache!.ffzGlobalEmotes).toEqual([]);
     expect(cache!.ffzChannelBadges).toEqual([]);
     expect(cache!.ffzGlobalBadges).toEqual([]);
-    expect(cache!.emotes).toEqual<SanitisedEmote[]>([
+    expect(cache!.twitchChannelEmotes).toEqual<SanitisedEmote[]>([
       twitchEmote('twitch-channel-new'),
+    ]);
+    expect(cache!.twitchGlobalEmotes).toEqual<SanitisedEmote[]>([
       twitchEmote('twitch-global-new', 'Twitch Global'),
     ]);
     // A first load with failed slices must stay stale-stamped so the next
@@ -513,13 +502,8 @@ describe('loadChannelResources cache fallback', () => {
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
         ...emptyEmoteData,
-        badges: [badge('ffz-global-badge-cached')],
         badgesLastUpdated: 2_000,
         bttvGlobalEmotes: [bttvEmote('bttv-global-cached', 'Global BTTV')],
-        emotes: [
-          bttvEmote('bttv-global-cached', 'Global BTTV'),
-          twitchEmote('existing-emote'),
-        ],
         ffzGlobalBadges: [badge('ffz-global-badge-cached')],
         lastUpdated: 9_000,
         twitchChannelEmotes: [twitchEmote('existing-emote')],
@@ -552,9 +536,7 @@ describe('loadChannelResources cache fallback', () => {
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
         ...emptyEmoteData,
-        badges: [badge('ffz-global-badge-cached')],
         badgesLastUpdated: 0,
-        emotes: [twitchEmote('existing-emote')],
         ffzGlobalBadges: [badge('ffz-global-badge-cached')],
         lastUpdated: 9_000,
         twitchChannelEmotes: [twitchEmote('existing-emote')],
@@ -593,7 +575,6 @@ describe('loadChannelResources cache fallback', () => {
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
         ...emptyEmoteData,
-        emotes: [twitchEmote('existing-emote')],
         lastUpdated: 9_000,
         twitchChannelEmotes: [twitchEmote('existing-emote')],
       },
@@ -891,9 +872,7 @@ describe('switchSevenTvEmoteSet', () => {
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
         ...emptyEmoteData,
-        badges: [],
         badgesLastUpdated: 1_000,
-        emotes: [sevenTvEmote('emote-a')],
         lastUpdated: 1_000,
         sevenTvChannelEmotes: [sevenTvEmote('emote-a')],
         sevenTvEmoteSetId: 'set-a',
@@ -909,7 +888,6 @@ describe('switchSevenTvEmoteSet', () => {
     const cache = chatStore$.persisted.channelCaches.peek()[channelId];
     expect(cache!.sevenTvEmoteSetId).toBe('set-b');
     expect(ids(cache!.sevenTvChannelEmotes)).toEqual(['emote-b']);
-    expect(ids(cache!.emotes)).toEqual(['emote-b']);
   });
 
   test('no-ops when the cache already points at the requested set', async () => {
@@ -950,9 +928,7 @@ describe('updateSevenTvEmotes', () => {
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
         ...emptyEmoteData,
-        badges: [],
         badgesLastUpdated: 1_000,
-        emotes: channelEmotes,
         lastUpdated: 1_000,
         sevenTvChannelEmotes: channelEmotes,
         sevenTvEmoteSetId: 'set-a',

--- a/src/store/chat/__tests__/channelRefreshPlan.test.ts
+++ b/src/store/chat/__tests__/channelRefreshPlan.test.ts
@@ -6,8 +6,8 @@ import type {
   GlobalCacheType,
 } from '@app/store/chat/types/constants';
 import {
-  emptyEmoteData,
-  emptyGlobalCacheData,
+  makeEmptyEmoteData,
+  makeEmptyGlobalCacheData,
 } from '@app/store/chat/types/constants';
 import type { SevenTvSanitisedEmote } from '@app/types/emote';
 
@@ -44,7 +44,7 @@ const emote = {
 const freshCache = (
   overrides?: Partial<ChannelCacheType>,
 ): ChannelCacheType => ({
-  ...emptyEmoteData,
+  ...makeEmptyEmoteData(),
   sevenTvChannelEmotes: [emote],
   sevenTvEmoteSetId: 'set-1',
   lastUpdated: NOW - 30 * 60 * 1000,
@@ -55,7 +55,7 @@ const freshCache = (
 const freshGlobalCache = (
   overrides?: Partial<GlobalCacheType>,
 ): GlobalCacheType => ({
-  ...emptyGlobalCacheData,
+  ...makeEmptyGlobalCacheData(),
   sevenTvGlobalEmotes: [emote],
   lastUpdated: NOW - 30 * 60 * 1000,
   ...overrides,
@@ -209,7 +209,7 @@ describe('planChannelRefresh', () => {
     const plan = planChannelRefresh({
       cache: freshCache(),
       forceRefresh: false,
-      globalCache: { ...emptyGlobalCacheData, lastUpdated: NOW },
+      globalCache: { ...makeEmptyGlobalCacheData(), lastUpdated: NOW },
       now: NOW,
     });
 

--- a/src/store/chat/__tests__/channelRefreshPlan.test.ts
+++ b/src/store/chat/__tests__/channelRefreshPlan.test.ts
@@ -1,8 +1,14 @@
 import { EmoteSetKind } from '@app/graphql/generated/gql';
 import type { ChannelRefreshPlan } from '@app/store/chat/actions/channelRefreshPlan';
 import { planChannelRefresh } from '@app/store/chat/actions/channelRefreshPlan';
-import type { ChannelCacheType } from '@app/store/chat/types/constants';
-import { emptyEmoteData } from '@app/store/chat/types/constants';
+import type {
+  ChannelCacheType,
+  GlobalCacheType,
+} from '@app/store/chat/types/constants';
+import {
+  emptyEmoteData,
+  emptyGlobalCacheData,
+} from '@app/store/chat/types/constants';
 import type { SevenTvSanitisedEmote } from '@app/types/emote';
 
 const NOW = Date.parse('2026-01-01T12:00:00.000Z');
@@ -46,27 +52,58 @@ const freshCache = (
   ...overrides,
 });
 
+const freshGlobalCache = (
+  overrides?: Partial<GlobalCacheType>,
+): GlobalCacheType => ({
+  ...emptyGlobalCacheData,
+  sevenTvGlobalEmotes: [emote],
+  lastUpdated: NOW - 30 * 60 * 1000,
+  ...overrides,
+});
+
 describe('planChannelRefresh', () => {
   test('plans a full load when there is no cache', () => {
     expect(
-      planChannelRefresh({ cache: undefined, forceRefresh: false, now: NOW }),
+      planChannelRefresh({
+        cache: undefined,
+        forceRefresh: false,
+        globalCache: freshGlobalCache(),
+        now: NOW,
+      }),
     ).toEqual<ChannelRefreshPlan>({ kind: 'full' });
   });
 
   test('plans a full load on forceRefresh even with a fresh cache', () => {
     expect(
-      planChannelRefresh({ cache: freshCache(), forceRefresh: true, now: NOW }),
+      planChannelRefresh({
+        cache: freshCache(),
+        forceRefresh: true,
+        globalCache: freshGlobalCache(),
+        now: NOW,
+      }),
     ).toEqual<ChannelRefreshPlan>({ kind: 'full' });
   });
 
-  test('plans a full load when every emote slice is empty', () => {
+  test('plans a full load when every channel and global emote slice is empty', () => {
     expect(
       planChannelRefresh({
         cache: freshCache({ sevenTvChannelEmotes: [] }),
         forceRefresh: false,
+        globalCache: undefined,
         now: NOW,
       }),
     ).toEqual<ChannelRefreshPlan>({ kind: 'full' });
+  });
+
+  test('serves the cache when the channel slices are empty but globals are held', () => {
+    const plan = planChannelRefresh({
+      cache: freshCache({ sevenTvChannelEmotes: [] }),
+      forceRefresh: false,
+      globalCache: freshGlobalCache(),
+      now: NOW,
+    });
+
+    expect(plan.kind).toBe('cached');
   });
 
   test('plans a full load once the cache outlives the cache duration', () => {
@@ -74,6 +111,7 @@ describe('planChannelRefresh', () => {
       planChannelRefresh({
         cache: freshCache({ lastUpdated: NOW - HOUR_MS }),
         forceRefresh: false,
+        globalCache: freshGlobalCache(),
         now: NOW,
       }),
     ).toEqual<ChannelRefreshPlan>({ kind: 'full' });
@@ -84,6 +122,7 @@ describe('planChannelRefresh', () => {
       planChannelRefresh({
         cache: freshCache(),
         forceRefresh: false,
+        globalCache: freshGlobalCache(),
         now: NOW,
       }),
     ).toEqual<ChannelRefreshPlan>({
@@ -93,6 +132,7 @@ describe('planChannelRefresh', () => {
       fetchEmoteSetId: false,
       fetchSubscriberEmotes: false,
       refreshBadges: false,
+      refreshGlobalResources: false,
     });
   });
 
@@ -100,6 +140,7 @@ describe('planChannelRefresh', () => {
     const plan = planChannelRefresh({
       cache: freshCache({ sevenTvEmoteSetId: undefined }),
       forceRefresh: false,
+      globalCache: freshGlobalCache(),
       now: NOW,
     });
 
@@ -108,22 +149,26 @@ describe('planChannelRefresh', () => {
 
   test('requests subscriber emotes only for a different logged-in user', () => {
     const cache = freshCache({ twitchSubscriberEmotesUserId: 'user-1' });
+    const globalCache = freshGlobalCache();
 
     const samePlan = planChannelRefresh({
       cache,
       forceRefresh: false,
+      globalCache,
       now: NOW,
       twitchUserId: 'user-1',
     });
     const otherPlan = planChannelRefresh({
       cache,
       forceRefresh: false,
+      globalCache,
       now: NOW,
       twitchUserId: 'user-2',
     });
     const anonPlan = planChannelRefresh({
       cache,
       forceRefresh: false,
+      globalCache,
       now: NOW,
     });
 
@@ -142,10 +187,46 @@ describe('planChannelRefresh', () => {
     const plan = planChannelRefresh({
       cache: freshCache({ badgesLastUpdated: NOW - HOUR_MS }),
       forceRefresh: false,
+      globalCache: freshGlobalCache(),
       now: NOW,
     });
 
     expect(plan.kind === 'cached' && plan.refreshBadges).toEqual(true);
+  });
+
+  test('refreshes globals once the shared slot outlives the cache duration', () => {
+    const plan = planChannelRefresh({
+      cache: freshCache(),
+      forceRefresh: false,
+      globalCache: freshGlobalCache({ lastUpdated: NOW - HOUR_MS }),
+      now: NOW,
+    });
+
+    expect(plan.kind === 'cached' && plan.refreshGlobalResources).toEqual(true);
+  });
+
+  test('refreshes globals when the shared slot is empty regardless of its stamp', () => {
+    const plan = planChannelRefresh({
+      cache: freshCache(),
+      forceRefresh: false,
+      globalCache: { ...emptyGlobalCacheData, lastUpdated: NOW },
+      now: NOW,
+    });
+
+    expect(plan.kind === 'cached' && plan.refreshGlobalResources).toEqual(true);
+  });
+
+  test('does not refresh a fresh global slot on a stale channel badge pass', () => {
+    const plan = planChannelRefresh({
+      cache: freshCache({ badgesLastUpdated: NOW - HOUR_MS }),
+      forceRefresh: false,
+      globalCache: freshGlobalCache(),
+      now: NOW,
+    });
+
+    expect(plan.kind === 'cached' && plan.refreshGlobalResources).toEqual(
+      false,
+    );
   });
 
   test('falls back to lastUpdated for badge age when badgesLastUpdated is missing', () => {
@@ -155,6 +236,7 @@ describe('planChannelRefresh', () => {
         lastUpdated: NOW - 45 * 60 * 1000,
       }),
       forceRefresh: false,
+      globalCache: freshGlobalCache(),
       now: NOW,
     });
 
@@ -165,6 +247,7 @@ describe('planChannelRefresh', () => {
       fetchEmoteSetId: false,
       fetchSubscriberEmotes: false,
       refreshBadges: false,
+      refreshGlobalResources: false,
     });
   });
 });

--- a/src/store/chat/__tests__/cosmetics.test.ts
+++ b/src/store/chat/__tests__/cosmetics.test.ts
@@ -214,17 +214,8 @@ describe('syncCachedUserCosmeticsFromStore', () => {
     syncCachedUserCosmeticsFromStore('stv-user-1', 'ttv-1');
 
     const expectedCosmetics: CachedUserCosmetics = {
-      badge: {
-        id: 'badge-1',
-        provider: '7tv',
-        set: 'badge-1',
-        title: 'Supporter',
-        type: '7TV Badge',
-        url: 'https://cdn.7tv.app/badge/badge-1/4x.webp',
-      },
       badgeId: 'badge-1',
       expiresAt: Date.now() + TWO_HOURS_MS,
-      paint: undefined,
       paintId: null,
       ttvUserId: 'ttv-1',
     };
@@ -242,10 +233,8 @@ describe('syncCachedUserCosmeticsFromStore', () => {
     syncCachedUserCosmeticsFromStore('stv-user-1', 'ttv-1');
 
     const expectedCosmetics: CachedUserCosmetics = {
-      badge: undefined,
       badgeId: null,
       expiresAt: Date.now() + THIRTY_MINUTES_MS,
-      paint: undefined,
       paintId: null,
       ttvUserId: 'ttv-1',
     };

--- a/src/store/chat/__tests__/cosmeticsChurn.test.ts
+++ b/src/store/chat/__tests__/cosmeticsChurn.test.ts
@@ -1,7 +1,10 @@
 import { storageService } from '@app/lib/storage';
+import { sevenTvService } from '@app/services/seventv-service';
 import {
   addBadge,
   addPaint,
+  type CachedUserCosmetics,
+  fetchAndCacheUserCosmetics,
   removeBadge,
   setUserBadge,
   setUserPaint,
@@ -178,5 +181,41 @@ describe('cosmetics entitlement-burst churn', () => {
     expect(chatStore$.cosmeticBindingsVersion.peek()).toEqual(2);
     expect(chatStore$.badges.peek()).toEqual({});
     expect(chatStore$.userBadgeIds.peek()).toEqual({});
+  });
+
+  test('an id-only snapshot with held definitions applies without a refetch', async () => {
+    addPaint(buildPaint());
+    addBadge(buildBadge());
+    const stored: CachedUserCosmetics = {
+      badgeId: BADGE_ID,
+      expiresAt: Date.now() + 60_000,
+      paintId: PAINT_ID,
+      ttvUserId: 'ttv-hit',
+    };
+    jest.mocked(storageService.getString).mockReturnValueOnce(stored);
+
+    const result = await fetchAndCacheUserCosmetics('stv-id-only-hit');
+
+    expect(result).toBe('ttv-hit');
+    expect(sevenTvService.getUserCosmeticsGql).not.toHaveBeenCalled();
+    expect(chatStore$.userPaintIds.peek()['ttv-hit']).toBe(PAINT_ID);
+    expect(chatStore$.userBadgeIds.peek()['ttv-hit']).toBe(BADGE_ID);
+  });
+
+  test('a snapshot whose bound ids no longer resolve is treated as a miss', async () => {
+    const stored: CachedUserCosmetics = {
+      badgeId: null,
+      expiresAt: Date.now() + 60_000,
+      paintId: PAINT_ID,
+      ttvUserId: 'ttv-stale',
+    };
+    jest.mocked(storageService.getString).mockReturnValueOnce(stored);
+    jest.mocked(sevenTvService.getUserCosmeticsGql).mockResolvedValue(null);
+
+    await fetchAndCacheUserCosmetics('stv-unresolvable');
+
+    expect(sevenTvService.getUserCosmeticsGql).toHaveBeenCalledWith(
+      'stv-unresolvable',
+    );
   });
 });

--- a/src/store/chat/__tests__/cosmeticsChurn.test.ts
+++ b/src/store/chat/__tests__/cosmeticsChurn.test.ts
@@ -8,19 +8,24 @@ import {
   fetchAndCacheUserCosmetics,
   hasUserPaint,
   removeBadge,
+  removeUserBadge,
   removeUserPaint,
   setUserBadge,
   setUserPaint,
   syncCachedUserCosmeticsFromStore,
 } from '@app/store/chat/actions/cosmetics';
 import { chatStore$ } from '@app/store/chat/observables/chatStore';
-import type { PaintData } from '@app/types/seventv/cosmetics';
+import type {
+  PaintData,
+  UserCosmeticsInfo,
+} from '@app/types/seventv/cosmetics';
 import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
 
 jest.mock('@app/lib/storage', () => ({
   storageService: {
     getString: jest.fn(() => null),
     set: jest.fn(),
+    delete: jest.fn(),
     clearNamespace: jest.fn(),
   },
 }));
@@ -249,5 +254,137 @@ describe('cosmetics entitlement-burst churn', () => {
     expect(sevenTvService.getUserCosmeticsGql).toHaveBeenCalledWith(
       'stv-unresolvable',
     );
+  });
+
+  test('an unresolvable snapshot whose refetch returns null is deleted', async () => {
+    const stored: CachedUserCosmetics = {
+      badgeId: 'badge-vanished',
+      expiresAt: Date.now() + 60_000,
+      paintId: null,
+      ttvUserId: 'ttv-dead',
+    };
+    jest.mocked(storageService.getString).mockReturnValueOnce(stored);
+    jest.mocked(sevenTvService.getUserCosmeticsGql).mockResolvedValue(null);
+    jest.mocked(sevenTvService.getUserCosmeticsGql).mockClear();
+    jest.mocked(storageService.delete).mockClear();
+
+    const result = await fetchAndCacheUserCosmetics('stv-dead');
+    await fetchAndCacheUserCosmetics('stv-dead');
+
+    expect(result).toBeNull();
+    expect(jest.mocked(storageService.delete).mock.calls).toEqual([
+      ['sevenTvUserCosmetics_user-cosmetics:stv-dead', 'seven_tv_cache'],
+    ]);
+    expect(jest.mocked(sevenTvService.getUserCosmeticsGql).mock.calls).toEqual([
+      ['stv-dead'],
+      ['stv-dead'],
+    ]);
+  });
+
+  test('an unresolvable snapshot heals when the refetch succeeds', async () => {
+    const stored: CachedUserCosmetics = {
+      badgeId: 'badge-heal',
+      expiresAt: Date.now() + 60_000,
+      paintId: null,
+      ttvUserId: 'ttv-heal',
+    };
+    jest.mocked(storageService.getString).mockReturnValueOnce(stored);
+    jest.mocked(storageService.delete).mockClear();
+    jest.mocked(sevenTvService.getUserCosmeticsGql).mockResolvedValueOnce({
+      userId: 'stv-heal',
+      ttvUserId: 'ttv-heal',
+      paintId: null,
+      badgeId: 'badge-heal',
+      paint: null,
+      badge: {
+        id: 'badge-heal',
+        name: 'Heal Badge',
+        description: null,
+        images: [
+          {
+            url: 'https://cdn.7tv.app/badge/badge-heal/4x.webp',
+            mime: 'image/webp',
+            size: 1,
+            scale: 4,
+            width: 18,
+            height: 18,
+            frameCount: 1,
+          },
+        ],
+      },
+    } satisfies UserCosmeticsInfo);
+
+    const result = await fetchAndCacheUserCosmetics('stv-heal');
+
+    expect(result).toBe('ttv-heal');
+    expect(chatStore$.userBadgeIds.peek()['ttv-heal']).toBe('badge-heal');
+    expect(Object.keys(chatStore$.badges.peek())).toEqual(['badge-heal']);
+    expect(jest.mocked(storageService.delete)).not.toHaveBeenCalled();
+  });
+
+  test('a resolvable old embedded-shape snapshot still serves as a hit', async () => {
+    addPaint(buildPaint());
+    addBadge(buildBadge());
+    const stored: CachedUserCosmetics & {
+      badge: SanitisedBadgeSet;
+      paint: PaintData;
+    } = {
+      badge: buildBadge(),
+      badgeId: BADGE_ID,
+      expiresAt: Date.now() + 60_000,
+      paint: buildPaint(),
+      paintId: PAINT_ID,
+      ttvUserId: 'ttv-embedded',
+    };
+    jest.mocked(storageService.getString).mockReturnValueOnce(stored);
+    jest.mocked(sevenTvService.getUserCosmeticsGql).mockClear();
+
+    const result = await fetchAndCacheUserCosmetics('stv-embedded');
+
+    expect(result).toBe('ttv-embedded');
+    expect(sevenTvService.getUserCosmeticsGql).not.toHaveBeenCalled();
+    expect(chatStore$.userPaintIds.peek()['ttv-embedded']).toBe(PAINT_ID);
+    expect(chatStore$.userBadgeIds.peek()['ttv-embedded']).toBe(BADGE_ID);
+  });
+
+  test('the badge sweep keeps ids referenced only by session cosmetic snapshots', () => {
+    addBadge({ ...buildBadge(), id: 'badge-session', set: 'badge-session' });
+    setUserBadge('ttv-session', 'badge-session');
+    syncCachedUserCosmeticsFromStore('stv-session-ref', 'ttv-session');
+    removeUserBadge('ttv-session');
+
+    for (let index = 0; index < 749; index += 1) {
+      addBadge({
+        ...buildBadge(),
+        id: `badge-${index}`,
+        set: `badge-${index}`,
+      });
+    }
+    addBadge({ ...buildBadge(), id: 'badge-new', set: 'badge-new' });
+
+    expect(Object.keys(chatStore$.badges.peek())).toEqual([
+      'badge-session',
+      'badge-new',
+    ]);
+  });
+
+  test('the paint sweep keeps ids referenced only by session cosmetic snapshots', () => {
+    addPaint({ ...buildPaint(), id: 'paint-session' });
+    setUserPaint('ttv-paint-session', 'paint-session');
+    syncCachedUserCosmeticsFromStore(
+      'stv-paint-session-ref',
+      'ttv-paint-session',
+    );
+    removeUserPaint('ttv-paint-session');
+
+    for (let index = 0; index < 749; index += 1) {
+      addPaint({ ...buildPaint(), id: `paint-${index}` });
+    }
+    addPaint({ ...buildPaint(), id: 'paint-new' });
+
+    expect(Object.keys(chatStore$.paints.peek())).toEqual([
+      'paint-session',
+      'paint-new',
+    ]);
   });
 });

--- a/src/store/chat/__tests__/cosmeticsChurn.test.ts
+++ b/src/store/chat/__tests__/cosmeticsChurn.test.ts
@@ -281,6 +281,25 @@ describe('cosmetics entitlement-burst churn', () => {
     ]);
   });
 
+  test('a network error keeps the stored snapshot for a later retry', async () => {
+    const stored: CachedUserCosmetics = {
+      badgeId: 'badge-offline',
+      expiresAt: Date.now() + 60_000,
+      paintId: null,
+      ttvUserId: 'ttv-offline',
+    };
+    jest.mocked(storageService.getString).mockReturnValueOnce(stored);
+    jest.mocked(storageService.delete).mockClear();
+    jest
+      .mocked(sevenTvService.getUserCosmeticsGql)
+      .mockRejectedValueOnce(new Error('network down'));
+
+    const result = await fetchAndCacheUserCosmetics('stv-offline');
+
+    expect(result).toBeNull();
+    expect(storageService.delete).not.toHaveBeenCalled();
+  });
+
   test('an unresolvable snapshot heals when the refetch succeeds', async () => {
     const stored: CachedUserCosmetics = {
       badgeId: 'badge-heal',

--- a/src/store/chat/__tests__/cosmeticsChurn.test.ts
+++ b/src/store/chat/__tests__/cosmeticsChurn.test.ts
@@ -4,8 +4,11 @@ import {
   addBadge,
   addPaint,
   type CachedUserCosmetics,
+  clearUserPaintFlagCache,
   fetchAndCacheUserCosmetics,
+  hasUserPaint,
   removeBadge,
+  removeUserPaint,
   setUserBadge,
   setUserPaint,
   syncCachedUserCosmeticsFromStore,
@@ -78,7 +81,7 @@ function resetStore() {
   chatStore$.badges.set({});
   chatStore$.userPaintIds.set({});
   chatStore$.userBadgeIds.set({});
-  chatStore$.sessionCaches.userPaintFlags.set({});
+  clearUserPaintFlagCache();
   chatStore$.cosmeticBindingsVersion.set(0);
   jest.mocked(storageService.set).mockClear();
 }
@@ -200,6 +203,35 @@ describe('cosmetics entitlement-burst churn', () => {
     expect(sevenTvService.getUserCosmeticsGql).not.toHaveBeenCalled();
     expect(chatStore$.userPaintIds.peek()['ttv-hit']).toBe(PAINT_ID);
     expect(chatStore$.userBadgeIds.peek()['ttv-hit']).toBe(BADGE_ID);
+  });
+
+  test('adding a badge past the definition cap sweeps unreferenced definitions', () => {
+    for (let index = 0; index < 750; index += 1) {
+      addBadge({
+        ...buildBadge(),
+        id: `badge-${index}`,
+        set: `badge-${index}`,
+      });
+    }
+    setUserBadge('ttv-user-0', 'badge-0');
+
+    addBadge({ ...buildBadge(), id: 'badge-750', set: 'badge-750' });
+
+    expect(Object.keys(chatStore$.badges.peek())).toEqual([
+      'badge-0',
+      'badge-750',
+    ]);
+  });
+
+  test('hasUserPaint memoises per user and invalidates on a binding change', () => {
+    addPaint(buildPaint());
+    setUserPaint('ttv-user-0', PAINT_ID);
+
+    expect(hasUserPaint('ttv-user-0')).toBe(true);
+
+    removeUserPaint('ttv-user-0');
+
+    expect(hasUserPaint('ttv-user-0')).toBe(false);
   });
 
   test('a snapshot whose bound ids no longer resolve is treated as a miss', async () => {

--- a/src/store/chat/__tests__/personalEmotes.test.ts
+++ b/src/store/chat/__tests__/personalEmotes.test.ts
@@ -3,6 +3,7 @@ import { sevenTvService } from '@app/services/seventv-service';
 import type { SevenTvSanitisedEmote } from '@app/types/emote';
 
 import {
+  clearChannelPersonalEmotes,
   clearPersonalEmotesCache,
   fetchUserPersonalEmotes,
   getUserPersonalEmotes,
@@ -125,6 +126,25 @@ describe('fetchUserPersonalEmotes', () => {
       ...makeEmptyEmoteData(),
       lastUpdated: 1_000,
     });
+  });
+
+  test('clearChannelPersonalEmotes drops only that channel and lets its users refetch', async () => {
+    const otherChannelId = '456';
+    mockGetPersonalEmoteSet.mockResolvedValue([personalEmote]);
+    await fetchUserPersonalEmotes(twitchUserId, channelId);
+    await refreshUserPersonalEmotes('user-2', otherChannelId);
+
+    clearChannelPersonalEmotes(channelId);
+
+    expect(getUserPersonalEmotes(twitchUserId, channelId)).toEqual([]);
+    expect(getUserPersonalEmotes('user-2', otherChannelId)).toEqual<
+      SevenTvSanitisedEmote[]
+    >([personalEmote]);
+
+    const refetched = await fetchUserPersonalEmotes(twitchUserId, channelId);
+
+    expect(refetched).toEqual<SevenTvSanitisedEmote[]>([personalEmote]);
+    expect(mockGetPersonalEmoteSet).toHaveBeenCalledTimes(3);
   });
 
   test('clearPersonalEmotesCache drops cached sets and bumps the version', async () => {

--- a/src/store/chat/__tests__/personalEmotes.test.ts
+++ b/src/store/chat/__tests__/personalEmotes.test.ts
@@ -5,9 +5,11 @@ import type { SevenTvSanitisedEmote } from '@app/types/emote';
 import {
   clearPersonalEmotesCache,
   fetchUserPersonalEmotes,
+  getUserPersonalEmotes,
   refreshUserPersonalEmotes,
 } from '../actions/personalEmotes';
 import { chatStore$ } from '../observables/chatStore';
+import type { ChannelCacheType } from '../types/constants';
 import { emptyEmoteData } from '../types/constants';
 
 jest.mock('@legendapp/state/persist', () => ({
@@ -107,6 +109,33 @@ describe('fetchUserPersonalEmotes', () => {
     expect(first).toBeNull();
     expect(second).toEqual<SevenTvSanitisedEmote[]>([]);
     expect(mockGetPersonalEmoteSet).toHaveBeenCalledTimes(1);
+  });
+
+  test('caches per session without touching the persisted channel cache', async () => {
+    mockGetPersonalEmoteSet.mockResolvedValueOnce([personalEmote]);
+
+    await fetchUserPersonalEmotes(twitchUserId, channelId);
+
+    expect(getUserPersonalEmotes(twitchUserId, channelId)).toEqual<
+      SevenTvSanitisedEmote[]
+    >([personalEmote]);
+    expect(
+      chatStore$.persisted.channelCaches.peek()[channelId],
+    ).toEqual<ChannelCacheType>({
+      ...structuredClone(emptyEmoteData),
+      lastUpdated: 1_000,
+    });
+  });
+
+  test('clearPersonalEmotesCache drops cached sets and bumps the version', async () => {
+    mockGetPersonalEmoteSet.mockResolvedValueOnce([personalEmote]);
+    await fetchUserPersonalEmotes(twitchUserId, channelId);
+    const versionBefore = chatStore$.personalEmotesVersion.peek();
+
+    clearPersonalEmotesCache();
+
+    expect(getUserPersonalEmotes(twitchUserId, channelId)).toEqual([]);
+    expect(chatStore$.personalEmotesVersion.peek()).toBe(versionBefore + 1);
   });
 });
 

--- a/src/store/chat/__tests__/personalEmotes.test.ts
+++ b/src/store/chat/__tests__/personalEmotes.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../actions/personalEmotes';
 import { chatStore$ } from '../observables/chatStore';
 import type { ChannelCacheType } from '../types/constants';
-import { emptyEmoteData } from '../types/constants';
+import { makeEmptyEmoteData } from '../types/constants';
 
 jest.mock('@legendapp/state/persist', () => ({
   configureObservablePersistence: jest.fn(),
@@ -85,7 +85,7 @@ describe('fetchUserPersonalEmotes', () => {
     clearPersonalEmotesCache();
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...structuredClone(emptyEmoteData),
+        ...makeEmptyEmoteData(),
         lastUpdated: 1_000,
       },
     });
@@ -122,7 +122,7 @@ describe('fetchUserPersonalEmotes', () => {
     expect(
       chatStore$.persisted.channelCaches.peek()[channelId],
     ).toEqual<ChannelCacheType>({
-      ...structuredClone(emptyEmoteData),
+      ...makeEmptyEmoteData(),
       lastUpdated: 1_000,
     });
   });
@@ -145,7 +145,7 @@ describe('personalEmotesVersion', () => {
     clearPersonalEmotesCache();
     chatStore$.persisted.channelCaches.set({
       [channelId]: {
-        ...structuredClone(emptyEmoteData),
+        ...makeEmptyEmoteData(),
         lastUpdated: 1_000,
       },
     });

--- a/src/store/chat/__tests__/state.test.ts
+++ b/src/store/chat/__tests__/state.test.ts
@@ -110,6 +110,8 @@ describe('migratePersistedChatStore', () => {
       badges: SanitisedBadgeSet[];
       chatterinoBadges: SanitisedBadgeSet[];
       emotes: SanitisedEmote[];
+      sevenTvPersonalBadges: Record<string, SanitisedBadgeSet[]>;
+      sevenTvPersonalEmotes: Record<string, SanitisedEmote[]>;
     } = {
       ...emptyEmoteData,
       badges: [badge('legacy-badge')],
@@ -117,6 +119,8 @@ describe('migratePersistedChatStore', () => {
       emotes: [emote('legacy-emote')],
       ffzGlobalBadges: [badge('kept-badge')],
       lastUpdated: 5_000,
+      sevenTvPersonalBadges: {},
+      sevenTvPersonalEmotes: { 'user-1': [emote('legacy-personal-emote')] },
       twitchChannelEmotes: [emote('kept-emote')],
     };
     chatStore$.persisted.channelCaches.set({ 'channel-1': legacyCache });

--- a/src/store/chat/__tests__/state.test.ts
+++ b/src/store/chat/__tests__/state.test.ts
@@ -231,6 +231,23 @@ describe('migratePersistedChatStore', () => {
     });
   });
 
+  test('seeds from a stale-stamped donor when no fresher channel holds global copies', () => {
+    const staleCache: LegacyChannelCache = {
+      ...makeEmptyEmoteData(),
+      bttvGlobalEmotes: [emote('stale-global-emote')],
+      lastUpdated: 0,
+    };
+    chatStore$.persisted.channelCaches.set({ 'channel-1': staleCache });
+
+    migratePersistedChatStore();
+
+    expect(chatStore$.persisted.globalCaches.peek()).toEqual<GlobalCacheType>({
+      ...makeEmptyGlobalCacheData(),
+      bttvGlobalEmotes: [emote('stale-global-emote')],
+      lastUpdated: 0,
+    });
+  });
+
   test('does not overwrite a populated global slot with channel copies', () => {
     chatStore$.persisted.globalCaches.set({
       ...makeEmptyGlobalCacheData(),

--- a/src/store/chat/__tests__/state.test.ts
+++ b/src/store/chat/__tests__/state.test.ts
@@ -7,7 +7,10 @@ import {
   migratePersistedChatStore,
 } from '../observables/chatStore';
 import type { ChannelCacheType, GlobalCacheType } from '../types/constants';
-import { emptyEmoteData, emptyGlobalCacheData } from '../types/constants';
+import {
+  makeEmptyEmoteData,
+  makeEmptyGlobalCacheData,
+} from '../types/constants';
 
 jest.mock('@legendapp/state/persist', () => ({
   configureObservablePersistence: jest.fn(),
@@ -30,7 +33,7 @@ jest.mock('react-native-mmkv', () => ({
 }));
 
 const makeCache = (lastUpdated: number) => ({
-  ...emptyEmoteData,
+  ...makeEmptyEmoteData(),
   lastUpdated,
 });
 
@@ -81,6 +84,65 @@ describe('limitChannelCaches', () => {
   });
 });
 
+describe('makeEmptyGlobalCacheData', () => {
+  const emote = (id: string): SanitisedEmote => ({
+    creator: null,
+    emote_link: `https://example.com/${id}`,
+    id,
+    name: id,
+    original_name: id,
+    site: 'BTTV',
+    static_url: `https://example.com/${id}.png`,
+    url: `https://example.com/${id}.webp`,
+  });
+
+  test('the store boots with its own instance, unshared with any other call', () => {
+    const fresh = makeEmptyGlobalCacheData();
+    const storeSlot = chatStore$.persisted.globalCaches.peek();
+
+    expect(storeSlot).not.toBe(fresh);
+    expect(storeSlot.twitchGlobalEmotes).not.toBe(fresh.twitchGlobalEmotes);
+    expect(makeEmptyGlobalCacheData()).not.toBe(fresh);
+    expect(makeEmptyGlobalCacheData().twitchGlobalEmotes).not.toBe(
+      fresh.twitchGlobalEmotes,
+    );
+  });
+
+  test('a hydration-style mutation of one instance does not leak into a clear', () => {
+    const hydrated: GlobalCacheType = makeEmptyGlobalCacheData();
+    hydrated.lastUpdated = 1_700_000_000_000;
+    hydrated.twitchGlobalEmotes.push(emote('hydrated-emote'));
+    hydrated.ffzGlobalBadges.push({
+      id: 'hydrated-badge',
+      set: 'hydrated-badge',
+      title: 'hydrated-badge',
+      type: 'FFZ Badge',
+      url: 'https://example.com/hydrated-badge.png',
+    });
+
+    chatStore$.persisted.globalCaches.set(makeEmptyGlobalCacheData());
+
+    expect(chatStore$.persisted.globalCaches.peek()).toEqual<GlobalCacheType>({
+      lastUpdated: 0,
+      twitchGlobalEmotes: [],
+      sevenTvGlobalEmotes: [],
+      ffzGlobalEmotes: [],
+      bttvGlobalEmotes: [],
+      twitchGlobalBadges: [],
+      ffzGlobalBadges: [],
+    });
+    expect({ ...makeEmptyGlobalCacheData() }).toEqual<GlobalCacheType>({
+      lastUpdated: 0,
+      twitchGlobalEmotes: [],
+      sevenTvGlobalEmotes: [],
+      ffzGlobalEmotes: [],
+      bttvGlobalEmotes: [],
+      twitchGlobalBadges: [],
+      ffzGlobalBadges: [],
+    });
+  });
+});
+
 describe('migratePersistedChatStore', () => {
   const emote = (id: string): SanitisedEmote => ({
     creator: null,
@@ -111,12 +173,12 @@ describe('migratePersistedChatStore', () => {
 
   beforeEach(() => {
     chatStore$.persisted.channelCaches.set({});
-    chatStore$.persisted.globalCaches.set({ ...emptyGlobalCacheData });
+    chatStore$.persisted.globalCaches.set(makeEmptyGlobalCacheData());
   });
 
   test('strips legacy aggregate and global fields from hydrated channel caches', () => {
     const legacyCache: LegacyChannelCache = {
-      ...emptyEmoteData,
+      ...makeEmptyEmoteData(),
       badges: [badge('legacy-badge')],
       bttvGlobalEmotes: [emote('legacy-global-emote')],
       chatterinoBadges: [badge('legacy-chatterino-badge')],
@@ -135,7 +197,7 @@ describe('migratePersistedChatStore', () => {
     expect(
       chatStore$.persisted.channelCaches.peek()['channel-1'],
     ).toEqual<ChannelCacheType>({
-      ...emptyEmoteData,
+      ...makeEmptyEmoteData(),
       ffzChannelBadges: [badge('kept-badge')],
       lastUpdated: 5_000,
       twitchChannelEmotes: [emote('kept-emote')],
@@ -144,12 +206,12 @@ describe('migratePersistedChatStore', () => {
 
   test('seeds the global slot from the newest channel copy before stripping', () => {
     const olderCache: LegacyChannelCache = {
-      ...emptyEmoteData,
+      ...makeEmptyEmoteData(),
       bttvGlobalEmotes: [emote('old-global-emote')],
       lastUpdated: 2_000,
     };
     const newerCache: LegacyChannelCache = {
-      ...emptyEmoteData,
+      ...makeEmptyEmoteData(),
       bttvGlobalEmotes: [emote('new-global-emote')],
       ffzGlobalBadges: [badge('new-global-badge')],
       lastUpdated: 8_000,
@@ -162,7 +224,7 @@ describe('migratePersistedChatStore', () => {
     migratePersistedChatStore();
 
     expect(chatStore$.persisted.globalCaches.peek()).toEqual<GlobalCacheType>({
-      ...emptyGlobalCacheData,
+      ...makeEmptyGlobalCacheData(),
       bttvGlobalEmotes: [emote('new-global-emote')],
       ffzGlobalBadges: [badge('new-global-badge')],
       lastUpdated: 8_000,
@@ -171,12 +233,12 @@ describe('migratePersistedChatStore', () => {
 
   test('does not overwrite a populated global slot with channel copies', () => {
     chatStore$.persisted.globalCaches.set({
-      ...emptyGlobalCacheData,
+      ...makeEmptyGlobalCacheData(),
       bttvGlobalEmotes: [emote('current-global-emote')],
       lastUpdated: 9_000,
     });
     const legacyCache: LegacyChannelCache = {
-      ...emptyEmoteData,
+      ...makeEmptyEmoteData(),
       bttvGlobalEmotes: [emote('legacy-global-emote')],
       lastUpdated: 8_000,
     };
@@ -185,7 +247,7 @@ describe('migratePersistedChatStore', () => {
     migratePersistedChatStore();
 
     expect(chatStore$.persisted.globalCaches.peek()).toEqual<GlobalCacheType>({
-      ...emptyGlobalCacheData,
+      ...makeEmptyGlobalCacheData(),
       bttvGlobalEmotes: [emote('current-global-emote')],
       lastUpdated: 9_000,
     });
@@ -193,7 +255,7 @@ describe('migratePersistedChatStore', () => {
 
   test('leaves a current-shape cache untouched', () => {
     const currentCache: ChannelCacheType = {
-      ...emptyEmoteData,
+      ...makeEmptyEmoteData(),
       lastUpdated: 5_000,
       twitchChannelEmotes: [emote('kept-emote')],
     };

--- a/src/store/chat/__tests__/state.test.ts
+++ b/src/store/chat/__tests__/state.test.ts
@@ -1,4 +1,12 @@
-import { limitChannelCaches } from '../observables/chatStore';
+import type { SanitisedEmote } from '@app/types/emote';
+import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
+
+import {
+  chatStore$,
+  limitChannelCaches,
+  migratePersistedChatStore,
+} from '../observables/chatStore';
+import type { ChannelCacheType } from '../types/constants';
 import { emptyEmoteData } from '../types/constants';
 
 jest.mock('@legendapp/state/persist', () => ({
@@ -70,5 +78,73 @@ describe('limitChannelCaches', () => {
         arrayPrototype.toSorted = nativeToSorted;
       }
     }
+  });
+});
+
+describe('migratePersistedChatStore', () => {
+  const emote = (id: string): SanitisedEmote => ({
+    creator: null,
+    emote_link: `https://example.com/${id}`,
+    id,
+    name: id,
+    original_name: id,
+    site: 'BTTV',
+    static_url: `https://example.com/${id}.png`,
+    url: `https://example.com/${id}.webp`,
+  });
+
+  const badge = (id: string): SanitisedBadgeSet => ({
+    id,
+    set: id,
+    title: id,
+    type: 'FFZ Badge',
+    url: `https://example.com/${id}.png`,
+  });
+
+  beforeEach(() => {
+    chatStore$.persisted.channelCaches.set({});
+  });
+
+  test('strips legacy aggregate fields from hydrated channel caches', () => {
+    const legacyCache: ChannelCacheType & {
+      badges: SanitisedBadgeSet[];
+      chatterinoBadges: SanitisedBadgeSet[];
+      emotes: SanitisedEmote[];
+    } = {
+      ...emptyEmoteData,
+      badges: [badge('legacy-badge')],
+      chatterinoBadges: [badge('legacy-chatterino-badge')],
+      emotes: [emote('legacy-emote')],
+      ffzGlobalBadges: [badge('kept-badge')],
+      lastUpdated: 5_000,
+      twitchChannelEmotes: [emote('kept-emote')],
+    };
+    chatStore$.persisted.channelCaches.set({ 'channel-1': legacyCache });
+
+    migratePersistedChatStore();
+
+    expect(
+      chatStore$.persisted.channelCaches.peek()['channel-1'],
+    ).toEqual<ChannelCacheType>({
+      ...emptyEmoteData,
+      ffzGlobalBadges: [badge('kept-badge')],
+      lastUpdated: 5_000,
+      twitchChannelEmotes: [emote('kept-emote')],
+    });
+  });
+
+  test('leaves a current-shape cache untouched', () => {
+    const currentCache: ChannelCacheType = {
+      ...emptyEmoteData,
+      lastUpdated: 5_000,
+      twitchChannelEmotes: [emote('kept-emote')],
+    };
+    chatStore$.persisted.channelCaches.set({ 'channel-1': currentCache });
+
+    migratePersistedChatStore();
+
+    expect(
+      chatStore$.persisted.channelCaches.peek()['channel-1'],
+    ).toEqual<ChannelCacheType>(currentCache);
   });
 });

--- a/src/store/chat/__tests__/state.test.ts
+++ b/src/store/chat/__tests__/state.test.ts
@@ -6,8 +6,8 @@ import {
   limitChannelCaches,
   migratePersistedChatStore,
 } from '../observables/chatStore';
-import type { ChannelCacheType } from '../types/constants';
-import { emptyEmoteData } from '../types/constants';
+import type { ChannelCacheType, GlobalCacheType } from '../types/constants';
+import { emptyEmoteData, emptyGlobalCacheData } from '../types/constants';
 
 jest.mock('@legendapp/state/persist', () => ({
   configureObservablePersistence: jest.fn(),
@@ -101,23 +101,28 @@ describe('migratePersistedChatStore', () => {
     url: `https://example.com/${id}.png`,
   });
 
+  type LegacyChannelCache = ChannelCacheType & {
+    badges?: SanitisedBadgeSet[];
+    chatterinoBadges?: SanitisedBadgeSet[];
+    emotes?: SanitisedEmote[];
+    sevenTvPersonalBadges?: Record<string, SanitisedBadgeSet[]>;
+    sevenTvPersonalEmotes?: Record<string, SanitisedEmote[]>;
+  } & Partial<Omit<GlobalCacheType, 'lastUpdated'>>;
+
   beforeEach(() => {
     chatStore$.persisted.channelCaches.set({});
+    chatStore$.persisted.globalCaches.set({ ...emptyGlobalCacheData });
   });
 
-  test('strips legacy aggregate fields from hydrated channel caches', () => {
-    const legacyCache: ChannelCacheType & {
-      badges: SanitisedBadgeSet[];
-      chatterinoBadges: SanitisedBadgeSet[];
-      emotes: SanitisedEmote[];
-      sevenTvPersonalBadges: Record<string, SanitisedBadgeSet[]>;
-      sevenTvPersonalEmotes: Record<string, SanitisedEmote[]>;
-    } = {
+  test('strips legacy aggregate and global fields from hydrated channel caches', () => {
+    const legacyCache: LegacyChannelCache = {
       ...emptyEmoteData,
       badges: [badge('legacy-badge')],
+      bttvGlobalEmotes: [emote('legacy-global-emote')],
       chatterinoBadges: [badge('legacy-chatterino-badge')],
       emotes: [emote('legacy-emote')],
-      ffzGlobalBadges: [badge('kept-badge')],
+      ffzChannelBadges: [badge('kept-badge')],
+      ffzGlobalBadges: [badge('legacy-global-badge')],
       lastUpdated: 5_000,
       sevenTvPersonalBadges: {},
       sevenTvPersonalEmotes: { 'user-1': [emote('legacy-personal-emote')] },
@@ -131,9 +136,58 @@ describe('migratePersistedChatStore', () => {
       chatStore$.persisted.channelCaches.peek()['channel-1'],
     ).toEqual<ChannelCacheType>({
       ...emptyEmoteData,
-      ffzGlobalBadges: [badge('kept-badge')],
+      ffzChannelBadges: [badge('kept-badge')],
       lastUpdated: 5_000,
       twitchChannelEmotes: [emote('kept-emote')],
+    });
+  });
+
+  test('seeds the global slot from the newest channel copy before stripping', () => {
+    const olderCache: LegacyChannelCache = {
+      ...emptyEmoteData,
+      bttvGlobalEmotes: [emote('old-global-emote')],
+      lastUpdated: 2_000,
+    };
+    const newerCache: LegacyChannelCache = {
+      ...emptyEmoteData,
+      bttvGlobalEmotes: [emote('new-global-emote')],
+      ffzGlobalBadges: [badge('new-global-badge')],
+      lastUpdated: 8_000,
+    };
+    chatStore$.persisted.channelCaches.set({
+      'channel-old': olderCache,
+      'channel-new': newerCache,
+    });
+
+    migratePersistedChatStore();
+
+    expect(chatStore$.persisted.globalCaches.peek()).toEqual<GlobalCacheType>({
+      ...emptyGlobalCacheData,
+      bttvGlobalEmotes: [emote('new-global-emote')],
+      ffzGlobalBadges: [badge('new-global-badge')],
+      lastUpdated: 8_000,
+    });
+  });
+
+  test('does not overwrite a populated global slot with channel copies', () => {
+    chatStore$.persisted.globalCaches.set({
+      ...emptyGlobalCacheData,
+      bttvGlobalEmotes: [emote('current-global-emote')],
+      lastUpdated: 9_000,
+    });
+    const legacyCache: LegacyChannelCache = {
+      ...emptyEmoteData,
+      bttvGlobalEmotes: [emote('legacy-global-emote')],
+      lastUpdated: 8_000,
+    };
+    chatStore$.persisted.channelCaches.set({ 'channel-1': legacyCache });
+
+    migratePersistedChatStore();
+
+    expect(chatStore$.persisted.globalCaches.peek()).toEqual<GlobalCacheType>({
+      ...emptyGlobalCacheData,
+      bttvGlobalEmotes: [emote('current-global-emote')],
+      lastUpdated: 9_000,
     });
   });
 

--- a/src/store/chat/__tests__/state.test.ts
+++ b/src/store/chat/__tests__/state.test.ts
@@ -131,7 +131,7 @@ describe('makeEmptyGlobalCacheData', () => {
       twitchGlobalBadges: [],
       ffzGlobalBadges: [],
     });
-    expect({ ...makeEmptyGlobalCacheData() }).toEqual<GlobalCacheType>({
+    expect(makeEmptyGlobalCacheData()).toEqual<GlobalCacheType>({
       lastUpdated: 0,
       twitchGlobalEmotes: [],
       sevenTvGlobalEmotes: [],

--- a/src/store/chat/actions/__tests__/channelResources.test.ts
+++ b/src/store/chat/actions/__tests__/channelResources.test.ts
@@ -1,6 +1,12 @@
 import { ApiError } from '@app/services/api/Client';
-import type { ChannelCacheType } from '@app/store/chat/types/constants';
-import { emptyEmoteData } from '@app/store/chat/types/constants';
+import type {
+  ChannelCacheType,
+  GlobalCacheType,
+} from '@app/store/chat/types/constants';
+import {
+  emptyEmoteData,
+  emptyGlobalCacheData,
+} from '@app/store/chat/types/constants';
 import type { SanitisedEmote } from '@app/types/emote';
 import { logger } from '@app/utils/logger';
 
@@ -174,6 +180,10 @@ describe('reconcileSettledSpecs', () => {
     ...emptyEmoteData,
     twitchChannelEmotes: [emote('cached')],
   };
+  const existingGlobalCache: GlobalCacheType = {
+    ...emptyGlobalCacheData,
+    bttvGlobalEmotes: [emote('cached-global')],
+  };
 
   test('deduplicates fulfilled results by id', () => {
     const settled: SettledSpec<EmoteCacheKey, SanitisedEmote>[] = [
@@ -189,6 +199,7 @@ describe('reconcileSettledSpecs', () => {
     const reconciled = reconcileSettledSpecs(settled, {
       channelId,
       existingCache: undefined,
+      existingGlobalCache: undefined,
     });
 
     expect(reconciled.get('twitchChannelEmotes')).toEqual<SanitisedEmote[]>([
@@ -208,10 +219,34 @@ describe('reconcileSettledSpecs', () => {
     const reconciled = reconcileSettledSpecs(settled, {
       channelId,
       existingCache,
+      existingGlobalCache,
     });
 
     expect(reconciled.get('twitchChannelEmotes')).toEqual<SanitisedEmote[]>([
       emote('cached'),
+    ]);
+  });
+
+  test('falls back to the global slot for a rejected global-scope spec', () => {
+    const globalSpec: EmoteResourceSpec = {
+      ...spec('bttvGlobalEmotes'),
+      scope: 'global',
+    };
+    const settled: SettledSpec<EmoteCacheKey, SanitisedEmote>[] = [
+      {
+        spec: globalSpec,
+        result: { status: 'rejected', reason: new Error('boom') },
+      },
+    ];
+
+    const reconciled = reconcileSettledSpecs(settled, {
+      channelId,
+      existingCache,
+      existingGlobalCache,
+    });
+
+    expect(reconciled.get('bttvGlobalEmotes')).toEqual<SanitisedEmote[]>([
+      emote('cached-global'),
     ]);
   });
 
@@ -226,6 +261,7 @@ describe('reconcileSettledSpecs', () => {
     const reconciled = reconcileSettledSpecs(settled, {
       channelId,
       existingCache: undefined,
+      existingGlobalCache: undefined,
     });
 
     expect(reconciled.get('twitchChannelEmotes')).toEqual([]);
@@ -274,7 +310,32 @@ describe('hadCachedResourcesForFailedSpecs', () => {
       twitchChannelEmotes: [emote('cached')],
     };
 
-    expect(hadCachedResourcesForFailedSpecs(existingCache, settled)).toBe(true);
+    expect(
+      hadCachedResourcesForFailedSpecs(
+        { existingCache, existingGlobalCache: undefined },
+        settled,
+      ),
+    ).toBe(true);
+  });
+
+  test('returns true when a rejected global spec still has items in the global slot', () => {
+    const settled: SettledSpec<EmoteCacheKey, SanitisedEmote>[] = [
+      {
+        spec: { ...spec('bttvGlobalEmotes'), scope: 'global' },
+        result: { status: 'rejected', reason: new Error('boom') },
+      },
+    ];
+    const existingGlobalCache: GlobalCacheType = {
+      ...emptyGlobalCacheData,
+      bttvGlobalEmotes: [emote('cached-global')],
+    };
+
+    expect(
+      hadCachedResourcesForFailedSpecs(
+        { existingCache: undefined, existingGlobalCache },
+        settled,
+      ),
+    ).toBe(true);
   });
 
   test('returns false when a rejected spec has no cached fallback', () => {
@@ -285,7 +346,12 @@ describe('hadCachedResourcesForFailedSpecs', () => {
       },
     ];
 
-    expect(hadCachedResourcesForFailedSpecs(undefined, settled)).toBe(false);
+    expect(
+      hadCachedResourcesForFailedSpecs(
+        { existingCache: undefined, existingGlobalCache: undefined },
+        settled,
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/store/chat/actions/__tests__/channelResources.test.ts
+++ b/src/store/chat/actions/__tests__/channelResources.test.ts
@@ -4,8 +4,8 @@ import type {
   GlobalCacheType,
 } from '@app/store/chat/types/constants';
 import {
-  emptyEmoteData,
-  emptyGlobalCacheData,
+  makeEmptyEmoteData,
+  makeEmptyGlobalCacheData,
 } from '@app/store/chat/types/constants';
 import type { SanitisedEmote } from '@app/types/emote';
 import { logger } from '@app/utils/logger';
@@ -177,11 +177,11 @@ describe('settleSpecs', () => {
 
 describe('reconcileSettledSpecs', () => {
   const existingCache: ChannelCacheType = {
-    ...emptyEmoteData,
+    ...makeEmptyEmoteData(),
     twitchChannelEmotes: [emote('cached')],
   };
   const existingGlobalCache: GlobalCacheType = {
-    ...emptyGlobalCacheData,
+    ...makeEmptyGlobalCacheData(),
     bttvGlobalEmotes: [emote('cached-global')],
   };
 
@@ -306,7 +306,7 @@ describe('hadCachedResourcesForFailedSpecs', () => {
       },
     ];
     const existingCache: ChannelCacheType = {
-      ...emptyEmoteData,
+      ...makeEmptyEmoteData(),
       twitchChannelEmotes: [emote('cached')],
     };
 
@@ -326,7 +326,7 @@ describe('hadCachedResourcesForFailedSpecs', () => {
       },
     ];
     const existingGlobalCache: GlobalCacheType = {
-      ...emptyGlobalCacheData,
+      ...makeEmptyGlobalCacheData(),
       bttvGlobalEmotes: [emote('cached-global')],
     };
 

--- a/src/store/chat/actions/channelLoad.ts
+++ b/src/store/chat/actions/channelLoad.ts
@@ -31,19 +31,27 @@ import {
 } from '../observables/recentMessagesPersistence';
 import type {
   ChannelCacheType,
+  GlobalCacheType,
   SanitisedBadgeSet,
   SubscriberChannelProfile,
 } from '../types/constants';
-import { emptyResolvedEmoteData } from '../types/constants';
+import {
+  emptyGlobalCacheData,
+  emptyResolvedEmoteData,
+} from '../types/constants';
 import { planChannelRefresh } from './channelRefreshPlan';
 import {
-  type BadgeResourceSets,
+  type BadgeCacheKey,
   buildBadgeResourceSpecs,
   buildEmoteResourceSpecs,
+  buildGlobalBadgeResourceSpecs,
+  buildGlobalEmoteResourceSpecs,
   buildSubscriberEmoteSpec,
+  type ChannelBadgeResourceSets,
+  type ChannelEmoteResourceSets,
   clearGlobalResourceCache,
   collectFailedProviderReasons,
-  type EmoteResourceSets,
+  type EmoteCacheKey,
   hadCachedResourcesForFailedSpecs,
   reconcileSettledSpecs,
   reportResourceResults,
@@ -109,17 +117,57 @@ const countReconciledItems = (
   return total;
 };
 
+/**
+ * Replaces the shared global slot with the reconciled global slices. The
+ * freshness stamp only advances when every global fetch succeeded, so a
+ * failed slice keeps its retry pressure instead of being served as fresh for
+ * the whole TTL.
+ */
+function writeGlobalCaches({
+  badgeByKey,
+  emoteByKey,
+  existingGlobalCache,
+  now,
+  settled,
+}: {
+  badgeByKey: ReadonlyMap<BadgeCacheKey, SanitisedBadgeSet[]>;
+  emoteByKey: ReadonlyMap<EmoteCacheKey, SanitisedEmote[]>;
+  existingGlobalCache: GlobalCacheType | undefined;
+  now: number;
+  settled: readonly ProviderFailureSettled[];
+}): void {
+  const hasGlobalResourceFailure = settled.some(
+    entry =>
+      entry.spec.scope === 'global' && entry.result.status === 'rejected',
+  );
+  chatStore$.persisted.globalCaches.set({
+    lastUpdated: hasGlobalResourceFailure
+      ? (existingGlobalCache?.lastUpdated ?? 0)
+      : now,
+    twitchGlobalEmotes: emoteByKey.get('twitchGlobalEmotes') ?? [],
+    sevenTvGlobalEmotes: emoteByKey.get('sevenTvGlobalEmotes') ?? [],
+    ffzGlobalEmotes: emoteByKey.get('ffzGlobalEmotes') ?? [],
+    bttvGlobalEmotes: emoteByKey.get('bttvGlobalEmotes') ?? [],
+    twitchGlobalBadges: badgeByKey.get('twitchGlobalBadges') ?? [],
+    ffzGlobalBadges: badgeByKey.get('ffzGlobalBadges') ?? [],
+  });
+}
+
 function notifyProviderLoadFailures(
   channelId: string,
   settled: readonly ProviderFailureSettled[],
   existingCache: ChannelCacheType | undefined,
+  existingGlobalCache: GlobalCacheType | undefined,
 ): void {
   const failedProviders = collectFailedProviderReasons(settled);
   if (failedProviders.length === 0) {
     return;
   }
 
-  const hadCache = hadCachedResourcesForFailedSpecs(existingCache, settled);
+  const hadCache = hadCachedResourcesForFailedSpecs(
+    { existingCache, existingGlobalCache },
+    settled,
+  );
   addMessage(
     createSystemMessage(
       channelId,
@@ -359,10 +407,12 @@ const loadChannelResourcesInternal = async (
   try {
     const caches = chatStore$.persisted.channelCaches.peek();
     const existingCache = caches?.[channelId];
+    const existingGlobalCache = chatStore$.persisted.globalCaches.peek();
 
     const plan = planChannelRefresh({
       cache: existingCache,
       forceRefresh: shouldForceRefresh,
+      globalCache: existingGlobalCache,
       now: Date.now(),
       twitchUserId,
     });
@@ -447,7 +497,9 @@ const loadChannelResourcesInternal = async (
           return false;
         }
 
-        const badgeSpecs = buildBadgeResourceSpecs({ channelId });
+        const badgeSpecs = buildBadgeResourceSpecs({ channelId }).filter(
+          spec => spec.scope !== 'global',
+        );
         const badgeSettled = await settleSpecs(badgeSpecs);
 
         if (exitIfAborted(signal, true)) {
@@ -465,12 +517,11 @@ const loadChannelResourcesInternal = async (
         const badgeByKey = reconcileSettledSpecs(badgeSettled, {
           channelId,
           existingCache,
+          existingGlobalCache,
         });
 
-        const badgeResourceSets: BadgeResourceSets = {
+        const badgeResourceSets: ChannelBadgeResourceSets = {
           twitchChannelBadges: badgeByKey.get('twitchChannelBadges') ?? [],
-          twitchGlobalBadges: badgeByKey.get('twitchGlobalBadges') ?? [],
-          ffzGlobalBadges: badgeByKey.get('ffzGlobalBadges') ?? [],
           ffzChannelBadges: badgeByKey.get('ffzChannelBadges') ?? [],
         };
 
@@ -507,10 +558,63 @@ const loadChannelResourcesInternal = async (
         });
       }
 
+      if (plan.refreshGlobalResources) {
+        if (exitIfAborted(signal, true)) {
+          return false;
+        }
+
+        const [globalEmoteSettled, globalBadgeSettled] = await Promise.all([
+          settleSpecs(buildGlobalEmoteResourceSpecs()),
+          settleSpecs(buildGlobalBadgeResourceSpecs()),
+        ]);
+
+        if (exitIfAborted(signal, true)) {
+          return false;
+        }
+
+        const globalSettled = [...globalEmoteSettled, ...globalBadgeSettled];
+
+        reportResourceResults({
+          channelId,
+          settled: globalSettled,
+          trigger: 'cached_global_resources_refresh',
+        });
+
+        cachedRefreshSettled.push(...globalSettled);
+
+        const globalCacheContext = {
+          channelId,
+          existingCache,
+          existingGlobalCache,
+        };
+        writeGlobalCaches({
+          badgeByKey: reconcileSettledSpecs(
+            globalBadgeSettled,
+            globalCacheContext,
+          ),
+          emoteByKey: reconcileSettledSpecs(
+            globalEmoteSettled,
+            globalCacheContext,
+          ),
+          existingGlobalCache,
+          now: Date.now(),
+          settled: globalSettled,
+        });
+
+        logger.chat.info('Refetched stale global provider slices', {
+          name: 'chat_resources_info',
+          action: 'global_resources_refetched',
+          category: 'data_loading',
+          channel_id: channelId,
+          screen: 'chat',
+        });
+      }
+
       notifyProviderLoadFailures(
         channelId,
         cachedRefreshSettled,
         existingCache,
+        existingGlobalCache,
       );
 
       batch(() => {
@@ -583,26 +687,20 @@ const loadChannelResourcesInternal = async (
       trigger: 'full_channel_resource_load',
     });
 
-    const cacheContext = { channelId, existingCache };
+    const cacheContext = { channelId, existingCache, existingGlobalCache };
     const emoteByKey = reconcileSettledSpecs(emoteSettled, cacheContext);
     const badgeByKey = reconcileSettledSpecs(badgeSettled, cacheContext);
 
-    const emoteResourceSets: EmoteResourceSets = {
+    const emoteResourceSets: ChannelEmoteResourceSets = {
       sevenTvChannelEmotes: emoteByKey.get('sevenTvChannelEmotes') ?? [],
-      sevenTvGlobalEmotes: emoteByKey.get('sevenTvGlobalEmotes') ?? [],
       twitchChannelEmotes: emoteByKey.get('twitchChannelEmotes') ?? [],
-      twitchGlobalEmotes: emoteByKey.get('twitchGlobalEmotes') ?? [],
       twitchSubscriberEmotes: emoteByKey.get('twitchSubscriberEmotes') ?? [],
-      bttvGlobalEmotes: emoteByKey.get('bttvGlobalEmotes') ?? [],
       bttvChannelEmotes: emoteByKey.get('bttvChannelEmotes') ?? [],
       ffzChannelEmotes: emoteByKey.get('ffzChannelEmotes') ?? [],
-      ffzGlobalEmotes: emoteByKey.get('ffzGlobalEmotes') ?? [],
     };
 
-    const badgeResourceSets: BadgeResourceSets = {
+    const badgeResourceSets: ChannelBadgeResourceSets = {
       twitchChannelBadges: badgeByKey.get('twitchChannelBadges') ?? [],
-      twitchGlobalBadges: badgeByKey.get('twitchGlobalBadges') ?? [],
-      ffzGlobalBadges: badgeByKey.get('ffzGlobalBadges') ?? [],
       ffzChannelBadges: badgeByKey.get('ffzChannelBadges') ?? [],
     };
 
@@ -610,19 +708,21 @@ const loadChannelResourcesInternal = async (
       return false;
     }
 
-    const hasEmoteResourceFailure = emoteSettled.some(
-      entry => entry.result.status === 'rejected',
+    const hasChannelEmoteFailure = emoteSettled.some(
+      entry =>
+        entry.spec.scope !== 'global' && entry.result.status === 'rejected',
     );
-    const hasBadgeResourceFailure = badgeSettled.some(
-      entry => entry.result.status === 'rejected',
+    const hasChannelBadgeFailure = badgeSettled.some(
+      entry =>
+        entry.spec.scope !== 'global' && entry.result.status === 'rejected',
     );
     const now = Date.now();
 
     const channelData: ChannelCacheType = {
-      lastUpdated: hasEmoteResourceFailure
+      lastUpdated: hasChannelEmoteFailure
         ? (existingCache?.lastUpdated ?? 0)
         : now,
-      badgesLastUpdated: hasBadgeResourceFailure
+      badgesLastUpdated: hasChannelBadgeFailure
         ? (existingCache?.badgesLastUpdated ?? 0)
         : now,
       ...emoteResourceSets,
@@ -636,6 +736,13 @@ const loadChannelResourcesInternal = async (
     clearChannelPersonalEmotes(channelId);
 
     batch(() => {
+      writeGlobalCaches({
+        badgeByKey,
+        emoteByKey,
+        existingGlobalCache,
+        now,
+        settled: [...emoteSettled, ...badgeSettled],
+      });
       const currentCaches = chatStore$.persisted.channelCaches.peek() ?? {};
       chatStore$.persisted.channelCaches.set(
         limitChannelCaches(
@@ -650,6 +757,7 @@ const loadChannelResourcesInternal = async (
       channelId,
       [...emoteSettled, ...badgeSettled],
       existingCache,
+      existingGlobalCache,
     );
 
     if (twitchUserId) {
@@ -771,7 +879,7 @@ export const clearCache = (channelId?: string) => {
   } else {
     batch(() => {
       chatStore$.persisted.channelCaches.set({});
-      chatStore$.persisted.lastGlobalUpdate.set(0);
+      chatStore$.persisted.globalCaches.set({ ...emptyGlobalCacheData });
       chatStore$.currentChannelId.set(null);
       chatStore$.loadingState.set('IDLE');
     });
@@ -784,7 +892,7 @@ export const clearChatCosmeticsCache = (): void => {
   batch(() => {
     chatStore$.persisted.channelCaches.set({});
     chatStore$.recentMessagesByChannel.set({});
-    chatStore$.persisted.lastGlobalUpdate.set(0);
+    chatStore$.persisted.globalCaches.set({ ...emptyGlobalCacheData });
     chatStore$.currentChannelId.set(null);
     chatStore$.loadingState.set('IDLE');
     chatStore$.emojis.set(getEmojiEmotes(getPreferences().emojiStyle));
@@ -816,6 +924,7 @@ export const getCurrentEmoteData = (channelId?: string) => {
     return emptyResolvedEmoteData;
   }
 
+  const globalCache = chatStore$.persisted.globalCaches.peek();
   const preferences = getPreferences();
 
   return {
@@ -823,7 +932,7 @@ export const getCurrentEmoteData = (channelId?: string) => {
       ? (cache.twitchChannelEmotes ?? NO_EMOTES)
       : NO_EMOTES,
     twitchGlobalEmotes: preferences.showTwitchEmotes
-      ? (cache.twitchGlobalEmotes ?? NO_EMOTES)
+      ? (globalCache?.twitchGlobalEmotes ?? NO_EMOTES)
       : NO_EMOTES,
     twitchSubscriberEmotes: preferences.showTwitchEmotes
       ? (cache.twitchSubscriberEmotes ?? NO_EMOTES)
@@ -832,16 +941,16 @@ export const getCurrentEmoteData = (channelId?: string) => {
       ? (cache.sevenTvChannelEmotes ?? NO_EMOTES)
       : NO_EMOTES,
     sevenTvGlobalEmotes: preferences.show7TvEmotes
-      ? (cache.sevenTvGlobalEmotes ?? NO_EMOTES)
+      ? (globalCache?.sevenTvGlobalEmotes ?? NO_EMOTES)
       : NO_EMOTES,
     ffzChannelEmotes: preferences.showFFzEmotes
       ? (cache.ffzChannelEmotes ?? NO_EMOTES)
       : NO_EMOTES,
     ffzGlobalEmotes: preferences.showFFzEmotes
-      ? (cache.ffzGlobalEmotes ?? NO_EMOTES)
+      ? (globalCache?.ffzGlobalEmotes ?? NO_EMOTES)
       : NO_EMOTES,
     bttvGlobalEmotes: preferences.showBttvEmotes
-      ? (cache.bttvGlobalEmotes ?? NO_EMOTES)
+      ? (globalCache?.bttvGlobalEmotes ?? NO_EMOTES)
       : NO_EMOTES,
     bttvChannelEmotes: preferences.showBttvEmotes
       ? (cache.bttvChannelEmotes ?? NO_EMOTES)
@@ -850,13 +959,13 @@ export const getCurrentEmoteData = (channelId?: string) => {
       ? (cache.twitchChannelBadges ?? NO_BADGES)
       : NO_BADGES,
     twitchGlobalBadges: preferences.showTwitchBadges
-      ? (cache.twitchGlobalBadges ?? NO_BADGES)
+      ? (globalCache?.twitchGlobalBadges ?? NO_BADGES)
       : NO_BADGES,
     ffzChannelBadges: preferences.showFFzBadges
       ? (cache.ffzChannelBadges ?? NO_BADGES)
       : NO_BADGES,
     ffzGlobalBadges: preferences.showFFzBadges
-      ? (cache.ffzGlobalBadges ?? NO_BADGES)
+      ? (globalCache?.ffzGlobalBadges ?? NO_BADGES)
       : NO_BADGES,
     chatterinoBadges: preferences.showChatterinoEmotes
       ? getChatterinoBadges()

--- a/src/store/chat/actions/channelLoad.ts
+++ b/src/store/chat/actions/channelLoad.ts
@@ -52,6 +52,7 @@ import {
 import { clearUserCosmeticsCache } from './cosmetics';
 import { addMessage } from './messages';
 import {
+  clearChannelPersonalEmotes,
   clearPersonalEmotesCache,
   fetchUserPersonalEmotes,
 } from './personalEmotes';
@@ -343,9 +344,10 @@ const loadChannelResourcesInternal = async (
   }
   chatStore$.loadingState.set('LOADING');
   if (shouldForceRefresh) {
-    // The full load below resets sevenTvPersonalEmotes to {}, so the checked
-    // set must forget those users or fetchUserPersonalEmotes short-circuits
-    // into the emptied cache until the channel is left and re-entered.
+    // The full load below resets the channel's personal-emote cache, so the
+    // checked set must forget those users or fetchUserPersonalEmotes
+    // short-circuits into the emptied cache until the channel is left and
+    // re-entered.
     clearPersonalEmotesCache();
     // An explicit refresh should re-download global provider data too, not
     // serve it from the session cache.
@@ -628,10 +630,10 @@ const loadChannelResourcesInternal = async (
       twitchSubscriberChannelProfiles:
         existingCache?.twitchSubscriberChannelProfiles ?? {},
       ...badgeResourceSets,
-      sevenTvPersonalBadges: {},
-      sevenTvPersonalEmotes: {},
       sevenTvEmoteSetId: sevenTvSetId === 'global' ? undefined : sevenTvSetId,
     };
+
+    clearChannelPersonalEmotes(channelId);
 
     batch(() => {
       const currentCaches = chatStore$.persisted.channelCaches.peek() ?? {};

--- a/src/store/chat/actions/channelLoad.ts
+++ b/src/store/chat/actions/channelLoad.ts
@@ -36,8 +36,8 @@ import type {
   SubscriberChannelProfile,
 } from '../types/constants';
 import {
-  emptyGlobalCacheData,
   emptyResolvedEmoteData,
+  makeEmptyGlobalCacheData,
 } from '../types/constants';
 import { planChannelRefresh } from './channelRefreshPlan';
 import {
@@ -879,7 +879,7 @@ export const clearCache = (channelId?: string) => {
   } else {
     batch(() => {
       chatStore$.persisted.channelCaches.set({});
-      chatStore$.persisted.globalCaches.set({ ...emptyGlobalCacheData });
+      chatStore$.persisted.globalCaches.set(makeEmptyGlobalCacheData());
       chatStore$.currentChannelId.set(null);
       chatStore$.loadingState.set('IDLE');
     });
@@ -892,7 +892,7 @@ export const clearChatCosmeticsCache = (): void => {
   batch(() => {
     chatStore$.persisted.channelCaches.set({});
     chatStore$.recentMessagesByChannel.set({});
-    chatStore$.persisted.globalCaches.set({ ...emptyGlobalCacheData });
+    chatStore$.persisted.globalCaches.set(makeEmptyGlobalCacheData());
     chatStore$.currentChannelId.set(null);
     chatStore$.loadingState.set('IDLE');
     chatStore$.emojis.set(getEmojiEmotes(getPreferences().emojiStyle));

--- a/src/store/chat/actions/channelLoad.ts
+++ b/src/store/chat/actions/channelLoad.ts
@@ -118,8 +118,7 @@ const countReconciledItems = (
 };
 
 /**
- * Replaces the shared global slot with the reconciled global slices. The
- * freshness stamp only advances when every global fetch succeeded, so a
+ * The freshness stamp only advances when every global fetch succeeded, so a
  * failed slice keeps its retry pressure instead of being served as fresh for
  * the whole TTL.
  */
@@ -284,13 +283,16 @@ export const resolveSubscriberChannelProfiles = async (
 };
 
 export const clearChannelResources = () => {
+  const channelId = chatStore$.currentChannelId.peek();
   batch(() => {
     chatStore$.currentChannelId.set(null);
     chatStore$.loadingState.set('IDLE');
     chatStore$.emojis.set(getEmojiEmotes(getPreferences().emojiStyle));
     chatStore$.bits.set([]);
   });
-  clearPersonalEmotesCache();
+  if (channelId) {
+    clearChannelPersonalEmotes(channelId);
+  }
 };
 
 export const notify7TVPresence = async (

--- a/src/store/chat/actions/channelLoad.ts
+++ b/src/store/chat/actions/channelLoad.ts
@@ -43,8 +43,6 @@ import {
   buildSubscriberEmoteSpec,
   clearGlobalResourceCache,
   collectFailedProviderReasons,
-  combineUniqueById,
-  deduplicateById,
   type EmoteResourceSets,
   hadCachedResourcesForFailedSpecs,
   reconcileSettledSpecs,
@@ -99,6 +97,16 @@ const exitIfAborted = (
 type ProviderFailureSettled = Parameters<
   typeof collectFailedProviderReasons
 >[0][number];
+
+const countReconciledItems = (
+  reconciled: ReadonlyMap<string, readonly unknown[]>,
+): number => {
+  let total = 0;
+  reconciled.forEach(items => {
+    total += items.length;
+  });
+  return total;
+};
 
 function notifyProviderLoadFailures(
   channelId: string,
@@ -428,10 +436,6 @@ const loadChannelResourcesInternal = async (
           channelCache.assign({
             twitchSubscriberEmotes: subscriberEmotes,
             twitchSubscriberEmotesUserId: twitchUserId,
-            emotes: deduplicateById([
-              ...subscriberEmotes,
-              ...(existingCache.emotes ?? []),
-            ]),
           });
         }
       }
@@ -468,10 +472,6 @@ const loadChannelResourcesInternal = async (
           ffzChannelBadges: badgeByKey.get('ffzChannelBadges') ?? [],
         };
 
-        const allBadges = combineUniqueById(
-          ...badgeSettled.map(entry => badgeByKey.get(entry.spec.key) ?? []),
-        );
-
         const channelCache = chatStore$.persisted.channelCaches[channelId];
 
         if (channelCache) {
@@ -480,7 +480,6 @@ const loadChannelResourcesInternal = async (
           );
 
           channelCache.assign({
-            badges: allBadges,
             ...badgeResourceSets,
             badgesLastUpdated: hasBadgeResourceFailure
               ? existingCache.badgesLastUpdated
@@ -605,14 +604,6 @@ const loadChannelResourcesInternal = async (
       ffzChannelBadges: badgeByKey.get('ffzChannelBadges') ?? [],
     };
 
-    const allEmotes = combineUniqueById(
-      ...emoteSettled.map(entry => emoteByKey.get(entry.spec.key) ?? []),
-    );
-
-    const allBadges = combineUniqueById(
-      ...badgeSettled.map(entry => badgeByKey.get(entry.spec.key) ?? []),
-    );
-
     if (exitIfAborted(signal, true)) {
       return false;
     }
@@ -626,8 +617,6 @@ const loadChannelResourcesInternal = async (
     const now = Date.now();
 
     const channelData: ChannelCacheType = {
-      emotes: allEmotes,
-      badges: allBadges,
       lastUpdated: hasEmoteResourceFailure
         ? (existingCache?.lastUpdated ?? 0)
         : now,
@@ -670,10 +659,10 @@ const loadChannelResourcesInternal = async (
     logger.chat.info('Loaded channel resources', {
       name: 'chat_resources_info',
       action: 'channel_resources_loaded',
-      badge_count: allBadges.length,
+      badge_count: countReconciledItems(badgeByKey),
       category: 'data_loading',
       channel_id: channelId,
-      emote_count: allEmotes.length,
+      emote_count: countReconciledItems(emoteByKey),
       screen: 'chat',
     });
 
@@ -923,17 +912,9 @@ export const switchSevenTvEmoteSet = async (
       return false;
     }
 
-    const oldSetEmoteIds = new Set(
-      (latest.sevenTvChannelEmotes ?? []).map(emote => emote.id),
-    );
-    const emotesWithoutOldSet = (latest.emotes ?? []).filter(
-      emote => !oldSetEmoteIds.has(emote.id),
-    );
-
     channelCache.assign({
       sevenTvEmoteSetId: newSetId,
       sevenTvChannelEmotes: newEmotes,
-      emotes: deduplicateById([...newEmotes, ...emotesWithoutOldSet]),
       lastUpdated: Date.now(),
     });
 

--- a/src/store/chat/actions/channelRefreshPlan.ts
+++ b/src/store/chat/actions/channelRefreshPlan.ts
@@ -1,8 +1,9 @@
-import type { ChannelCacheType } from '../types/constants';
+import type { ChannelCacheType, GlobalCacheType } from '../types/constants';
 import { BADGE_CACHE_DURATION, CACHE_DURATION } from '../types/constants';
 
 export interface ChannelRefreshPlanInput {
   cache: ChannelCacheType | undefined;
+  globalCache: GlobalCacheType | undefined;
   forceRefresh: boolean;
   now: number;
   twitchUserId?: string;
@@ -15,29 +16,38 @@ export interface CachedChannelRefreshPlan {
   fetchEmoteSetId: boolean;
   fetchSubscriberEmotes: boolean;
   refreshBadges: boolean;
+  refreshGlobalResources: boolean;
 }
 
 export type ChannelRefreshPlan = { kind: 'full' } | CachedChannelRefreshPlan;
 
-const EMOTE_SLICES = [
+const CHANNEL_EMOTE_SLICES = [
   'twitchChannelEmotes',
-  'twitchGlobalEmotes',
   'sevenTvChannelEmotes',
-  'sevenTvGlobalEmotes',
   'ffzChannelEmotes',
-  'ffzGlobalEmotes',
   'bttvChannelEmotes',
+] as const;
+
+const GLOBAL_EMOTE_SLICES = [
+  'twitchGlobalEmotes',
+  'sevenTvGlobalEmotes',
+  'ffzGlobalEmotes',
   'bttvGlobalEmotes',
 ] as const;
+
+const GLOBAL_BADGE_SLICES = ['twitchGlobalBadges', 'ffzGlobalBadges'] as const;
 
 /**
  * Pure freshness policy for a channel's cached resources: decides between a
  * full reload and serving the cache, and which slices of a served cache still
- * need fetching. Effects live in loadChannelResourcesInternal.
+ * need fetching. Global provider slices live in the shared global slot with
+ * their own freshness stamp, so they are judged separately from the channel's
+ * TTL. Effects live in loadChannelResourcesInternal.
  */
 export const planChannelRefresh = ({
   cache,
   forceRefresh,
+  globalCache,
   now,
   twitchUserId,
 }: ChannelRefreshPlanInput): ChannelRefreshPlan => {
@@ -46,9 +56,12 @@ export const planChannelRefresh = ({
   }
 
   const cacheAgeMs = now - cache.lastUpdated;
-  const hasEmptyEmotes = EMOTE_SLICES.every(
-    slice => (cache[slice]?.length || 0) === 0,
+  const hasEmptyGlobalEmotes = GLOBAL_EMOTE_SLICES.every(
+    slice => (globalCache?.[slice]?.length || 0) === 0,
   );
+  const hasEmptyEmotes =
+    CHANNEL_EMOTE_SLICES.every(slice => (cache[slice]?.length || 0) === 0) &&
+    hasEmptyGlobalEmotes;
 
   if (hasEmptyEmotes || cacheAgeMs >= CACHE_DURATION) {
     return { kind: 'full' };
@@ -56,6 +69,12 @@ export const planChannelRefresh = ({
 
   const badgeCacheAgeMs =
     now - (cache.badgesLastUpdated ?? cache.lastUpdated ?? 0);
+  const globalCacheAgeMs = now - (globalCache?.lastUpdated ?? 0);
+  const hasEmptyGlobalSlices =
+    hasEmptyGlobalEmotes &&
+    GLOBAL_BADGE_SLICES.every(
+      slice => (globalCache?.[slice]?.length || 0) === 0,
+    );
 
   return {
     kind: 'cached',
@@ -66,5 +85,7 @@ export const planChannelRefresh = ({
       twitchUserId && cache.twitchSubscriberEmotesUserId !== twitchUserId,
     ),
     refreshBadges: badgeCacheAgeMs >= BADGE_CACHE_DURATION,
+    refreshGlobalResources:
+      hasEmptyGlobalSlices || globalCacheAgeMs >= CACHE_DURATION,
   };
 };

--- a/src/store/chat/actions/channelResources.ts
+++ b/src/store/chat/actions/channelResources.ts
@@ -9,7 +9,7 @@ import type { SanitisedEmote } from '@app/types/emote';
 import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
 import { logger } from '@app/utils/logger';
 
-import type { ChannelCacheType } from '../types/constants';
+import type { ChannelCacheType, GlobalCacheType } from '../types/constants';
 
 export type ProviderName = 'bttv' | 'ffz' | 'seven_tv' | 'twitch';
 export type ProviderResourceScope = 'channel' | 'global' | 'local' | 'personal';
@@ -17,14 +17,39 @@ export type ProviderResourceType = 'badges' | 'emotes';
 
 export type Identifiable = { id: string };
 
+export type ChannelEmoteCacheKey =
+  | 'bttvChannelEmotes'
+  | 'ffzChannelEmotes'
+  | 'sevenTvChannelEmotes'
+  | 'twitchChannelEmotes'
+  | 'twitchSubscriberEmotes';
+
+export type GlobalEmoteCacheKey =
+  | 'bttvGlobalEmotes'
+  | 'ffzGlobalEmotes'
+  | 'sevenTvGlobalEmotes'
+  | 'twitchGlobalEmotes';
+
+export type EmoteCacheKey = ChannelEmoteCacheKey | GlobalEmoteCacheKey;
+
+export type ChannelBadgeCacheKey = 'ffzChannelBadges' | 'twitchChannelBadges';
+
+export type GlobalBadgeCacheKey = 'ffzGlobalBadges' | 'twitchGlobalBadges';
+
+export type BadgeCacheKey = ChannelBadgeCacheKey | GlobalBadgeCacheKey;
+
+export type ResourceCacheKey = EmoteCacheKey | BadgeCacheKey;
+
 /**
  * One ordered description of a single (provider, scope) resource: how to fetch
  * it, which cache field it populates, and how to label it in logs. The spec
  * list is the seam — adding a provider is a single entry, and the fan-out,
- * reporting, cache-reconcile, and merge are all driven from it.
+ * reporting, cache-reconcile, and merge are all driven from it. Channel-scope
+ * specs populate the per-channel cache; global-scope specs populate the shared
+ * `persisted.globalCaches` slot.
  */
 export interface ResourceSpec<
-  TKey extends keyof ChannelCacheType,
+  TKey extends ResourceCacheKey,
   TItem extends Identifiable,
 > {
   key: TKey;
@@ -43,38 +68,27 @@ export interface ResourceSpec<
   fetch: () => Promise<TItem[]>;
 }
 
-export type EmoteCacheKey =
-  | 'bttvChannelEmotes'
-  | 'bttvGlobalEmotes'
-  | 'ffzChannelEmotes'
-  | 'ffzGlobalEmotes'
-  | 'sevenTvChannelEmotes'
-  | 'sevenTvGlobalEmotes'
-  | 'twitchChannelEmotes'
-  | 'twitchGlobalEmotes'
-  | 'twitchSubscriberEmotes';
-
-export type BadgeCacheKey =
-  | 'ffzChannelBadges'
-  | 'ffzGlobalBadges'
-  | 'twitchChannelBadges'
-  | 'twitchGlobalBadges';
-
-export type EmoteResourceSets = Pick<ChannelCacheType, EmoteCacheKey>;
-export type BadgeResourceSets = Pick<ChannelCacheType, BadgeCacheKey>;
+export type ChannelEmoteResourceSets = Pick<
+  ChannelCacheType,
+  ChannelEmoteCacheKey
+>;
+export type ChannelBadgeResourceSets = Pick<
+  ChannelCacheType,
+  ChannelBadgeCacheKey
+>;
 
 export type EmoteResourceSpec = ResourceSpec<EmoteCacheKey, SanitisedEmote>;
 export type BadgeResourceSpec = ResourceSpec<BadgeCacheKey, SanitisedBadgeSet>;
 
 export type SettledSpec<
-  TKey extends keyof ChannelCacheType,
+  TKey extends ResourceCacheKey,
   TItem extends Identifiable,
 > = {
   spec: ResourceSpec<TKey, TItem>;
   result: PromiseSettledResult<TItem[]>;
 };
 
-type AnySettledSpec = SettledSpec<keyof ChannelCacheType, Identifiable>;
+type AnySettledSpec = SettledSpec<ResourceCacheKey, Identifiable>;
 
 export const deduplicateById = <T extends Identifiable>(
   items: readonly T[],
@@ -145,6 +159,102 @@ export const buildSubscriberEmoteSpec = ({
  */
 export const SEVEN_TV_SET_ID_LOOKUP_BUDGET_MS = 3000;
 
+const SEVEN_TV_GLOBAL_EMOTE_SPEC: EmoteResourceSpec = {
+  key: 'sevenTvGlobalEmotes',
+  name: 'seven_tv_global_emotes',
+  label: '7TV global emotes',
+  provider: 'seven_tv',
+  resourceType: 'emotes',
+  scope: 'global',
+  warningName: 'seven_tv_emotes_warning',
+  fetch: () =>
+    fetchGlobalResourceOnce('seven_tv_global_emotes', () =>
+      sevenTvService.getSanitisedEmoteSet('global'),
+    ),
+};
+
+const TWITCH_GLOBAL_EMOTE_SPEC: EmoteResourceSpec = {
+  key: 'twitchGlobalEmotes',
+  name: 'twitch_global_emotes',
+  label: 'Twitch global emotes',
+  provider: 'twitch',
+  resourceType: 'emotes',
+  scope: 'global',
+  warningName: 'twitch_emotes_warning',
+  fetch: () =>
+    fetchGlobalResourceOnce('twitch_global_emotes', () =>
+      twitchEmoteService.getGlobalEmotes(),
+    ),
+};
+
+const BTTV_GLOBAL_EMOTE_SPEC: EmoteResourceSpec = {
+  key: 'bttvGlobalEmotes',
+  name: 'bttv_global_emotes',
+  label: 'BTTV global emotes',
+  provider: 'bttv',
+  resourceType: 'emotes',
+  scope: 'global',
+  warningName: 'bttv_emotes_warning',
+  fetch: () =>
+    fetchGlobalResourceOnce('bttv_global_emotes', () =>
+      bttvEmoteService.getSanitisedGlobalEmotes(),
+    ),
+};
+
+const FFZ_GLOBAL_EMOTE_SPEC: EmoteResourceSpec = {
+  key: 'ffzGlobalEmotes',
+  name: 'ffz_global_emotes',
+  label: 'FFZ global emotes',
+  provider: 'ffz',
+  resourceType: 'emotes',
+  scope: 'global',
+  warningName: 'ffz_emotes_warning',
+  fetch: () =>
+    fetchGlobalResourceOnce('ffz_global_emotes', () =>
+      ffzService.getSanitisedGlobalEmotes(),
+    ),
+};
+
+const TWITCH_GLOBAL_BADGE_SPEC: BadgeResourceSpec = {
+  key: 'twitchGlobalBadges',
+  name: 'twitch_global_badges',
+  label: 'Twitch global badges',
+  provider: 'twitch',
+  resourceType: 'badges',
+  scope: 'global',
+  warningName: 'twitch_badges_warning',
+  fetch: () =>
+    fetchGlobalResourceOnce('twitch_global_badges', () =>
+      twitchBadgeService.listSanitisedGlobalBadges(),
+    ),
+};
+
+const FFZ_GLOBAL_BADGE_SPEC: BadgeResourceSpec = {
+  key: 'ffzGlobalBadges',
+  name: 'ffz_global_badges',
+  label: 'FFZ global badges',
+  provider: 'ffz',
+  resourceType: 'badges',
+  scope: 'global',
+  warningName: 'ffz_badges_warning',
+  fetch: () =>
+    fetchGlobalResourceOnce('ffz_global_badges', () =>
+      ffzService.getSanitisedGlobalBadges(),
+    ),
+};
+
+export const buildGlobalEmoteResourceSpecs = (): EmoteResourceSpec[] => [
+  SEVEN_TV_GLOBAL_EMOTE_SPEC,
+  TWITCH_GLOBAL_EMOTE_SPEC,
+  BTTV_GLOBAL_EMOTE_SPEC,
+  FFZ_GLOBAL_EMOTE_SPEC,
+];
+
+export const buildGlobalBadgeResourceSpecs = (): BadgeResourceSpec[] => [
+  TWITCH_GLOBAL_BADGE_SPEC,
+  FFZ_GLOBAL_BADGE_SPEC,
+];
+
 export const buildEmoteResourceSpecs = ({
   channelId,
   sevenTvSetId,
@@ -187,19 +297,7 @@ export const buildEmoteResourceSpecs = ({
       return sevenTvService.getSanitisedEmoteSet(resolvedSetId);
     },
   },
-  {
-    key: 'sevenTvGlobalEmotes',
-    name: 'seven_tv_global_emotes',
-    label: '7TV global emotes',
-    provider: 'seven_tv',
-    resourceType: 'emotes',
-    scope: 'global',
-    warningName: 'seven_tv_emotes_warning',
-    fetch: () =>
-      fetchGlobalResourceOnce('seven_tv_global_emotes', () =>
-        sevenTvService.getSanitisedEmoteSet('global'),
-      ),
-  },
+  SEVEN_TV_GLOBAL_EMOTE_SPEC,
   {
     key: 'twitchChannelEmotes',
     name: 'twitch_channel_emotes',
@@ -210,33 +308,9 @@ export const buildEmoteResourceSpecs = ({
     warningName: 'twitch_emotes_warning',
     fetch: () => twitchEmoteService.getChannelEmotes(channelId),
   },
-  {
-    key: 'twitchGlobalEmotes',
-    name: 'twitch_global_emotes',
-    label: 'Twitch global emotes',
-    provider: 'twitch',
-    resourceType: 'emotes',
-    scope: 'global',
-    warningName: 'twitch_emotes_warning',
-    fetch: () =>
-      fetchGlobalResourceOnce('twitch_global_emotes', () =>
-        twitchEmoteService.getGlobalEmotes(),
-      ),
-  },
+  TWITCH_GLOBAL_EMOTE_SPEC,
   buildSubscriberEmoteSpec({ channelId, twitchUserId }),
-  {
-    key: 'bttvGlobalEmotes',
-    name: 'bttv_global_emotes',
-    label: 'BTTV global emotes',
-    provider: 'bttv',
-    resourceType: 'emotes',
-    scope: 'global',
-    warningName: 'bttv_emotes_warning',
-    fetch: () =>
-      fetchGlobalResourceOnce('bttv_global_emotes', () =>
-        bttvEmoteService.getSanitisedGlobalEmotes(),
-      ),
-  },
+  BTTV_GLOBAL_EMOTE_SPEC,
   {
     key: 'bttvChannelEmotes',
     name: 'bttv_channel_emotes',
@@ -257,19 +331,7 @@ export const buildEmoteResourceSpecs = ({
     warningName: 'ffz_emotes_warning',
     fetch: () => ffzService.getSanitisedChannelEmotes(channelId),
   },
-  {
-    key: 'ffzGlobalEmotes',
-    name: 'ffz_global_emotes',
-    label: 'FFZ global emotes',
-    provider: 'ffz',
-    resourceType: 'emotes',
-    scope: 'global',
-    warningName: 'ffz_emotes_warning',
-    fetch: () =>
-      fetchGlobalResourceOnce('ffz_global_emotes', () =>
-        ffzService.getSanitisedGlobalEmotes(),
-      ),
-  },
+  FFZ_GLOBAL_EMOTE_SPEC,
 ];
 
 export const buildBadgeResourceSpecs = ({
@@ -287,32 +349,8 @@ export const buildBadgeResourceSpecs = ({
     warningName: 'twitch_badges_warning',
     fetch: () => twitchBadgeService.listSanitisedChannelBadges(channelId),
   },
-  {
-    key: 'twitchGlobalBadges',
-    name: 'twitch_global_badges',
-    label: 'Twitch global badges',
-    provider: 'twitch',
-    resourceType: 'badges',
-    scope: 'global',
-    warningName: 'twitch_badges_warning',
-    fetch: () =>
-      fetchGlobalResourceOnce('twitch_global_badges', () =>
-        twitchBadgeService.listSanitisedGlobalBadges(),
-      ),
-  },
-  {
-    key: 'ffzGlobalBadges',
-    name: 'ffz_global_badges',
-    label: 'FFZ global badges',
-    provider: 'ffz',
-    resourceType: 'badges',
-    scope: 'global',
-    warningName: 'ffz_badges_warning',
-    fetch: () =>
-      fetchGlobalResourceOnce('ffz_global_badges', () =>
-        ffzService.getSanitisedGlobalBadges(),
-      ),
-  },
+  TWITCH_GLOBAL_BADGE_SPEC,
+  FFZ_GLOBAL_BADGE_SPEC,
   {
     key: 'ffzChannelBadges',
     name: 'ffz_channel_badges',
@@ -356,7 +394,7 @@ const withTimeout = <T>(
   });
 
 export const settleSpecs = async <
-  TKey extends keyof ChannelCacheType,
+  TKey extends ResourceCacheKey,
   TItem extends Identifiable,
 >(
   specs: readonly ResourceSpec<TKey, TItem>[],
@@ -371,27 +409,43 @@ export const settleSpecs = async <
 export interface ResourceCacheContext {
   channelId: string;
   existingCache: ChannelCacheType | undefined;
+  existingGlobalCache: GlobalCacheType | undefined;
 }
 
+const getCachedSliceForSpec = (
+  spec: ResourceSpec<ResourceCacheKey, Identifiable>,
+  {
+    existingCache,
+    existingGlobalCache,
+  }: Pick<ResourceCacheContext, 'existingCache' | 'existingGlobalCache'>,
+): Identifiable[] =>
+  spec.scope === 'global'
+    ? (existingGlobalCache?.[
+        spec.key as GlobalEmoteCacheKey | GlobalBadgeCacheKey
+      ] ?? [])
+    : (existingCache?.[
+        spec.key as ChannelEmoteCacheKey | ChannelBadgeCacheKey
+      ] ?? []);
+
 const reconcileSettledSpec = <
-  TKey extends keyof ChannelCacheType,
+  TKey extends ResourceCacheKey,
   TItem extends Identifiable,
 >(
   { result, spec }: SettledSpec<TKey, TItem>,
-  { channelId, existingCache }: ResourceCacheContext,
+  context: ResourceCacheContext,
 ): TItem[] => {
   if (result.status === 'fulfilled') {
     return deduplicateById(result.value);
   }
 
-  const cachedItems = (existingCache?.[spec.key] ?? []) as unknown as TItem[];
+  const cachedItems = getCachedSliceForSpec(spec, context) as TItem[];
 
   if (cachedItems.length > 0) {
     logger.chat.info(`Using cached ${spec.label} as fallback`, {
       name: 'chat_resources_info',
       action: 'provider_resource_cache_fallback_used',
       cached_count: cachedItems.length,
-      channel_id: channelId,
+      channel_id: context.channelId,
       provider: spec.provider,
       resource_name: spec.label,
       resource_type: spec.resourceType,
@@ -404,7 +458,7 @@ const reconcileSettledSpec = <
 };
 
 export const reconcileSettledSpecs = <
-  TKey extends keyof ChannelCacheType,
+  TKey extends ResourceCacheKey,
   TItem extends Identifiable,
 >(
   settled: readonly SettledSpec<TKey, TItem>[],
@@ -511,22 +565,17 @@ export const collectFailedProviderReasons = (
 
 /**
  * True when at least one rejected resource spec still has a non-empty slice in
- * the channel cache to fall back to.
+ * its cache (the channel cache for channel-scope specs, the shared global
+ * slot for global-scope specs) to fall back to.
  */
 export const hadCachedResourcesForFailedSpecs = (
-  existingCache: ChannelCacheType | undefined,
+  context: Omit<ResourceCacheContext, 'channelId'>,
   settled: readonly AnySettledSpec[],
-): boolean => {
-  if (!existingCache) {
-    return false;
-  }
-
-  return settled.some(({ result, spec }) => {
+): boolean =>
+  settled.some(({ result, spec }) => {
     if (result.status !== 'rejected') {
       return false;
     }
 
-    const cached = existingCache[spec.key as keyof ChannelCacheType];
-    return Array.isArray(cached) && cached.length > 0;
+    return getCachedSliceForSpec(spec, context).length > 0;
   });
-};

--- a/src/store/chat/actions/channelResources.ts
+++ b/src/store/chat/actions/channelResources.ts
@@ -564,9 +564,8 @@ export const collectFailedProviderReasons = (
 };
 
 /**
- * True when at least one rejected resource spec still has a non-empty slice in
- * its cache (the channel cache for channel-scope specs, the shared global
- * slot for global-scope specs) to fall back to.
+ * True when at least one rejected resource spec still has a non-empty cached
+ * slice to fall back to.
  */
 export const hadCachedResourcesForFailedSpecs = (
   context: Omit<ResourceCacheContext, 'channelId'>,

--- a/src/store/chat/actions/channelResources.ts
+++ b/src/store/chat/actions/channelResources.ts
@@ -80,10 +80,6 @@ export const deduplicateById = <T extends Identifiable>(
   items: readonly T[],
 ): T[] => Array.from(new Map(items.map(item => [item.id, item])).values());
 
-export const combineUniqueById = <T extends Identifiable>(
-  ...itemGroups: readonly T[][]
-): T[] => deduplicateById(itemGroups.flat());
-
 /**
  * Global (channel-independent) provider data is identical for every channel,
  * so re-downloading it on each channel join wastes a round trip per provider.

--- a/src/store/chat/actions/chatDebugLog.ts
+++ b/src/store/chat/actions/chatDebugLog.ts
@@ -1,5 +1,6 @@
 import { getBadge, getPaint } from '@app/store/chat/actions/cosmetics';
 import { getMissingBadgeIds } from '@app/store/chat/actions/missingBadges';
+import { getChannelPersonalEmotes } from '@app/store/chat/actions/personalEmotes';
 import { chatStore$ } from '@app/store/chat/observables/chatStore';
 import type { SanitisedEmote } from '@app/types/emote';
 import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
@@ -201,20 +202,23 @@ export function getChatDebugEmoteSources(): Record<string, unknown> {
   if (!cache) {
     return { channelId, cacheLoaded: false };
   }
+  const globalCaches = chatStore$.persisted.globalCaches.peek();
   return {
     channelId,
     lastUpdated: formatCacheAge(cache.lastUpdated),
+    globalsLastUpdated: formatCacheAge(globalCaches.lastUpdated),
     sevenTvEmoteSetId: cache.sevenTvEmoteSetId ?? null,
     twitchChannel: cache.twitchChannelEmotes.length,
-    twitchGlobal: cache.twitchGlobalEmotes.length,
+    twitchGlobal: globalCaches.twitchGlobalEmotes.length,
     twitchSubscriber: cache.twitchSubscriberEmotes.length,
     sevenTvChannel: cache.sevenTvChannelEmotes.length,
-    sevenTvGlobal: cache.sevenTvGlobalEmotes.length,
-    sevenTvPersonalUsers: Object.keys(cache.sevenTvPersonalEmotes).length,
+    sevenTvGlobal: globalCaches.sevenTvGlobalEmotes.length,
+    sevenTvPersonalUsers: Object.keys(getChannelPersonalEmotes(channelId))
+      .length,
     bttvChannel: cache.bttvChannelEmotes.length,
-    bttvGlobal: cache.bttvGlobalEmotes.length,
+    bttvGlobal: globalCaches.bttvGlobalEmotes.length,
     ffzChannel: cache.ffzChannelEmotes.length,
-    ffzGlobal: cache.ffzGlobalEmotes.length,
+    ffzGlobal: globalCaches.ffzGlobalEmotes.length,
   };
 }
 
@@ -222,26 +226,27 @@ export function getChatDebugEmoteDetails(emote: {
   id?: string;
   name?: string;
 }): Record<string, unknown> {
-  const { cache } = getCurrentChannelCache();
+  const { channelId, cache } = getCurrentChannelCache();
   if (!cache) {
     return { foundInCache: false, cacheLoaded: false };
   }
 
+  const globalCaches = chatStore$.persisted.globalCaches.peek();
   const lists: [string, SanitisedEmote[]][] = [
     ['sevenTvChannel', cache.sevenTvChannelEmotes],
-    ['sevenTvGlobal', cache.sevenTvGlobalEmotes],
-    ...Object.entries(cache.sevenTvPersonalEmotes).map(
+    ['sevenTvGlobal', globalCaches.sevenTvGlobalEmotes],
+    ...Object.entries(getChannelPersonalEmotes(channelId)).map(
       ([ownerId, emotes]): [string, SanitisedEmote[]] => [
         `sevenTvPersonal:${ownerId}`,
         emotes,
       ],
     ),
     ['bttvChannel', cache.bttvChannelEmotes],
-    ['bttvGlobal', cache.bttvGlobalEmotes],
+    ['bttvGlobal', globalCaches.bttvGlobalEmotes],
     ['ffzChannel', cache.ffzChannelEmotes],
-    ['ffzGlobal', cache.ffzGlobalEmotes],
+    ['ffzGlobal', globalCaches.ffzGlobalEmotes],
     ['twitchChannel', cache.twitchChannelEmotes],
-    ['twitchGlobal', cache.twitchGlobalEmotes],
+    ['twitchGlobal', globalCaches.twitchGlobalEmotes],
     ['twitchSubscriber', cache.twitchSubscriberEmotes],
   ];
 
@@ -284,14 +289,15 @@ export function getChatDebugBadgeSources(): Record<string, unknown> {
   if (!cache) {
     return { channelId, cacheLoaded: false };
   }
+  const globalCaches = chatStore$.persisted.globalCaches.peek();
   return {
     channelId,
     badgesLastUpdated: formatCacheAge(cache.badgesLastUpdated),
+    globalsLastUpdated: formatCacheAge(globalCaches.lastUpdated),
     twitchChannel: cache.twitchChannelBadges.length,
-    twitchGlobal: cache.twitchGlobalBadges.length,
+    twitchGlobal: globalCaches.twitchGlobalBadges.length,
     ffzChannel: cache.ffzChannelBadges.length,
-    ffzGlobal: cache.ffzGlobalBadges.length,
-    sevenTvPersonalUsers: Object.keys(cache.sevenTvPersonalBadges).length,
+    ffzGlobal: globalCaches.ffzGlobalBadges.length,
     sevenTvBadgeDefinitions: Object.keys(chatStore$.badges.peek()).length,
     sevenTvBadgeWearers: Object.keys(chatStore$.userBadgeIds.peek()).length,
     missingSevenTvBadgeIds: getMissingBadgeIds(),
@@ -333,11 +339,10 @@ export function getChatDebugUserSnapshot(
     }
   }
 
-  const { cache } = getCurrentChannelCache();
-  const personalEmotes =
-    userId && cache ? (cache.sevenTvPersonalEmotes[userId] ?? []) : [];
-  const personalBadges =
-    userId && cache ? (cache.sevenTvPersonalBadges[userId] ?? []) : [];
+  const { channelId } = getCurrentChannelCache();
+  const personalEmotes = userId
+    ? (getChannelPersonalEmotes(channelId)[userId] ?? [])
+    : [];
 
   return {
     login: target || null,
@@ -347,7 +352,6 @@ export function getChatDebugUserSnapshot(
     sevenTvBadgeId: badgeId,
     sevenTvBadgeTitle: badgeId ? (getBadge(badgeId)?.title ?? null) : null,
     sevenTvPersonalEmotes: personalEmotes.map(emote => emote.name),
-    sevenTvPersonalBadges: personalBadges.map(badge => badge.title),
     latestMessage: latestMessage
       ? {
           messageId: latestMessage.message_id,

--- a/src/store/chat/actions/cosmetics.ts
+++ b/src/store/chat/actions/cosmetics.ts
@@ -209,12 +209,22 @@ function getCachedUserCosmetics(
       SEVEN_TV_CACHE_NAMESPACE,
     ) ?? undefined;
 
-  if (stored) {
+  // An unresolvable snapshot is not servable, so promoting it into the
+  // session map would only churn the map on every sighting of the user.
+  if (stored && hasResolvableCosmeticDefinitions(stored)) {
     cacheSessionCosmetics(sevenTvUserId, stored);
   }
 
   return stored;
 }
+
+const deleteCachedUserCosmetics = (sevenTvUserId: string): void => {
+  sessionCosmeticsCache.delete(sevenTvUserId);
+  storageService.delete(
+    getUserCosmeticsStorageKey(sevenTvUserId),
+    SEVEN_TV_CACHE_NAMESPACE,
+  );
+};
 
 function setCachedUserCosmetics(
   sevenTvUserId: string,
@@ -273,6 +283,11 @@ export const fetchAndCacheUserCosmetics = async (
     try {
       const cosmetics = await sevenTvService.getUserCosmeticsGql(sevenTvUserId);
       if (!cosmetics) {
+        // Without this, an unresolvable snapshot stays a guaranteed miss for
+        // its whole TTL and re-fires this fetch on every sighting.
+        if (cached && ctx.stillCurrent()) {
+          deleteCachedUserCosmetics(sevenTvUserId);
+        }
         return null;
       }
 
@@ -309,6 +324,9 @@ export const fetchAndCacheUserCosmetics = async (
         `Error fetching cosmetics for user ${sevenTvUserId}:`,
         error,
       );
+      if (cached && ctx.stillCurrent()) {
+        deleteCachedUserCosmetics(sevenTvUserId);
+      }
       return null;
     }
   });
@@ -418,7 +436,15 @@ const sweepUnreferencedPaints = () => {
   if (paintIds.length < MAX_PAINT_DEFINITIONS) {
     return;
   }
+  // Session snapshots resolve against these definitions too - sweeping a
+  // paint a cached snapshot still points at would turn that snapshot into a
+  // guaranteed refetch on its next sighting.
   const referenced = new Set(Object.values(chatStore$.userPaintIds.peek()));
+  for (const cosmetics of sessionCosmeticsCache.values()) {
+    if (cosmetics.paintId) {
+      referenced.add(cosmetics.paintId);
+    }
+  }
   const next: typeof paints = {};
   paintIds.forEach(paintId => {
     if (referenced.has(paintId)) {
@@ -517,6 +543,11 @@ const sweepUnreferencedBadges = () => {
     return;
   }
   const referenced = new Set(Object.values(chatStore$.userBadgeIds.peek()));
+  for (const cosmetics of sessionCosmeticsCache.values()) {
+    if (cosmetics.badgeId) {
+      referenced.add(cosmetics.badgeId);
+    }
+  }
   const next: typeof badges = {};
   badgeIds.forEach(badgeId => {
     if (referenced.has(badgeId)) {

--- a/src/store/chat/actions/cosmetics.ts
+++ b/src/store/chat/actions/cosmetics.ts
@@ -100,11 +100,15 @@ const USER_COSMETICS_CACHE_TTL_MS = 2 * 60 * 60 * 1000;
 const USER_COSMETICS_NEGATIVE_CACHE_TTL_MS = 30 * 60 * 1000;
 const SEVEN_TV_CACHE_NAMESPACE = 'seven_tv_cache';
 
+/**
+ * Per-user cosmetics snapshot: binding ids only. Definitions live once in
+ * `chatStore$.paints` / `chatStore$.badges` (persisted via the cosmetics
+ * snapshot) and are resolved by id at apply time - embedding a copy per
+ * wearer duplicated every popular paint hundreds of times.
+ */
 export type CachedUserCosmetics = {
-  badge?: SanitisedBadgeSet;
   badgeId: string | null;
   expiresAt: number;
-  paint?: PaintData;
   paintId: string | null;
   ttvUserId: string | null;
 };
@@ -161,26 +165,32 @@ const convertV4BadgeToSanitised = (badge: V4Badge): SanitisedBadgeSet => {
 };
 
 function applyCachedUserCosmetics(cosmetics: CachedUserCosmetics) {
+  if (!cosmetics.ttvUserId) {
+    return;
+  }
+  const { badgeId, paintId, ttvUserId } = cosmetics;
   batch(() => {
-    if (cosmetics.paint) {
-      addPaint(cosmetics.paint);
+    if (paintId) {
+      setUserPaint(ttvUserId, paintId);
     }
 
-    if (cosmetics.badge) {
-      addBadge(cosmetics.badge);
-    }
-
-    if (cosmetics.ttvUserId) {
-      if (cosmetics.paintId) {
-        setUserPaint(cosmetics.ttvUserId, cosmetics.paintId);
-      }
-
-      if (cosmetics.badgeId) {
-        setUserBadge(cosmetics.ttvUserId, cosmetics.badgeId);
-      }
+    if (badgeId) {
+      setUserBadge(ttvUserId, badgeId);
     }
   });
 }
+
+/**
+ * A snapshot is only servable when every bound id resolves against the
+ * definitions we hold; an id without its definition (old embedded-shape
+ * blobs, or a definitions store that was cleared since the snapshot was
+ * written) must fall through to a refetch instead of binding to nothing.
+ */
+const hasResolvableCosmeticDefinitions = (
+  cosmetics: CachedUserCosmetics,
+): boolean =>
+  (!cosmetics.paintId || Boolean(getPaint(cosmetics.paintId))) &&
+  (!cosmetics.badgeId || Boolean(getBadge(cosmetics.badgeId)));
 
 function getCachedUserCosmetics(
   sevenTvUserId: string,
@@ -224,17 +234,14 @@ function buildCachedUserCosmeticsFromStore(
 ): CachedUserCosmetics {
   const paintId = chatStore$.userPaintIds[ttvUserId]?.peek() ?? null;
   const badgeId = chatStore$.userBadgeIds[ttvUserId]?.peek() ?? null;
-  const badge = badgeId ? getBadge(badgeId) : undefined;
 
   return {
-    badge: badge?.url?.trim() ? badge : undefined,
     badgeId,
     expiresAt:
       Date.now() +
       (paintId || badgeId
         ? USER_COSMETICS_CACHE_TTL_MS
         : USER_COSMETICS_NEGATIVE_CACHE_TTL_MS),
-    paint: paintId ? getPaint(paintId) : undefined,
     paintId,
     ttvUserId,
   };
@@ -253,24 +260,11 @@ export const syncCachedUserCosmeticsFromStore = (
   );
 };
 
-function refreshCachedUserCosmeticsForDefinition(cosmeticId: string): void {
-  for (const [sevenTvUserId, cached] of Array.from(
-    sessionCosmeticsCache.entries(),
-  )) {
-    if (
-      cached.ttvUserId &&
-      (cached.paintId === cosmeticId || cached.badgeId === cosmeticId)
-    ) {
-      syncCachedUserCosmeticsFromStore(sevenTvUserId, cached.ttvUserId);
-    }
-  }
-}
-
 export const fetchAndCacheUserCosmetics = async (
   sevenTvUserId: string,
 ): Promise<string | null> => {
   const cached = getCachedUserCosmetics(sevenTvUserId);
-  if (cached) {
+  if (cached && hasResolvableCosmeticDefinitions(cached)) {
     applyCachedUserCosmetics(cached);
     return cached.ttvUserId;
   }
@@ -289,19 +283,23 @@ export const fetchAndCacheUserCosmetics = async (
         ? convertV4BadgeToSanitised(cosmetics.badge)
         : undefined;
       const cachedCosmetics: CachedUserCosmetics = {
-        badge,
         badgeId: cosmetics.badgeId,
         expiresAt:
           Date.now() +
           (paint || badge
             ? USER_COSMETICS_CACHE_TTL_MS
             : USER_COSMETICS_NEGATIVE_CACHE_TTL_MS),
-        paint,
         paintId: cosmetics.paintId,
         ttvUserId: cosmetics.ttvUserId,
       };
 
       if (ctx.stillCurrent()) {
+        if (paint) {
+          addPaint(paint);
+        }
+        if (badge) {
+          addBadge(badge);
+        }
         setCachedUserCosmetics(sevenTvUserId, cachedCosmetics);
         applyCachedUserCosmetics(cachedCosmetics);
       }
@@ -442,7 +440,6 @@ export const addPaint = (paint: PaintData) => {
     sweepUnreferencedPaints();
     chatStore$.paints[paint.id]?.set(paint);
     scheduleCosmeticsPersist('definitions');
-    refreshCachedUserCosmeticsForDefinition(paint.id);
   }
 };
 
@@ -550,8 +547,6 @@ export const addBadge = (badge: SanitisedBadgeSet) => {
   if (previousUrl !== normalizedBadge.url.trim()) {
     scheduleCosmeticBindingsBump();
   }
-
-  refreshCachedUserCosmeticsForDefinition(badge.id);
 };
 
 export const getBadge = (badgeId: string): SanitisedBadgeSet | undefined => {

--- a/src/store/chat/actions/cosmetics.ts
+++ b/src/store/chat/actions/cosmetics.ts
@@ -449,6 +449,17 @@ export const getPaint = (paintId: string): PaintData | undefined =>
 export const getUserPaintId = (ttvUserId: string): string | undefined =>
   chatStore$.userPaintIds[ttvUserId]?.peek();
 
+/**
+ * Per-user has-a-paint memo, read imperatively per chat row - a plain bounded
+ * Map per the chat-state rule, since routing it through an observable cloned
+ * and key-diffed the whole bucket on every write.
+ */
+const userPaintFlags = new Map<string, boolean>();
+
+export const clearUserPaintFlagCache = (): void => {
+  userPaintFlags.clear();
+};
+
 let userPaintFlagInvalidatorAttached = false;
 
 /**
@@ -461,18 +472,17 @@ function ensureUserPaintFlagInvalidator(): void {
     return;
   }
   userPaintFlagInvalidatorAttached = true;
-  const clear = () => chatStore$.sessionCaches.userPaintFlags.set({});
   chatStore$.userPaintIds.onChange(({ changes }) => {
     for (const change of changes) {
       const changedUserId = change.path[0];
       if (typeof changedUserId !== 'string') {
-        clear();
+        clearUserPaintFlagCache();
         return;
       }
-      chatStore$.sessionCaches.userPaintFlags[changedUserId]?.delete();
+      userPaintFlags.delete(changedUserId);
     }
   });
-  chatStore$.paints.onChange(clear);
+  chatStore$.paints.onChange(clearUserPaintFlagCache);
 }
 
 export const hasUserPaint = (ttvUserId?: string): boolean => {
@@ -482,7 +492,7 @@ export const hasUserPaint = (ttvUserId?: string): boolean => {
 
   ensureUserPaintFlagInvalidator();
 
-  const cached = chatStore$.sessionCaches.userPaintFlags[ttvUserId]?.peek();
+  const cached = userPaintFlags.get(ttvUserId);
   if (cached !== undefined) {
     return cached;
   }
@@ -490,13 +500,30 @@ export const hasUserPaint = (ttvUserId?: string): boolean => {
   const paintId = getUserPaintId(ttvUserId);
   const result = Boolean(paintId && getPaint(paintId));
 
-  const flags = chatStore$.sessionCaches.userPaintFlags;
-  if (Object.keys(flags.peek()).length >= MAX_COSMETIC_ENTRIES) {
-    flags.set({});
+  if (userPaintFlags.size >= MAX_COSMETIC_ENTRIES) {
+    userPaintFlags.clear();
   }
-  flags[ttvUserId]?.set(result);
+  userPaintFlags.set(ttvUserId, result);
 
   return result;
+};
+
+const MAX_BADGE_DEFINITIONS = 750;
+
+const sweepUnreferencedBadges = () => {
+  const badges = chatStore$.badges.peek();
+  const badgeIds = Object.keys(badges);
+  if (badgeIds.length < MAX_BADGE_DEFINITIONS) {
+    return;
+  }
+  const referenced = new Set(Object.values(chatStore$.userBadgeIds.peek()));
+  const next: typeof badges = {};
+  badgeIds.forEach(badgeId => {
+    if (referenced.has(badgeId)) {
+      next[badgeId] = badges[badgeId] as SanitisedBadgeSet;
+    }
+  });
+  chatStore$.badges.set(next);
 };
 
 /**
@@ -541,6 +568,7 @@ export const addBadge = (badge: SanitisedBadgeSet) => {
   }
 
   const previousUrl = previous?.url?.trim();
+  sweepUnreferencedBadges();
   cell?.set(normalizedBadge);
   scheduleCosmeticsPersist('definitions');
 

--- a/src/store/chat/actions/cosmetics.ts
+++ b/src/store/chat/actions/cosmetics.ts
@@ -181,10 +181,9 @@ function applyCachedUserCosmetics(cosmetics: CachedUserCosmetics) {
 }
 
 /**
- * A snapshot is only servable when every bound id resolves against the
- * definitions we hold; an id without its definition (old embedded-shape
- * blobs, or a definitions store that was cleared since the snapshot was
- * written) must fall through to a refetch instead of binding to nothing.
+ * An id without its definition (old embedded-shape blobs, or a definitions
+ * store cleared since the snapshot was written) must fall through to a
+ * refetch instead of binding to nothing.
  */
 const hasResolvableCosmeticDefinitions = (
   cosmetics: CachedUserCosmetics,
@@ -324,9 +323,9 @@ export const fetchAndCacheUserCosmetics = async (
         `Error fetching cosmetics for user ${sevenTvUserId}:`,
         error,
       );
-      if (cached && ctx.stillCurrent()) {
-        deleteCachedUserCosmetics(sevenTvUserId);
-      }
+      // A transport error keeps the snapshot: its ids may resolve again once
+      // the deferred cosmetics hydration lands. Only a definitive null
+      // response above deletes it.
       return null;
     }
   });

--- a/src/store/chat/actions/personalEmotes.ts
+++ b/src/store/chat/actions/personalEmotes.ts
@@ -30,10 +30,21 @@ export const getChannelPersonalEmotes = (
   (channelId ? personalEmotesByChannel.get(channelId) : undefined) ??
   EMPTY_PERSONAL_EMOTES;
 
+/**
+ * Drops one channel's sets and the fetch-once stamps of the users they
+ * belonged to, so those users refetch instead of short-circuiting into the
+ * emptied cache.
+ */
 export const clearChannelPersonalEmotes = (channelId: string): void => {
-  if (personalEmotesByChannel.delete(channelId)) {
-    chatStore$.personalEmotesVersion.set(version => version + 1);
+  const channelEmotes = personalEmotesByChannel.get(channelId);
+  if (!channelEmotes) {
+    return;
   }
+  for (const twitchUserId of Object.keys(channelEmotes)) {
+    personalEmotesGuard.clearKey(twitchUserId);
+  }
+  personalEmotesByChannel.delete(channelId);
+  chatStore$.personalEmotesVersion.set(version => version + 1);
 };
 
 export const fetchUserPersonalEmotes = async (

--- a/src/store/chat/actions/personalEmotes.ts
+++ b/src/store/chat/actions/personalEmotes.ts
@@ -7,19 +7,47 @@ import { chatStore$ } from '../observables/chatStore';
 
 const personalEmotesGuard = createFetchOnceGuard();
 
+/**
+ * Session cache of each sighted chatter's 7TV personal emote set, keyed by
+ * channel then Twitch user id. Kept as a plain bounded Map rather than on the
+ * persisted store: sets are refetched per session anyway, and routing every
+ * chatter sighting through the persisted observable re-stringified the whole
+ * multi-MB channel-cache table per write. Reads are imperative (ingest and
+ * render); React consumers subscribe via `personalEmotesVersion`.
+ */
+const MAX_PERSONAL_EMOTE_CHANNELS = 20;
+
+const personalEmotesByChannel = new Map<
+  string,
+  Record<string, SanitisedEmote[]>
+>();
+
+const EMPTY_PERSONAL_EMOTES: Record<string, SanitisedEmote[]> = {};
+
+export const getChannelPersonalEmotes = (
+  channelId: string | null | undefined,
+): Record<string, SanitisedEmote[]> =>
+  (channelId ? personalEmotesByChannel.get(channelId) : undefined) ??
+  EMPTY_PERSONAL_EMOTES;
+
+export const clearChannelPersonalEmotes = (channelId: string): void => {
+  if (personalEmotesByChannel.delete(channelId)) {
+    chatStore$.personalEmotesVersion.set(version => version + 1);
+  }
+};
+
 export const fetchUserPersonalEmotes = async (
   twitchUserId: string,
   channelId: string,
 ): Promise<SanitisedEmote[] | null> => {
   if (personalEmotesGuard.hasFetched(twitchUserId)) {
-    const cache = chatStore$.persisted.channelCaches[channelId]?.peek();
-    return cache?.sevenTvPersonalEmotes?.[twitchUserId] || [];
+    return getChannelPersonalEmotes(channelId)[twitchUserId] || [];
   }
-  const cache = chatStore$.persisted.channelCaches[channelId]?.peek();
 
-  if (cache?.sevenTvPersonalEmotes?.[twitchUserId]?.length) {
+  const cached = getChannelPersonalEmotes(channelId)[twitchUserId];
+  if (cached?.length) {
     personalEmotesGuard.markFetched(twitchUserId);
-    return cache.sevenTvPersonalEmotes[twitchUserId];
+    return cached;
   }
 
   return personalEmotesGuard.run(twitchUserId, async ctx => {
@@ -58,20 +86,29 @@ function writePersonalEmotes(
   twitchUserId: string,
   personalEmotes: SanitisedEmote[],
 ): void {
-  const channelCache = chatStore$.persisted.channelCaches[channelId];
-  if (!channelCache?.peek()) {
-    return;
-  }
-  const previousEmotes =
-    channelCache.sevenTvPersonalEmotes[twitchUserId]?.peek() ?? [];
+  const channelEmotes = personalEmotesByChannel.get(channelId);
+  const previousEmotes = channelEmotes?.[twitchUserId] ?? [];
   const emoteIdsChanged =
     previousEmotes.length !== personalEmotes.length ||
     personalEmotes.some(
       (emote, index) => emote.id !== previousEmotes[index]?.id,
     );
-  // Keyed child set so concurrent writes for other users are not clobbered
-  // by rebuilding the whole record.
-  channelCache.sevenTvPersonalEmotes[twitchUserId]?.set(personalEmotes);
+  if (!emoteIdsChanged && channelEmotes) {
+    return;
+  }
+  if (
+    !channelEmotes &&
+    personalEmotesByChannel.size >= MAX_PERSONAL_EMOTE_CHANNELS
+  ) {
+    const oldest = personalEmotesByChannel.keys().next().value;
+    if (oldest !== undefined) {
+      personalEmotesByChannel.delete(oldest);
+    }
+  }
+  personalEmotesByChannel.set(channelId, {
+    ...channelEmotes,
+    [twitchUserId]: personalEmotes,
+  });
   if (emoteIdsChanged) {
     chatStore$.personalEmotesVersion.set(version => version + 1);
   }
@@ -80,13 +117,14 @@ function writePersonalEmotes(
 export const getUserPersonalEmotes = (
   twitchUserId: string,
   channelId: string,
-): SanitisedEmote[] => {
-  const cache = chatStore$.persisted.channelCaches[channelId]?.peek();
-  return cache?.sevenTvPersonalEmotes?.[twitchUserId] || [];
-};
+): SanitisedEmote[] => getChannelPersonalEmotes(channelId)[twitchUserId] || [];
 
 export const clearPersonalEmotesCache = () => {
   personalEmotesGuard.clear();
+  if (personalEmotesByChannel.size > 0) {
+    personalEmotesByChannel.clear();
+    chatStore$.personalEmotesVersion.set(version => version + 1);
+  }
 };
 
 /**
@@ -143,8 +181,7 @@ export const findPersonalEmoteSetOwner = (
   if (!channelId) {
     return null;
   }
-  const cache = chatStore$.persisted.channelCaches[channelId]?.peek();
-  const personalEmotes = cache?.sevenTvPersonalEmotes ?? {};
+  const personalEmotes = getChannelPersonalEmotes(channelId);
   for (const [twitchUserId, emotes] of Object.entries(personalEmotes)) {
     if (emotes.some(emote => getEmoteSetId(emote) === emoteSetId)) {
       return twitchUserId;

--- a/src/store/chat/actions/personalEmotes.ts
+++ b/src/store/chat/actions/personalEmotes.ts
@@ -7,6 +7,8 @@ import { chatStore$ } from '../observables/chatStore';
 
 const personalEmotesGuard = createFetchOnceGuard();
 
+const MAX_PERSONAL_EMOTE_CHANNELS = 20;
+
 /**
  * Session cache of each sighted chatter's 7TV personal emote set, keyed by
  * channel then Twitch user id. Kept as a plain bounded Map rather than on the
@@ -15,8 +17,6 @@ const personalEmotesGuard = createFetchOnceGuard();
  * multi-MB channel-cache table per write. Reads are imperative (ingest and
  * render); React consumers subscribe via `personalEmotesVersion`.
  */
-const MAX_PERSONAL_EMOTE_CHANNELS = 20;
-
 const personalEmotesByChannel = new Map<
   string,
   Record<string, SanitisedEmote[]>

--- a/src/store/chat/observables/chatStore.ts
+++ b/src/store/chat/observables/chatStore.ts
@@ -203,9 +203,17 @@ InteractionManager.runAfterInteractions(hydrateDeferredChatState);
 // Recent messages used to live inside `persisted`; chatterino badges used to
 // be stored per channel (~4,100 entries each) and are now resolved from the
 // bundled table at read time; the `emotes`/`badges` aggregates duplicated the
-// per-provider arrays stored alongside them. Stripping them on hydrate stops
-// every future channelCaches write from re-serializing them.
-const STALE_CHANNEL_CACHE_KEYS = ['chatterinoBadges', 'emotes', 'badges'];
+// per-provider arrays stored alongside them; 7TV personal emotes are now
+// session state refetched per sighting, and personal badges were only ever
+// written empty. Stripping them on hydrate stops every future channelCaches
+// write from re-serializing them.
+const STALE_CHANNEL_CACHE_KEYS = [
+  'chatterinoBadges',
+  'emotes',
+  'badges',
+  'sevenTvPersonalEmotes',
+  'sevenTvPersonalBadges',
+];
 
 export const migratePersistedChatStore = () => {
   const persisted = chatStore$.persisted.peek() as {

--- a/src/store/chat/observables/chatStore.ts
+++ b/src/store/chat/observables/chatStore.ts
@@ -55,12 +55,6 @@ export interface ChatStoreState {
   userPaintIds: Record<string, string>;
   badges: Record<string, SanitisedBadgeSet>;
   userBadgeIds: Record<string, string>;
-  sessionCaches: {
-    // getChatRowItemType runs per row on every list data change; caching the
-    // two-peek paints/userPaintIds traversal per user avoids re-walking those
-    // observables for every row on every render.
-    userPaintFlags: Record<string, boolean>;
-  };
 }
 
 export const limitChannelCaches = (
@@ -109,9 +103,6 @@ const initialChatStoreState: ChatStoreState = {
   userPaintIds: {},
   badges: {},
   userBadgeIds: {},
-  sessionCaches: {
-    userPaintFlags: {},
-  },
 };
 
 ensureObservablePersistenceConfig();

--- a/src/store/chat/observables/chatStore.ts
+++ b/src/store/chat/observables/chatStore.ts
@@ -18,11 +18,12 @@ import type {
   Bit,
   ChannelCacheType,
   ChatLoadingState,
+  GlobalCacheType,
   PaintData,
   SanitisedBadgeSet,
   SanitisedEmote,
 } from '../types/constants';
-import { MAX_CACHED_CHANNELS } from '../types/constants';
+import { emptyGlobalCacheData, MAX_CACHED_CHANNELS } from '../types/constants';
 import { loadPersistedCosmetics } from './cosmeticsPersistence';
 import {
   loadPersistedRecentMessages,
@@ -32,7 +33,7 @@ import {
 export interface ChatStoreState {
   persisted: {
     channelCaches: Record<string, ChannelCacheType>;
-    lastGlobalUpdate: number;
+    globalCaches: GlobalCacheType;
   };
   // Persisted separately from `persisted` so frequent message syncs do not
   // re-serialize the channel emote caches (issue #594).
@@ -99,7 +100,7 @@ export const limitChannelCaches = (
 const initialChatStoreState: ChatStoreState = {
   persisted: {
     channelCaches: {},
-    lastGlobalUpdate: 0,
+    globalCaches: emptyGlobalCacheData,
   },
   recentMessagesByChannel: {},
   loadingState: 'IDLE',
@@ -199,24 +200,83 @@ const hydrateDeferredChatState = () => {
 
 InteractionManager.runAfterInteractions(hydrateDeferredChatState);
 
+const GLOBAL_CACHE_SLICE_KEYS = [
+  'twitchGlobalEmotes',
+  'sevenTvGlobalEmotes',
+  'ffzGlobalEmotes',
+  'bttvGlobalEmotes',
+  'twitchGlobalBadges',
+  'ffzGlobalBadges',
+] as const;
+
 // Fields older builds persisted but the current schema no longer holds.
 // Recent messages used to live inside `persisted`; chatterino badges used to
 // be stored per channel (~4,100 entries each) and are now resolved from the
 // bundled table at read time; the `emotes`/`badges` aggregates duplicated the
 // per-provider arrays stored alongside them; 7TV personal emotes are now
 // session state refetched per sighting, and personal badges were only ever
-// written empty. Stripping them on hydrate stops every future channelCaches
-// write from re-serializing them.
+// written empty; the global provider slices moved to the shared
+// `persisted.globalCaches` slot. Stripping them on hydrate stops every future
+// channelCaches write from re-serializing them.
 const STALE_CHANNEL_CACHE_KEYS = [
   'chatterinoBadges',
   'emotes',
   'badges',
   'sevenTvPersonalEmotes',
   'sevenTvPersonalBadges',
+  ...GLOBAL_CACHE_SLICE_KEYS,
 ];
+
+type LegacyChannelCache = ChannelCacheType &
+  Partial<Pick<GlobalCacheType, (typeof GLOBAL_CACHE_SLICE_KEYS)[number]>>;
+
+/**
+ * Old installs duplicated the global provider slices into every channel
+ * cache; the newest copy is as fresh as any global data the app has ever
+ * held, so it becomes the shared slot's first value instead of forcing an
+ * empty slot on the first launch after the upgrade.
+ */
+const seedGlobalCachesFromChannelCopies = (
+  caches: Record<string, LegacyChannelCache>,
+): void => {
+  const globalCache = chatStore$.persisted.globalCaches.peek();
+  const hasGlobalData =
+    (globalCache?.lastUpdated ?? 0) > 0 ||
+    GLOBAL_CACHE_SLICE_KEYS.some(key => (globalCache?.[key]?.length ?? 0) > 0);
+  if (hasGlobalData) {
+    return;
+  }
+
+  let donor: LegacyChannelCache | undefined;
+  for (const cache of Object.values(caches)) {
+    const holdsGlobalCopies = GLOBAL_CACHE_SLICE_KEYS.some(
+      key => (cache[key]?.length ?? 0) > 0,
+    );
+    if (
+      holdsGlobalCopies &&
+      (cache.lastUpdated || 0) > (donor?.lastUpdated || 0)
+    ) {
+      donor = cache;
+    }
+  }
+  if (!donor) {
+    return;
+  }
+
+  chatStore$.persisted.globalCaches.set({
+    lastUpdated: donor.lastUpdated || 0,
+    twitchGlobalEmotes: donor.twitchGlobalEmotes ?? [],
+    sevenTvGlobalEmotes: donor.sevenTvGlobalEmotes ?? [],
+    ffzGlobalEmotes: donor.ffzGlobalEmotes ?? [],
+    bttvGlobalEmotes: donor.bttvGlobalEmotes ?? [],
+    twitchGlobalBadges: donor.twitchGlobalBadges ?? [],
+    ffzGlobalBadges: donor.ffzGlobalBadges ?? [],
+  });
+};
 
 export const migratePersistedChatStore = () => {
   const persisted = chatStore$.persisted.peek() as {
+    lastGlobalUpdate?: unknown;
     recentMessagesByChannel?: unknown;
   };
   if (persisted.recentMessagesByChannel !== undefined) {
@@ -226,9 +286,20 @@ export const migratePersistedChatStore = () => {
       }
     ).recentMessagesByChannel.delete();
   }
+  if (persisted.lastGlobalUpdate !== undefined) {
+    (
+      chatStore$.persisted as unknown as {
+        lastGlobalUpdate: { delete: () => void };
+      }
+    ).lastGlobalUpdate.delete();
+  }
 
-  const caches = chatStore$.persisted.channelCaches.peek() ?? {};
+  const caches = (chatStore$.persisted.channelCaches.peek() ?? {}) as Record<
+    string,
+    LegacyChannelCache
+  >;
   batch(() => {
+    seedGlobalCachesFromChannelCopies(caches);
     for (const [id, cache] of Object.entries(caches)) {
       const cache$ = chatStore$.persisted.channelCaches[id] as unknown as
         Record<string, { delete: () => void }> | undefined;

--- a/src/store/chat/observables/chatStore.ts
+++ b/src/store/chat/observables/chatStore.ts
@@ -23,7 +23,10 @@ import type {
   SanitisedBadgeSet,
   SanitisedEmote,
 } from '../types/constants';
-import { emptyGlobalCacheData, MAX_CACHED_CHANNELS } from '../types/constants';
+import {
+  makeEmptyGlobalCacheData,
+  MAX_CACHED_CHANNELS,
+} from '../types/constants';
 import { loadPersistedCosmetics } from './cosmeticsPersistence';
 import {
   loadPersistedRecentMessages,
@@ -84,7 +87,7 @@ export const limitChannelCaches = (
 const initialChatStoreState: ChatStoreState = {
   persisted: {
     channelCaches: {},
-    globalCaches: emptyGlobalCacheData,
+    globalCaches: makeEmptyGlobalCacheData(),
   },
   recentMessagesByChannel: {},
   loadingState: 'IDLE',

--- a/src/store/chat/observables/chatStore.ts
+++ b/src/store/chat/observables/chatStore.ts
@@ -61,16 +61,6 @@ export interface ChatStoreState {
     // observables for every row on every render.
     userPaintFlags: Record<string, boolean>;
   };
-  sharedChatBadgeCaches: {
-    sourceBadges: Record<
-      string,
-      { value: SanitisedBadgeSet | null; expiresAt: number }
-    >;
-    channelBadges: Record<
-      string,
-      { value: SanitisedBadgeSet[]; expiresAt: number }
-    >;
-  };
 }
 
 export const limitChannelCaches = (
@@ -121,10 +111,6 @@ const initialChatStoreState: ChatStoreState = {
   userBadgeIds: {},
   sessionCaches: {
     userPaintFlags: {},
-  },
-  sharedChatBadgeCaches: {
-    sourceBadges: {},
-    channelBadges: {},
   },
 };
 

--- a/src/store/chat/observables/chatStore.ts
+++ b/src/store/chat/observables/chatStore.ts
@@ -189,15 +189,14 @@ const GLOBAL_CACHE_SLICE_KEYS = [
   'ffzGlobalBadges',
 ] as const;
 
-// Fields older builds persisted but the current schema no longer holds.
-// Recent messages used to live inside `persisted`; chatterino badges used to
-// be stored per channel (~4,100 entries each) and are now resolved from the
-// bundled table at read time; the `emotes`/`badges` aggregates duplicated the
-// per-provider arrays stored alongside them; 7TV personal emotes are now
-// session state refetched per sighting, and personal badges were only ever
-// written empty; the global provider slices moved to the shared
-// `persisted.globalCaches` slot. Stripping them on hydrate stops every future
-// channelCaches write from re-serializing them.
+// Fields older builds persisted per channel but the current schema no longer
+// holds: chatterino badges (~4,100 entries each, now resolved from the
+// bundled table at read time), the `emotes`/`badges` aggregates (duplicated
+// the per-provider arrays stored alongside them), 7TV personal emotes (now
+// session state refetched per sighting), personal badges (only ever written
+// empty), and the global provider slices (moved to the shared
+// `persisted.globalCaches` slot). Stripping them on hydrate stops every
+// future channelCaches write from re-serializing them.
 const STALE_CHANNEL_CACHE_KEYS = [
   'chatterinoBadges',
   'emotes',
@@ -234,7 +233,7 @@ const seedGlobalCachesFromChannelCopies = (
     );
     if (
       holdsGlobalCopies &&
-      (cache.lastUpdated || 0) > (donor?.lastUpdated || 0)
+      (!donor || (cache.lastUpdated || 0) > (donor.lastUpdated || 0))
     ) {
       donor = cache;
     }

--- a/src/store/chat/observables/chatStore.ts
+++ b/src/store/chat/observables/chatStore.ts
@@ -199,12 +199,15 @@ const hydrateDeferredChatState = () => {
 
 InteractionManager.runAfterInteractions(hydrateDeferredChatState);
 
-// Recent messages used to live inside `persisted`; drop the stale field from
-// old installs so channelCaches writes stop re-serializing it. Chatterino
-// badges likewise used to be stored per channel (~4,100 entries each) but are
-// now resolved from the bundled table at read time; strip them from old
-// caches so every future channelCaches write stops re-serializing them.
-when(persistedState$?._state?.isLoadedLocal, () => {
+// Fields older builds persisted but the current schema no longer holds.
+// Recent messages used to live inside `persisted`; chatterino badges used to
+// be stored per channel (~4,100 entries each) and are now resolved from the
+// bundled table at read time; the `emotes`/`badges` aggregates duplicated the
+// per-provider arrays stored alongside them. Stripping them on hydrate stops
+// every future channelCaches write from re-serializing them.
+const STALE_CHANNEL_CACHE_KEYS = ['chatterinoBadges', 'emotes', 'badges'];
+
+export const migratePersistedChatStore = () => {
   const persisted = chatStore$.persisted.peek() as {
     recentMessagesByChannel?: unknown;
   };
@@ -217,23 +220,22 @@ when(persistedState$?._state?.isLoadedLocal, () => {
   }
 
   const caches = chatStore$.persisted.channelCaches.peek() ?? {};
-  const staleChannelIds: string[] = [];
-  for (const [id, cache] of Object.entries(caches)) {
-    if ('chatterinoBadges' in cache) {
-      staleChannelIds.push(id);
-    }
-  }
-  if (staleChannelIds.length > 0) {
-    batch(() => {
-      for (const id of staleChannelIds) {
-        (
-          chatStore$.persisted.channelCaches[id] as unknown as {
-            chatterinoBadges: { delete: () => void };
-          }
-        ).chatterinoBadges.delete();
+  batch(() => {
+    for (const [id, cache] of Object.entries(caches)) {
+      const cache$ = chatStore$.persisted.channelCaches[id] as unknown as
+        Record<string, { delete: () => void }> | undefined;
+      if (!cache$) {
+        continue;
       }
-    });
-  }
-});
+      for (const key of STALE_CHANNEL_CACHE_KEYS) {
+        if (key in cache) {
+          cache$[key]?.delete();
+        }
+      }
+    }
+  });
+};
+
+when(persistedState$?._state?.isLoadedLocal, migratePersistedChatStore);
 
 export type ChatMessagesObservable = typeof chatStore$.messages;

--- a/src/store/chat/react/selectors.ts
+++ b/src/store/chat/react/selectors.ts
@@ -3,6 +3,7 @@ import { useSelector } from '@legendapp/state/react';
 import { useEmoteRenderPreferences } from '@app/store/preferences/selectors';
 import { getChatterinoBadges } from '@app/utils/chat/chatterinoBadges';
 
+import { getChannelPersonalEmotes } from '../actions/personalEmotes';
 import { chatStore$ } from '../observables/chatStore';
 import {
   type ChannelCacheType,
@@ -21,7 +22,6 @@ type ChannelEmoteCache = Pick<
   | 'twitchGlobalEmotes'
   | 'twitchSubscriberEmotes'
   | 'twitchSubscriberChannelProfiles'
-  | 'sevenTvPersonalEmotes'
   | 'sevenTvChannelEmotes'
   | 'sevenTvGlobalEmotes'
   | 'ffzChannelEmotes'
@@ -32,7 +32,9 @@ type ChannelEmoteCache = Pick<
   | 'twitchGlobalBadges'
   | 'ffzChannelBadges'
   | 'ffzGlobalBadges'
->;
+> & {
+  sevenTvPersonalEmotes: Record<string, SanitisedEmote[]>;
+};
 
 type ChannelEmoteData = ChannelEmoteCache & {
   chatterinoBadges: SanitisedBadgeSet[];
@@ -43,7 +45,7 @@ const EMPTY_BADGES: SanitisedBadgeSet[] = [];
 const EMPTY_SUBSCRIBER_PROFILES: NonNullable<
   ChannelCacheType['twitchSubscriberChannelProfiles']
 > = {};
-const EMPTY_PERSONAL_EMOTES: ChannelCacheType['sevenTvPersonalEmotes'] = {};
+const EMPTY_PERSONAL_EMOTES: Record<string, SanitisedEmote[]> = {};
 
 function resolveEmoteData(
   cache: ChannelEmoteCache | undefined,
@@ -105,12 +107,21 @@ function resolveEmoteData(
   };
 }
 
+const emptyChannelEmoteCache: ChannelEmoteCache = {
+  ...emptyEmoteData,
+  sevenTvPersonalEmotes: EMPTY_PERSONAL_EMOTES,
+};
+
 function getChannelEmoteData(channelId: string | null): ChannelEmoteCache {
   if (!channelId) {
-    return emptyEmoteData;
+    return emptyChannelEmoteCache;
   }
 
   const cache$ = chatStore$.persisted.channelCaches[channelId];
+
+  // Personal emotes live in a plain session Map; `personalEmotesVersion` is
+  // the observable edge that re-runs this selector when they change.
+  chatStore$.personalEmotesVersion.get();
 
   return {
     twitchChannelEmotes: cache$?.twitchChannelEmotes.get() ?? EMPTY_EMOTES,
@@ -120,8 +131,7 @@ function getChannelEmoteData(channelId: string | null): ChannelEmoteCache {
     twitchSubscriberChannelProfiles:
       cache$?.twitchSubscriberChannelProfiles.get() ??
       EMPTY_SUBSCRIBER_PROFILES,
-    sevenTvPersonalEmotes:
-      cache$?.sevenTvPersonalEmotes.get() ?? EMPTY_PERSONAL_EMOTES,
+    sevenTvPersonalEmotes: getChannelPersonalEmotes(channelId),
     sevenTvChannelEmotes: cache$?.sevenTvChannelEmotes.get() ?? EMPTY_EMOTES,
     sevenTvGlobalEmotes: cache$?.sevenTvGlobalEmotes.get() ?? EMPTY_EMOTES,
     ffzChannelEmotes: cache$?.ffzChannelEmotes.get() ?? EMPTY_EMOTES,

--- a/src/store/chat/react/selectors.ts
+++ b/src/store/chat/react/selectors.ts
@@ -7,10 +7,10 @@ import { getChannelPersonalEmotes } from '../actions/personalEmotes';
 import { chatStore$ } from '../observables/chatStore';
 import {
   type ChannelCacheType,
-  emptyEmoteData,
-  emptyGlobalCacheData,
   emptyResolvedEmoteData,
   type GlobalCacheType,
+  makeEmptyEmoteData,
+  makeEmptyGlobalCacheData,
   type SanitisedBadgeSet,
   type SanitisedEmote,
 } from '../types/constants';
@@ -113,8 +113,8 @@ function resolveEmoteData(
 }
 
 const emptyChannelEmoteCache: ChannelEmoteCache = {
-  ...emptyEmoteData,
-  ...emptyGlobalCacheData,
+  ...makeEmptyEmoteData(),
+  ...makeEmptyGlobalCacheData(),
   sevenTvPersonalEmotes: EMPTY_PERSONAL_EMOTES,
 };
 

--- a/src/store/chat/react/selectors.ts
+++ b/src/store/chat/react/selectors.ts
@@ -8,7 +8,9 @@ import { chatStore$ } from '../observables/chatStore';
 import {
   type ChannelCacheType,
   emptyEmoteData,
+  emptyGlobalCacheData,
   emptyResolvedEmoteData,
+  type GlobalCacheType,
   type SanitisedBadgeSet,
   type SanitisedEmote,
 } from '../types/constants';
@@ -19,22 +21,25 @@ export const useEmojis = () => useSelector(chatStore$.emojis);
 type ChannelEmoteCache = Pick<
   ChannelCacheType,
   | 'twitchChannelEmotes'
-  | 'twitchGlobalEmotes'
   | 'twitchSubscriberEmotes'
   | 'twitchSubscriberChannelProfiles'
   | 'sevenTvChannelEmotes'
-  | 'sevenTvGlobalEmotes'
   | 'ffzChannelEmotes'
-  | 'ffzGlobalEmotes'
-  | 'bttvGlobalEmotes'
   | 'bttvChannelEmotes'
   | 'twitchChannelBadges'
-  | 'twitchGlobalBadges'
   | 'ffzChannelBadges'
-  | 'ffzGlobalBadges'
-> & {
-  sevenTvPersonalEmotes: Record<string, SanitisedEmote[]>;
-};
+> &
+  Pick<
+    GlobalCacheType,
+    | 'twitchGlobalEmotes'
+    | 'sevenTvGlobalEmotes'
+    | 'ffzGlobalEmotes'
+    | 'bttvGlobalEmotes'
+    | 'twitchGlobalBadges'
+    | 'ffzGlobalBadges'
+  > & {
+    sevenTvPersonalEmotes: Record<string, SanitisedEmote[]>;
+  };
 
 type ChannelEmoteData = ChannelEmoteCache & {
   chatterinoBadges: SanitisedBadgeSet[];
@@ -109,6 +114,7 @@ function resolveEmoteData(
 
 const emptyChannelEmoteCache: ChannelEmoteCache = {
   ...emptyEmoteData,
+  ...emptyGlobalCacheData,
   sevenTvPersonalEmotes: EMPTY_PERSONAL_EMOTES,
 };
 
@@ -118,6 +124,7 @@ function getChannelEmoteData(channelId: string | null): ChannelEmoteCache {
   }
 
   const cache$ = chatStore$.persisted.channelCaches[channelId];
+  const globalCache$ = chatStore$.persisted.globalCaches;
 
   // Personal emotes live in a plain session Map; `personalEmotesVersion` is
   // the observable edge that re-runs this selector when they change.
@@ -125,7 +132,7 @@ function getChannelEmoteData(channelId: string | null): ChannelEmoteCache {
 
   return {
     twitchChannelEmotes: cache$?.twitchChannelEmotes.get() ?? EMPTY_EMOTES,
-    twitchGlobalEmotes: cache$?.twitchGlobalEmotes.get() ?? EMPTY_EMOTES,
+    twitchGlobalEmotes: globalCache$.twitchGlobalEmotes.get() ?? EMPTY_EMOTES,
     twitchSubscriberEmotes:
       cache$?.twitchSubscriberEmotes.get() ?? EMPTY_EMOTES,
     twitchSubscriberChannelProfiles:
@@ -133,15 +140,15 @@ function getChannelEmoteData(channelId: string | null): ChannelEmoteCache {
       EMPTY_SUBSCRIBER_PROFILES,
     sevenTvPersonalEmotes: getChannelPersonalEmotes(channelId),
     sevenTvChannelEmotes: cache$?.sevenTvChannelEmotes.get() ?? EMPTY_EMOTES,
-    sevenTvGlobalEmotes: cache$?.sevenTvGlobalEmotes.get() ?? EMPTY_EMOTES,
+    sevenTvGlobalEmotes: globalCache$.sevenTvGlobalEmotes.get() ?? EMPTY_EMOTES,
     ffzChannelEmotes: cache$?.ffzChannelEmotes.get() ?? EMPTY_EMOTES,
-    ffzGlobalEmotes: cache$?.ffzGlobalEmotes.get() ?? EMPTY_EMOTES,
-    bttvGlobalEmotes: cache$?.bttvGlobalEmotes.get() ?? EMPTY_EMOTES,
+    ffzGlobalEmotes: globalCache$.ffzGlobalEmotes.get() ?? EMPTY_EMOTES,
+    bttvGlobalEmotes: globalCache$.bttvGlobalEmotes.get() ?? EMPTY_EMOTES,
     bttvChannelEmotes: cache$?.bttvChannelEmotes.get() ?? EMPTY_EMOTES,
     twitchChannelBadges: cache$?.twitchChannelBadges.get() ?? EMPTY_BADGES,
-    twitchGlobalBadges: cache$?.twitchGlobalBadges.get() ?? EMPTY_BADGES,
+    twitchGlobalBadges: globalCache$.twitchGlobalBadges.get() ?? EMPTY_BADGES,
     ffzChannelBadges: cache$?.ffzChannelBadges.get() ?? EMPTY_BADGES,
-    ffzGlobalBadges: cache$?.ffzGlobalBadges.get() ?? EMPTY_BADGES,
+    ffzGlobalBadges: globalCache$.ffzGlobalBadges.get() ?? EMPTY_BADGES,
   };
 }
 
@@ -169,21 +176,23 @@ export const useChannelEmoteDataForReprocess = (channelId: string | null) => {
       return null;
     }
     const cache$ = chatStore$.persisted.channelCaches[channelId];
+    const globalCache$ = chatStore$.persisted.globalCaches;
     return {
       twitchChannelEmotes: cache$?.twitchChannelEmotes.get() ?? EMPTY_EMOTES,
-      twitchGlobalEmotes: cache$?.twitchGlobalEmotes.get() ?? EMPTY_EMOTES,
+      twitchGlobalEmotes: globalCache$.twitchGlobalEmotes.get() ?? EMPTY_EMOTES,
       twitchSubscriberEmotes:
         cache$?.twitchSubscriberEmotes.get() ?? EMPTY_EMOTES,
       sevenTvChannelEmotes: cache$?.sevenTvChannelEmotes.get() ?? EMPTY_EMOTES,
-      sevenTvGlobalEmotes: cache$?.sevenTvGlobalEmotes.get() ?? EMPTY_EMOTES,
+      sevenTvGlobalEmotes:
+        globalCache$.sevenTvGlobalEmotes.get() ?? EMPTY_EMOTES,
       ffzChannelEmotes: cache$?.ffzChannelEmotes.get() ?? EMPTY_EMOTES,
-      ffzGlobalEmotes: cache$?.ffzGlobalEmotes.get() ?? EMPTY_EMOTES,
-      bttvGlobalEmotes: cache$?.bttvGlobalEmotes.get() ?? EMPTY_EMOTES,
+      ffzGlobalEmotes: globalCache$.ffzGlobalEmotes.get() ?? EMPTY_EMOTES,
+      bttvGlobalEmotes: globalCache$.bttvGlobalEmotes.get() ?? EMPTY_EMOTES,
       bttvChannelEmotes: cache$?.bttvChannelEmotes.get() ?? EMPTY_EMOTES,
       twitchChannelBadges: cache$?.twitchChannelBadges.get() ?? EMPTY_BADGES,
-      twitchGlobalBadges: cache$?.twitchGlobalBadges.get() ?? EMPTY_BADGES,
+      twitchGlobalBadges: globalCache$.twitchGlobalBadges.get() ?? EMPTY_BADGES,
       ffzChannelBadges: cache$?.ffzChannelBadges.get() ?? EMPTY_BADGES,
-      ffzGlobalBadges: cache$?.ffzGlobalBadges.get() ?? EMPTY_BADGES,
+      ffzGlobalBadges: globalCache$.ffzGlobalBadges.get() ?? EMPTY_BADGES,
     };
   });
 };

--- a/src/store/chat/types/constants.ts
+++ b/src/store/chat/types/constants.ts
@@ -1,5 +1,3 @@
-import type { ViewStyle } from 'react-native';
-
 import type { ClearChatTags } from '@app/types/chat/irc-tags/clearchat';
 import type { ClearMsgTags } from '@app/types/chat/irc-tags/clearmsg';
 import type { GlobalUserStateTags } from '@app/types/chat/irc-tags/globaluserstate';
@@ -85,7 +83,6 @@ export interface ChatMessageType<
   message_nonce: string;
   timestamp?: string;
   sender: string;
-  style?: ViewStyle;
   parentDisplayName?: string;
   isSpecialNotice?: boolean;
   moderationNotice?: string;

--- a/src/store/chat/types/constants.ts
+++ b/src/store/chat/types/constants.ts
@@ -190,30 +190,38 @@ export const MAX_COSMETIC_ENTRIES = 500;
 export const CACHE_DURATION = 60 * 60 * 1000; // 1 hour
 export const BADGE_CACHE_DURATION = 60 * 60 * 1000; // 1 hour
 
-export const emptyEmoteData = {
-  twitchChannelEmotes: [],
-  twitchSubscriberEmotes: [],
-  twitchSubscriberEmotesUserId: undefined,
-  twitchSubscriberChannelProfiles: {},
-  sevenTvChannelEmotes: [],
-  ffzChannelEmotes: [],
-  bttvChannelEmotes: [],
-  twitchChannelBadges: [],
-  ffzChannelBadges: [],
-  lastUpdated: 0,
-  badgesLastUpdated: 0,
-  sevenTvEmoteSetId: undefined,
-} satisfies ChannelCacheType;
+/**
+ * Factories rather than shared constants: an empty-cache object embedded into
+ * an observable is written through by legend-state's hydration merge, so a
+ * shared constant would come back from "clear cache" holding the launch-time
+ * hydrated data instead of an empty slot.
+ */
+export const makeEmptyEmoteData = () =>
+  ({
+    twitchChannelEmotes: [],
+    twitchSubscriberEmotes: [],
+    twitchSubscriberEmotesUserId: undefined,
+    twitchSubscriberChannelProfiles: {},
+    sevenTvChannelEmotes: [],
+    ffzChannelEmotes: [],
+    bttvChannelEmotes: [],
+    twitchChannelBadges: [],
+    ffzChannelBadges: [],
+    lastUpdated: 0,
+    badgesLastUpdated: 0,
+    sevenTvEmoteSetId: undefined,
+  }) satisfies ChannelCacheType;
 
-export const emptyGlobalCacheData = {
-  lastUpdated: 0,
-  twitchGlobalEmotes: [],
-  sevenTvGlobalEmotes: [],
-  ffzGlobalEmotes: [],
-  bttvGlobalEmotes: [],
-  twitchGlobalBadges: [],
-  ffzGlobalBadges: [],
-} satisfies GlobalCacheType;
+export const makeEmptyGlobalCacheData = () =>
+  ({
+    lastUpdated: 0,
+    twitchGlobalEmotes: [],
+    sevenTvGlobalEmotes: [],
+    ffzGlobalEmotes: [],
+    bttvGlobalEmotes: [],
+    twitchGlobalBadges: [],
+    ffzGlobalBadges: [],
+  }) satisfies GlobalCacheType;
 
 /**
  * Consumer-facing emote-data shape: channel-cache fields plus the slices that
@@ -222,8 +230,8 @@ export const emptyGlobalCacheData = {
  * from the bundled table at read time.
  */
 export const emptyResolvedEmoteData = {
-  ...emptyEmoteData,
-  ...emptyGlobalCacheData,
+  ...makeEmptyEmoteData(),
+  ...makeEmptyGlobalCacheData(),
   lastUpdated: 0,
   sevenTvPersonalEmotes: {} as Record<string, SanitisedEmote[]>,
   chatterinoBadges: [] as SanitisedBadgeSet[],

--- a/src/store/chat/types/constants.ts
+++ b/src/store/chat/types/constants.ts
@@ -232,7 +232,6 @@ export const makeEmptyGlobalCacheData = () =>
 export const emptyResolvedEmoteData = {
   ...makeEmptyEmoteData(),
   ...makeEmptyGlobalCacheData(),
-  lastUpdated: 0,
   sevenTvPersonalEmotes: {} as Record<string, SanitisedEmote[]>,
   chatterinoBadges: [] as SanitisedBadgeSet[],
   bttvBadges: [] as SanitisedBadgeSet[],

--- a/src/store/chat/types/constants.ts
+++ b/src/store/chat/types/constants.ts
@@ -167,8 +167,6 @@ export interface ChannelCacheType {
   twitchSubscriberChannelProfiles?: Record<string, SubscriberChannelProfile>;
   sevenTvChannelEmotes: SanitisedEmote[];
   sevenTvGlobalEmotes: SanitisedEmote[];
-  sevenTvPersonalEmotes: Record<string, SanitisedEmote[]>;
-  sevenTvPersonalBadges: Record<string, SanitisedBadgeSet[]>;
   ffzChannelEmotes: SanitisedEmote[];
   ffzGlobalEmotes: SanitisedEmote[];
   bttvGlobalEmotes: SanitisedEmote[];
@@ -194,8 +192,6 @@ export const emptyEmoteData = {
   twitchSubscriberChannelProfiles: {},
   sevenTvChannelEmotes: [],
   sevenTvGlobalEmotes: [],
-  sevenTvPersonalBadges: {},
-  sevenTvPersonalEmotes: {},
   ffzChannelEmotes: [],
   ffzGlobalEmotes: [],
   bttvGlobalEmotes: [],
@@ -210,12 +206,13 @@ export const emptyEmoteData = {
 } satisfies ChannelCacheType;
 
 /**
- * Consumer-facing emote-data shape: channel-cache fields plus the
- * chatterinoBadges set, which is resolved from the bundled table at read time
- * rather than stored per channel.
+ * Consumer-facing emote-data shape: channel-cache fields plus the slices that
+ * are not stored per channel - session-scoped 7TV personal emotes and the
+ * chatterinoBadges set resolved from the bundled table at read time.
  */
 export const emptyResolvedEmoteData = {
   ...emptyEmoteData,
+  sevenTvPersonalEmotes: {} as Record<string, SanitisedEmote[]>,
   chatterinoBadges: [] as SanitisedBadgeSet[],
   bttvBadges: [] as SanitisedBadgeSet[],
 };

--- a/src/store/chat/types/constants.ts
+++ b/src/store/chat/types/constants.ts
@@ -154,8 +154,6 @@ export interface SubscriberChannelProfile {
 }
 
 export interface ChannelCacheType {
-  emotes: SanitisedEmote[];
-  badges: SanitisedBadgeSet[];
   lastUpdated: number;
   twitchChannelEmotes: SanitisedEmote[];
   twitchGlobalEmotes: SanitisedEmote[];
@@ -206,8 +204,6 @@ export const emptyEmoteData = {
   twitchGlobalBadges: [],
   ffzChannelBadges: [],
   ffzGlobalBadges: [],
-  badges: [],
-  emotes: [],
   lastUpdated: 0,
   badgesLastUpdated: 0,
   sevenTvEmoteSetId: undefined,

--- a/src/store/chat/types/constants.ts
+++ b/src/store/chat/types/constants.ts
@@ -156,7 +156,6 @@ export interface SubscriberChannelProfile {
 export interface ChannelCacheType {
   lastUpdated: number;
   twitchChannelEmotes: SanitisedEmote[];
-  twitchGlobalEmotes: SanitisedEmote[];
   twitchSubscriberEmotes: SanitisedEmote[];
   twitchSubscriberEmotesUserId?: string;
   /**
@@ -166,17 +165,27 @@ export interface ChannelCacheType {
    */
   twitchSubscriberChannelProfiles?: Record<string, SubscriberChannelProfile>;
   sevenTvChannelEmotes: SanitisedEmote[];
-  sevenTvGlobalEmotes: SanitisedEmote[];
   ffzChannelEmotes: SanitisedEmote[];
-  ffzGlobalEmotes: SanitisedEmote[];
-  bttvGlobalEmotes: SanitisedEmote[];
   bttvChannelEmotes: SanitisedEmote[];
   twitchChannelBadges: SanitisedBadgeSet[];
-  twitchGlobalBadges: SanitisedBadgeSet[];
-  ffzGlobalBadges: SanitisedBadgeSet[];
   ffzChannelBadges: SanitisedBadgeSet[];
   sevenTvEmoteSetId?: string;
   badgesLastUpdated?: number;
+}
+
+/**
+ * Channel-invariant provider data, stored once instead of duplicated into
+ * every channel cache. `lastUpdated` is its own freshness stamp - global
+ * slices refresh on their own TTL, independent of any channel's.
+ */
+export interface GlobalCacheType {
+  lastUpdated: number;
+  twitchGlobalEmotes: SanitisedEmote[];
+  sevenTvGlobalEmotes: SanitisedEmote[];
+  ffzGlobalEmotes: SanitisedEmote[];
+  bttvGlobalEmotes: SanitisedEmote[];
+  twitchGlobalBadges: SanitisedBadgeSet[];
+  ffzGlobalBadges: SanitisedBadgeSet[];
 }
 
 export const MAX_CACHED_CHANNELS = 20;
@@ -186,32 +195,39 @@ export const BADGE_CACHE_DURATION = 60 * 60 * 1000; // 1 hour
 
 export const emptyEmoteData = {
   twitchChannelEmotes: [],
-  twitchGlobalEmotes: [],
   twitchSubscriberEmotes: [],
   twitchSubscriberEmotesUserId: undefined,
   twitchSubscriberChannelProfiles: {},
   sevenTvChannelEmotes: [],
-  sevenTvGlobalEmotes: [],
   ffzChannelEmotes: [],
-  ffzGlobalEmotes: [],
-  bttvGlobalEmotes: [],
   bttvChannelEmotes: [],
   twitchChannelBadges: [],
-  twitchGlobalBadges: [],
   ffzChannelBadges: [],
-  ffzGlobalBadges: [],
   lastUpdated: 0,
   badgesLastUpdated: 0,
   sevenTvEmoteSetId: undefined,
 } satisfies ChannelCacheType;
 
+export const emptyGlobalCacheData = {
+  lastUpdated: 0,
+  twitchGlobalEmotes: [],
+  sevenTvGlobalEmotes: [],
+  ffzGlobalEmotes: [],
+  bttvGlobalEmotes: [],
+  twitchGlobalBadges: [],
+  ffzGlobalBadges: [],
+} satisfies GlobalCacheType;
+
 /**
  * Consumer-facing emote-data shape: channel-cache fields plus the slices that
- * are not stored per channel - session-scoped 7TV personal emotes and the
- * chatterinoBadges set resolved from the bundled table at read time.
+ * are not stored per channel - the shared global provider slices,
+ * session-scoped 7TV personal emotes, and the chatterinoBadges set resolved
+ * from the bundled table at read time.
  */
 export const emptyResolvedEmoteData = {
   ...emptyEmoteData,
+  ...emptyGlobalCacheData,
+  lastUpdated: 0,
   sevenTvPersonalEmotes: {} as Record<string, SanitisedEmote[]>,
   chatterinoBadges: [] as SanitisedBadgeSet[],
   bttvBadges: [] as SanitisedBadgeSet[],


### PR DESCRIPTION
# Why

The legend-state MMKV plugin re-stringifies the entire persisted table on every write, so the size of `persisted.channelCaches` is the cost of every write to it. The table was mostly duplication: an `emotes`/`badges` aggregate rebuilt from the per-provider arrays stored right next to it, six channel-invariant global slices copied into up to 20 channel caches (~95% duplication), per-chatter 7TV personal emote sets that are refetched every session anyway (a full multi-MB stringify per chatter burst), and per-wearer cosmetic blobs embedding full paint/badge definitions.

# How

One commit per item:

- drop the `emotes`/`badges` aggregates from `ChannelCacheType`; the two readers (subscriber-refresh merge, 7TV set switch) never needed them
- move `sevenTvPersonalEmotes` to a plain bounded session Map in `actions/personalEmotes` (React reads go through `personalEmotesVersion`); delete `sevenTvPersonalBadges`, which was only ever written `{}`
- hoist the six global provider slices into a single `persisted.globalCaches` slot with its own freshness stamp; `planChannelRefresh` judges global staleness separately from the channel TTL, the cached path refetches only stale globals, and cache fallbacks for global-scope specs read the shared slot; the dead `lastGlobalUpdate` field is deleted
- per-user cosmetic snapshots store `paintId`/`badgeId` only and resolve via `getPaint`/`getBadge` at apply time, with a refetch when an id no longer resolves; `refreshCachedUserCosmeticsForDefinition` (which existed only to re-sync the embedded copies) is deleted; old embedded-shape blobs read as misses and refetch (2h TTL)
- remove the dead `sharedChatBadgeCaches` node and `ChatMessageType.style`
- move `sessionCaches.userPaintFlags` to a plain module Map and add a badge-definition sweep symmetric to `sweepUnreferencedPaints` (capped 750)

All legacy shapes are stripped on hydrate by `migratePersistedChatStore` (same pattern as the chatterinoBadges strip), which also seeds the global slot from the newest channel copy so the first launch after the upgrade does not start from an empty slot.

# Test Plan

- `bunx tsc --noEmit`, eslint and prettier clean over the branch diff
- `bunx jest src/store/chat src/components/Chat` (115 suites, 860 tests) and `src/utils/chat` + `src/Providers` (78 suites, 8313 tests)
- new tests: migration strip/seed (`state.test.ts`), personal-emote session scoping, refresh-plan global freshness, cached-path global refresh + global-slot fallbacks (`channelLoad.test.ts`, `channelResources.test.ts`), id-only cosmetic snapshots hit/miss, badge sweep, `hasUserPaint` invalidation (`cosmeticsChurn.test.ts`)
