### PR TITLE
fix(player): resume and re-attach the player when the app comes back

### DIFF
--- a/src/components/StreamPlayer/StreamPlayer.tsx
+++ b/src/components/StreamPlayer/StreamPlayer.tsx
@@ -3,9 +3,11 @@ import { InteractionManager, Platform, StyleSheet, View } from 'react-native';
 import type { WebViewMessageEvent } from 'react-native-webview';
 import { WebView } from 'react-native-webview';
 
+import { useOnAppStateChange } from '@app/hooks/useOnAppStateChange';
 import { useWatchTimeTracking } from '@app/hooks/useWatchTimeTracking';
 import { usePreference } from '@app/store/preferenceStore';
 import { theme } from '@app/styles/themes';
+import { isForegroundTransition } from '@app/utils/appState/appStateTransitions';
 import { logger } from '@app/utils/logger';
 
 import { Image } from '../Image/Image';
@@ -183,6 +185,18 @@ export const StreamPlayer = memo(function StreamPlayer({
   const [layoutNudge, setLayoutNudge] = useState(0);
   const nudgeTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const nudgePlayedRef = useRef(false);
+  const nudgeLayerTree = useCallback(() => {
+    nudgeTimeoutsRef.current.forEach(clearTimeout);
+    nudgeTimeoutsRef.current = [];
+    const pulse = (delay: number) => {
+      nudgeTimeoutsRef.current.push(
+        setTimeout(() => setLayoutNudge(1), delay),
+        setTimeout(() => setLayoutNudge(0), delay + 120),
+      );
+    };
+    pulse(0);
+    pulse(2500);
+  }, []);
   /**
    * Loading frame shown over the WebView (stream thumbnail + spinner) until the
    * player has actually started, replacing the black box during page load.
@@ -203,15 +217,22 @@ export const StreamPlayer = memo(function StreamPlayer({
         setLoadedGeneration(generationRef.current);
       }, POSTER_HIDE_DELAY_MS);
     }
-    const pulse = (delay: number) => {
-      nudgeTimeoutsRef.current.push(
-        setTimeout(() => setLayoutNudge(1), delay),
-        setTimeout(() => setLayoutNudge(0), delay + 120),
-      );
-    };
-    pulse(0);
-    pulse(2500);
-  }, []);
+    nudgeLayerTree();
+  }, [nudgeLayerTree]);
+
+  /**
+   * iOS suspends the WKWebView while the app is backgrounded and does not
+   * reliably re-attach the inline video's AVPlayer layer to the compositor on
+   * the way back, so the player returns as a blank rectangle. The mount-time
+   * nudge above is once-per-generation and has long since fired by then, so
+   * pulse the frame again on every foreground.
+   */
+  useOnAppStateChange(transition => {
+    if (isForegroundTransition(transition)) {
+      nudgeLayerTree();
+    }
+  });
+
   useEffect(() => {
     const timeoutsRef = nudgeTimeoutsRef;
     const posterTimeoutRef = posterHideTimeoutRef;

--- a/src/components/StreamPlayer/__tests__/StreamPlayer.test.tsx
+++ b/src/components/StreamPlayer/__tests__/StreamPlayer.test.tsx
@@ -1,4 +1,6 @@
 import { createRef } from 'react';
+import { AppState, StyleSheet } from 'react-native';
+import type { AppStateStatus, ViewStyle } from 'react-native';
 import type { WebViewProps } from 'react-native-webview';
 
 import { act, render } from '@testing-library/react-native';
@@ -82,10 +84,36 @@ function sendPlayerMessage(type: string, payload: unknown = {}) {
   });
 }
 
+type RenderedTree = ReturnType<ReturnType<typeof render>['toJSON']>;
+
+/**
+ * The layout nudge that forces WKWebView to rebuild its layer tree shows up as
+ * a 1px `paddingBottom` on the player container (the render root).
+ */
+function containerPaddingBottom(tree: RenderedTree) {
+  if (!tree || Array.isArray(tree)) {
+    throw new Error('expected a single player container element');
+  }
+  const style: ViewStyle = StyleSheet.flatten(tree.props.style);
+  return style.paddingBottom;
+}
+
 describe('StreamPlayer component messaging', () => {
+  let emitAppState: (nextState: AppStateStatus) => void;
+
   beforeEach(() => {
     mockInjectJavaScript.mockClear();
     mockWebViewProps.length = 0;
+    emitAppState = () => {
+      throw new Error('no AppState change handler registered');
+    };
+    AppState.currentState = 'active';
+    jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation((_type, handler) => {
+        emitAppState = handler;
+        return { remove: jest.fn() };
+      });
   });
 
   afterEach(() => {
@@ -93,7 +121,10 @@ describe('StreamPlayer component messaging', () => {
     jest.restoreAllMocks();
   });
 
+  // Playback start pulses the layout nudge on a timer; without fake timers the
+  // pulse lands after the test ends and warns about an unwrapped state update.
   test('maps player bridge messages to callbacks and state updates', () => {
+    jest.useFakeTimers();
     const onContentGateChange = jest.fn();
     const onEnded = jest.fn();
     const onError = jest.fn();
@@ -289,6 +320,7 @@ describe('StreamPlayer component messaging', () => {
   });
 
   test('loads the stock raw Twitch player URL without the control bootstrap', () => {
+    jest.useFakeTimers();
     const onWebViewLoaded = jest.fn();
 
     render(
@@ -343,6 +375,7 @@ describe('StreamPlayer component messaging', () => {
   });
 
   test('uses the Twitch clip embed URL for clips', () => {
+    jest.useFakeTimers();
     const onWebViewLoaded = jest.fn();
 
     render(
@@ -375,6 +408,48 @@ describe('StreamPlayer component messaging', () => {
 
     expect(onWebViewLoaded).toHaveBeenCalledTimes(1);
     expect(mockInjectJavaScript).not.toHaveBeenCalled();
+  });
+
+  test('pulses the player frame again when the app returns to the foreground', () => {
+    jest.useFakeTimers();
+
+    const { toJSON } = render(
+      <StreamPlayer
+        channel='cohhcarnage'
+        height={200}
+        muted
+        showOverlayControls={false}
+        width={300}
+      />,
+    );
+
+    // The mount-time nudge fires off WebView load-end and is once-per-generation.
+    const { onLoadEnd } = latestWebViewProps();
+    act(() => {
+      (onLoadEnd as (event: { nativeEvent: { url: string } }) => void)({
+        nativeEvent: { url: 'https://player.twitch.tv/?channel=cohhcarnage' },
+      });
+    });
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(containerPaddingBottom(toJSON())).toEqual(undefined);
+
+    act(() => {
+      emitAppState('background');
+      emitAppState('active');
+      jest.advanceTimersByTime(0);
+    });
+
+    expect(containerPaddingBottom(toJSON())).toEqual(1);
+
+    // Drains both foreground pulses back to a resting frame.
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(containerPaddingBottom(toJSON())).toEqual(undefined);
   });
 
   test('keeps external auth windows inside the current WebView', () => {

--- a/src/screens/Stream/LiveStreamScreen.tsx
+++ b/src/screens/Stream/LiveStreamScreen.tsx
@@ -75,6 +75,7 @@ import {
   initialLiveStreamScreenState,
   liveStreamScreenReducer,
 } from './liveStreamScreenReducer';
+import { resolvePlayerAppStateAction } from './resolvePlayerAppStateAction';
 import { showSleepTimerMenu } from './showSleepTimerMenu';
 import { useSleepTimer } from './useSleepTimer';
 
@@ -265,18 +266,7 @@ export const LiveStreamScreen = memo(function LiveStreamScreen({
     }, [dispatchUi, isStreamEnabledRef]),
   );
 
-  /**
-   * Pauses the player when the app is backgrounded and resumes it on return,
-   * but only for a *full* background.
-   *
-   * `inactive` fires for transient interruptions (Control Center / notification
-   * pulldown, call banner, Face ID, app-switcher peek) that don't background the
-   * app - pausing on those left the player stopped with nothing to resume it,
-   * which read as the intermittent pausing this effect fixes. The pre-background
-   * play state is captured so a player the user had already paused stays paused
-   * on resume.
-   */
-  useOnAppStateChange(({ current }) => {
+  useOnAppStateChange(transition => {
     const player = streamPlayerRef.current;
     if (!player) {
       return;
@@ -287,10 +277,15 @@ export const LiveStreamScreen = memo(function LiveStreamScreen({
       wasPlayingBeforeBackgroundRef.current = false;
       return;
     }
-    if (current === 'background') {
+    const { capturePlayState, pausePlayer, resumePlayer } =
+      resolvePlayerAppStateAction(transition);
+    if (capturePlayState) {
       wasPlayingBeforeBackgroundRef.current = !player.getPaused();
+    }
+    if (pausePlayer) {
       player.pause();
-    } else if (current === 'active') {
+    }
+    if (resumePlayer) {
       if (wasPlayingBeforeBackgroundRef.current) {
         player.play();
       }

--- a/src/screens/Stream/__tests__/resolvePlayerAppStateAction.test.ts
+++ b/src/screens/Stream/__tests__/resolvePlayerAppStateAction.test.ts
@@ -1,0 +1,63 @@
+import type { PlayerAppStateAction } from '@app/screens/Stream/resolvePlayerAppStateAction';
+import { resolvePlayerAppStateAction } from '@app/screens/Stream/resolvePlayerAppStateAction';
+
+describe('resolvePlayerAppStateAction', () => {
+  test('captures the play state on the first step away from active', () => {
+    expect(
+      resolvePlayerAppStateAction({ previous: 'active', current: 'inactive' }),
+    ).toEqual<PlayerAppStateAction>({
+      capturePlayState: true,
+      pausePlayer: false,
+      resumePlayer: false,
+    });
+  });
+
+  test('does not re-capture when background follows inactive', () => {
+    expect(
+      resolvePlayerAppStateAction({
+        previous: 'inactive',
+        current: 'background',
+      }),
+    ).toEqual<PlayerAppStateAction>({
+      capturePlayState: false,
+      pausePlayer: true,
+      resumePlayer: false,
+    });
+  });
+
+  test('captures and pauses when active goes straight to background', () => {
+    expect(
+      resolvePlayerAppStateAction({
+        previous: 'active',
+        current: 'background',
+      }),
+    ).toEqual<PlayerAppStateAction>({
+      capturePlayState: true,
+      pausePlayer: true,
+      resumePlayer: false,
+    });
+  });
+
+  test('resumes when returning from a full background', () => {
+    expect(
+      resolvePlayerAppStateAction({
+        previous: 'background',
+        current: 'active',
+      }),
+    ).toEqual<PlayerAppStateAction>({
+      capturePlayState: false,
+      pausePlayer: false,
+      resumePlayer: true,
+    });
+  });
+
+  test('resumes when returning from an inactive-only interruption', () => {
+    expect(
+      resolvePlayerAppStateAction({ previous: 'inactive', current: 'active' }),
+    ).toEqual<PlayerAppStateAction>({
+      capturePlayState: false,
+      pausePlayer: false,
+      resumePlayer: true,
+    });
+  });
+});

--- a/src/screens/Stream/resolvePlayerAppStateAction.ts
+++ b/src/screens/Stream/resolvePlayerAppStateAction.ts
@@ -1,0 +1,35 @@
+import type { AppStateTransition } from '@app/utils/appState/appStateTransitions';
+
+export interface PlayerAppStateAction {
+  /**
+   * Read and remember whether the player was playing before this excursion.
+   */
+  capturePlayState: boolean;
+  pausePlayer: boolean;
+  resumePlayer: boolean;
+}
+
+/**
+ * Decides what an app-state transition should do to the stream player.
+ *
+ * Only a full `background` pauses: `inactive` also fires for interruptions that
+ * never background the app (Control Center, notification pulldown, call banner,
+ * Face ID, app-switcher peek), and pausing on those left the player stopped
+ * with nothing to resume it. The resume, by contrast, runs on every return to
+ * `active`, because WebKit pauses the inline video on some of those same
+ * interruptions and nothing else brings it back.
+ *
+ * The play state is captured on the first step away from `active` rather than
+ * on `background`, since `inactive` lands first and WebKit's own pause can
+ * arrive in between - reading it later reports the user as having paused.
+ */
+export function resolvePlayerAppStateAction({
+  current,
+  previous,
+}: AppStateTransition): PlayerAppStateAction {
+  return {
+    capturePlayState: previous === 'active' && current !== 'active',
+    pausePlayer: current === 'background',
+    resumePlayer: current === 'active',
+  };
+}


### PR DESCRIPTION
# Why

Watching a live stream, opening a notification or switching to another app and coming back leaves the player as a blank rectangle - it never resumes.

Two separate causes.

**The resume flag is only armed on a full background.** `LiveStreamScreen` captured the pre-excursion play state inside the `current === 'background'` branch. A notification pulldown, app-switcher peek, call banner or Face ID gives `active -> inactive -> active` with no `background` in between, so the flag is never set and `play()` is never called on the way back. WebKit has paused the inline video by then and the page-side `__foamEnsurePlaying` pump has burned its 12s deadline, so nothing restarts it.

Same code has a second-order version of the bug on the full-background path: `inactive` lands before `background`, and WebKit's own pause event can arrive in that gap. When it does, `getPaused()` reads `true` and we record "the user had it paused", so we deliberately don't resume.

**Nothing re-attaches the video layer on foreground.** The layout nudge in `StreamPlayer` exists because WKWebView sometimes leaves the inline video's AVPlayer layer out of the compositor - the existing comment already describes it as "picture stays black or frozen while playback advances". It's gated on `nudgePlayedRef`, which is once-per-generation and reset only on a source change or remount. Coming back from suspend is exactly when iOS drops that layer, and the nudge fired minutes earlier. The poster is gone too (`loadedGeneration === generation`), so there's nothing covering the hole.

# How

`resolvePlayerAppStateAction` is a new pure decision next to `liveStreamScreenReducer`: capture the play state on the first step away from `active`, pause only on a full `background`, resume on every return to `active`. `LiveStreamScreen` uses it; the picture-in-picture escape hatch is unchanged.

`nudgeLayerTree()` is extracted out of `handleBridgePlaying` and also fired on `isForegroundTransition`. It clears pending pulses before scheduling, so repeated app switches don't accumulate timeout handles in the ref.

Also fixes three pre-existing "not wrapped in act" warnings in `StreamPlayer.test.tsx` - those tests start playback on real timers, so the nudge landed after the test had finished.

# Test Plan

`bun jest src/components/StreamPlayer src/screens/Stream src/utils/appState` - 27 suites, 154 tests pass. `tsc --noEmit` and eslint clean. Act warnings in the player suite go 3 -> 0.

New coverage:
- `resolvePlayerAppStateAction.test.ts` pins all five transitions, including `inactive -> active` resuming and `inactive -> background` not re-capturing.
- `StreamPlayer.test.tsx` asserts the container gets its 1px nudge padding on a foreground transition *after* the mount-time nudge has already fired and settled.

Manual repro on device (not yet run - needs a build):
1. Open a live stream, let it play.
2. Swipe to another app, wait a few seconds, swipe back. Player should resume with picture, not a blank box.
3. Repeat with just a notification pulldown (never fully backgrounding).
4. Pause the stream yourself, background, return - should stay paused.

The `inactive` half is deterministic and I'm confident in it. The nudge half targets the compositor race, and it's the same mitigation this file already uses at mount - if the blank frame survives it, the next step is a foreground remount fallback (bump `webViewKey`), which is heavier but definitive.
