### PR TITLE
fix(chat): bucket chat row item types by content width so the size average stops opening holes

### DIFF
--- a/src/components/Chat/hooks/__tests__/useChatRowRenderer.test.tsx
+++ b/src/components/Chat/hooks/__tests__/useChatRowRenderer.test.tsx
@@ -216,7 +216,7 @@ describe('useChatRowRenderer', () => {
 
     expect(hook.result.current.keyExtractor(replyMessage)).toBe('msg-2_msg-2');
     expect(hook.result.current.getItemType(replyMessage)).toBe(
-      'user_chat-reply',
+      'user_chat-reply-w0',
     );
     expect(hook.result.current.messageListExtraData).toEqual({
       animate: true,

--- a/src/components/Chat/util/__tests__/chatRowItemType.test.ts
+++ b/src/components/Chat/util/__tests__/chatRowItemType.test.ts
@@ -74,9 +74,9 @@ describe('getChatRowItemType', () => {
       replyBody: 'hi',
     });
 
-    expect(getChatRowItemType(plain)).toBe('user_chat');
-    expect(getChatRowItemType(moderated)).toBe('user_chat-mod');
-    expect(getChatRowItemType(reply)).toBe('user_chat-reply');
+    expect(getChatRowItemType(plain)).toBe('user_chat-w0');
+    expect(getChatRowItemType(moderated)).toBe('user_chat-mod-w0');
+    expect(getChatRowItemType(reply)).toBe('user_chat-reply-w0');
     expect(getChatRowItemType(moderated)).not.toBe(getChatRowItemType(reply));
   });
 
@@ -87,7 +87,19 @@ describe('getChatRowItemType', () => {
     });
 
     expect(getChatRowItemType(reply, { showInlineReplyContext: false })).toBe(
-      'user_chat',
+      'user_chat-w0',
     );
+  });
+
+  test('splits user chat rows by how much room their content needs', () => {
+    const short = createUserChatMessage({ message: [createTextPart('gg')] });
+    const copypasta = createUserChatMessage({
+      message: [
+        createTextPart('OHNE YOU JUST DECLINED A 0.000005 FLOAT '.repeat(8)),
+      ],
+    });
+
+    expect(getChatRowItemType(short)).toBe('user_chat-w0');
+    expect(getChatRowItemType(copypasta)).toBe('user_chat-w6');
   });
 });

--- a/src/components/Chat/util/__tests__/chatRowSizeBucket.test.ts
+++ b/src/components/Chat/util/__tests__/chatRowSizeBucket.test.ts
@@ -1,0 +1,97 @@
+import type { AnyChatMessageType } from '@app/store/chat/types/constants';
+import { createUserStateTags } from '@app/types/chat/irc-tags/__fixtures__/userStateTags.fixture';
+import {
+  createEmotePart,
+  createTextPart,
+} from '@app/utils/chat/__tests__/__fixtures__/parsedPart.fixture';
+
+import { getChatRowSizeBucket } from '../chatRowSizeBucket';
+
+function createMessage(
+  overrides: Partial<AnyChatMessageType> = {},
+): AnyChatMessageType {
+  return {
+    id: 'msg-1',
+    message_id: 'msg-1',
+    message_nonce: 'nonce-1',
+    channel: 'channel',
+    sender: 'viewer',
+    message: [createTextPart('hello')],
+    userstate: createUserStateTags({
+      username: 'viewer',
+      'display-name': 'Viewer',
+      'user-id': '123',
+    }),
+    badges: [],
+    replyBody: '',
+    replyDisplayName: '',
+    parentDisplayName: '',
+    ...overrides,
+  };
+}
+
+describe('getChatRowSizeBucket', () => {
+  test('keeps every one-line row in the first bucket', () => {
+    expect(getChatRowSizeBucket(createMessage())).toBe('w0');
+    expect(
+      getChatRowSizeBucket(createMessage({ message: [createTextPart('gg')] })),
+    ).toBe('w0');
+  });
+
+  test('climbs a bucket as the body grows', () => {
+    const buckets = [40, 90, 140, 210, 300, 450, 630, 900].map(length =>
+      getChatRowSizeBucket(
+        createMessage({ message: [createTextPart('a'.repeat(length))] }),
+      ),
+    );
+
+    expect(buckets).toEqual<string[]>([
+      'w1',
+      'w2',
+      'w3',
+      'w4',
+      'w5',
+      'w6',
+      'w7',
+      'w8',
+    ]);
+  });
+
+  test('separates emote rows from text rows of the same width', () => {
+    const text = createMessage({ message: [createTextPart('hello')] });
+    const emote = createMessage({ message: [createEmotePart('Kappa')] });
+
+    expect(getChatRowSizeBucket(text)).toBe('w0');
+    expect(getChatRowSizeBucket(emote)).toBe('w0e');
+  });
+
+  test('climbs a bucket as an emote wall grows', () => {
+    const few = createMessage({
+      message: Array.from({ length: 4 }, () => createEmotePart('Kappa')),
+    });
+    const wall = createMessage({
+      message: Array.from({ length: 12 }, () => createEmotePart('Kappa')),
+    });
+
+    expect(getChatRowSizeBucket(few)).toBe('w0e');
+    expect(getChatRowSizeBucket(wall)).toBe('w1e');
+  });
+
+  test('reads the username but never the badges', () => {
+    const withBadges = createMessage({
+      badges: [
+        {
+          id: 'moderator',
+          set: 'moderator',
+          title: 'Moderator',
+          type: 'Twitch Global Badge',
+          url: 'https://example.test/mod.png',
+        },
+      ],
+    });
+
+    expect(getChatRowSizeBucket(withBadges)).toBe(
+      getChatRowSizeBucket(createMessage()),
+    );
+  });
+});

--- a/src/components/Chat/util/__tests__/chatRowSizeBucket.test.ts
+++ b/src/components/Chat/util/__tests__/chatRowSizeBucket.test.ts
@@ -77,6 +77,19 @@ describe('getChatRowSizeBucket', () => {
     expect(getChatRowSizeBucket(wall)).toBe('w1e');
   });
 
+  test('weighs the media cards a link renders instead of its url', () => {
+    const url = 'https://7tv.app/emotes/01F6MZGCNG000255K4X1V15WQE';
+    const stvEmote = createMessage({
+      message: [{ type: 'stvEmote', content: url, url }],
+    });
+    const clip = createMessage({
+      message: [{ type: 'twitchClip', content: url, url }],
+    });
+
+    expect(getChatRowSizeBucket(stvEmote)).toBe('w1');
+    expect(getChatRowSizeBucket(clip)).toBe('w2');
+  });
+
   test('reads the username but never the badges', () => {
     const withBadges = createMessage({
       badges: [

--- a/src/components/Chat/util/__tests__/chatRowSizeBucket.test.ts
+++ b/src/components/Chat/util/__tests__/chatRowSizeBucket.test.ts
@@ -38,20 +38,31 @@ describe('getChatRowSizeBucket', () => {
     ).toBe('w0');
   });
 
-  test('climbs a bucket as the body grows', () => {
-    const buckets = [40, 90, 140, 210, 300, 450, 630, 900].map(length =>
-      getChatRowSizeBucket(
-        createMessage({ message: [createTextPart('a'.repeat(length))] }),
+  test('climbs a bucket on the character that passes each bound', () => {
+    const usernameWeight = 'viewer'.length;
+    const buckets = [30, 60, 100, 150, 220, 320, 460, 640].flatMap(bound =>
+      [bound - usernameWeight, bound - usernameWeight + 1].map(length =>
+        getChatRowSizeBucket(
+          createMessage({ message: [createTextPart('a'.repeat(length))] }),
+        ),
       ),
     );
 
     expect(buckets).toEqual<string[]>([
+      'w0',
+      'w1',
       'w1',
       'w2',
+      'w2',
+      'w3',
       'w3',
       'w4',
+      'w4',
+      'w5',
       'w5',
       'w6',
+      'w6',
+      'w7',
       'w7',
       'w8',
     ]);

--- a/src/components/Chat/util/chatRowItemType.ts
+++ b/src/components/Chat/util/chatRowItemType.ts
@@ -4,6 +4,7 @@ import type { ChatBodyVariant } from '@app/utils/chat/deriveChatBody/types';
 import { isRenderableChatMessage } from '@app/utils/chat/messageIdentity/isRenderableChatMessage';
 
 import { hasSharedChannelPointsMessage } from './channelPointsSharedMessage';
+import { getChatRowSizeBucket } from './chatRowSizeBucket';
 
 export interface ChatRowItemTypeOptions {
   showInlineReplyContext?: boolean;
@@ -70,7 +71,14 @@ function getUserChatRowItemType(
     flags.push('shared');
   }
 
-  return flags.length > 0 ? `user_chat-${flags.join('-')}` : 'user_chat';
+  /**
+   * The list lays an unmeasured row out at the running average of its item
+   * type, so one `user_chat` type averages a one-line "gg" with an eight-line
+   * copypasta and the over-estimated rows leave unpainted background behind.
+   */
+  flags.push(getChatRowSizeBucket(item));
+
+  return `user_chat-${flags.join('-')}`;
 }
 
 /**

--- a/src/components/Chat/util/chatRowSizeBucket.ts
+++ b/src/components/Chat/util/chatRowSizeBucket.ts
@@ -1,0 +1,65 @@
+import type { AnyChatMessageType } from '@app/store/chat/types/constants';
+import { getMessageStructure } from '@app/utils/chat/deriveChatBody/getMessageStructure';
+import type { ParsedPart } from '@app/utils/chat/parsedPart';
+
+/**
+ * Weights are "one average character wide", never points. A bucket only has to
+ * group rows of similar height; the list learns each bucket's real height from
+ * the first row of that shape it measures, at the current width, density and
+ * font scale.
+ */
+const EMOTE_WEIGHT = 4;
+/**
+ * A clip renders a MediaLinkCard on its own line, roughly two lines of body.
+ */
+const TWITCH_CLIP_WEIGHT = 70;
+
+/**
+ * About a wrapped line apart at the low end where nearly every row sits,
+ * widening down the tail so one copypasta cannot open a bucket of its own.
+ */
+const BUCKET_UPPER_BOUNDS = [30, 60, 100, 150, 220, 320, 460, 640];
+
+const bucketCache = new WeakMap<AnyChatMessageType, string>();
+
+function getPartWeight(part: ParsedPart): number {
+  switch (part.type) {
+    case 'text':
+    case 'link':
+    case 'mention':
+    case 'cheermote':
+      return part.content.length;
+    case 'emote':
+      return EMOTE_WEIGHT;
+    case 'twitchClip':
+      return TWITCH_CLIP_WEIGHT;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Reads the message only. Badges, paints and the rest of the cosmetics land
+ * after the row is placed, and the list treats a row's type as fixed from that
+ * point.
+ */
+export function getChatRowSizeBucket(item: AnyChatMessageType): string {
+  const cached = bucketCache.get(item);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let weight = item.userstate?.username?.length ?? 0;
+  for (const part of item.message) {
+    weight += getPartWeight(part);
+  }
+
+  const bounded = BUCKET_UPPER_BOUNDS.findIndex(bound => weight <= bound);
+  const bucket = bounded === -1 ? BUCKET_UPPER_BOUNDS.length : bounded;
+  const value = getMessageStructure(item.message).containsEmotes
+    ? `w${bucket}e`
+    : `w${bucket}`;
+  bucketCache.set(item, value);
+
+  return value;
+}

--- a/src/components/Chat/util/chatRowSizeBucket.ts
+++ b/src/components/Chat/util/chatRowSizeBucket.ts
@@ -13,6 +13,11 @@ const EMOTE_WEIGHT = 4;
  * A clip renders a MediaLinkCard on its own line, roughly two lines of body.
  */
 const TWITCH_CLIP_WEIGHT = 70;
+/**
+ * A 7TV emote link renders the inline MediaLinkCard chip, a 28pt thumbnail and
+ * a one-line title that can stretch to the full row.
+ */
+const STV_EMOTE_LINK_WEIGHT = 35;
 
 /**
  * About a wrapped line apart at the low end where nearly every row sits,
@@ -33,6 +38,8 @@ function getPartWeight(part: ParsedPart): number {
       return EMOTE_WEIGHT;
     case 'twitchClip':
       return TWITCH_CLIP_WEIGHT;
+    case 'stvEmote':
+      return STV_EMOTE_LINK_WEIGHT;
     default:
       return 0;
   }


### PR DESCRIPTION
# Why

Follow-up to #860. Blank vertical holes still show up in chat, worst in copypasta-heavy channels like ohnePixel and in emote-spam channels.

#860 went after the two ways Legend List can skip a position recompute. It never touched the thing that decides how big the hole is when one gets skipped, which is the estimate itself.

`estimatedItemSize={26}` is only a cold-start fallback. Once one row of a given `getItemType` has been measured, `getItemSize` uses `averageSizes[itemType].avg` for every unmeasured row of that type (`react-native.mjs:1177-1182`) and the constant is never read again. The list is already auto-estimating, from a running average per item type.

`getChatRowItemType` returned `user_chat` for essentially every message. One average, blending a 31pt `gg` with a 200pt copypasta, laid over every not-yet-measured row. The over-estimated ones are the black gaps, which is why it's worst where the height spread is widest.

# How

Keeps the auto-estimate and gives it finer pools.

New `chatRowSizeBucket.ts` walks a message's parts once, WeakMap-cached, and returns a bucket like `w3` or `w1e`. Weight is in character-advance units: username plus text, mention, link and cheer content length, 4 per emote, 35 for the inline 7TV emote chip and 70 for the two-line clip card. Bucketed on `[30, 60, 100, 150, 220, 320, 460, 640]`, about a wrapped line apart at the low end where nearly every row sits, widening down the tail so one copypasta can't open a bucket of its own. The `e` marker comes from the existing `getMessageStructure` scan and keeps emote rows out of the text-row average, since emote lines lead taller.

`getChatRowItemType` appends it as another flag, so `user_chat` becomes `user_chat-w0` and a long reply becomes `user_chat-reply-w6`.

The units never need calibrating against real points. A bucket only has to group rows of similar height; the list learns each bucket's actual height from the first row of that shape it measures, at the current width, density and font scale. A cold bucket falls back to 26, which under-estimates, and an under-estimated slot just expands on measure. Same reason emote width is flat rather than scaled by aspect ratio: it undercounts wide emotes, and undercounting is the safe direction.

Weights read the message only, no badges and no paints. Those land after the row is placed and the list treats a row's type as fixed from then on.

Notice variants stay unbucketed. They're low volume and their chrome dominates, so a blended average beats a pile of cold types.

The only other lever v3 offers is `getFixedItemSize`, and it's worse: it writes straight into `sizesKnown` and the row is never re-measured (`getKnownOrFixedSize`, line 1125). Right for fixed-height rows, wrong for wrapping text. v3 removed the per-item `getEstimatedItemSize` hook that `pretextChatHeight` used to feed, so there's no way to hand it a height directly.

Extra item types are cheap here. Container allocation falls back cross-type (`assignFromPool(..., allowCrossType: true)`) and `recycleItems={false}` means reuse matching doesn't matter anyway.

# Test Plan

- `tsc` clean, eslint clean
- new `chatRowSizeBucket.test.ts` pins the bucket boundaries, the emote marker, an emote wall climbing a bucket, the two media cards, and that badges are never read
- `chatRowItemType.test.ts` pins the composed type strings and that notices stay unbucketed
- 98 suites / 703 tests green across `src/components/Chat`

Not confirmed on device yet. JS only so it goes out over OTA. Repro: busy copypasta channel, sit pinned at the bottom, look for pure black gaps. Alternating Rows makes it obvious, a real hole has no banding.

Unaffected and separate: the rows that render a badge and username with no body are the ImageRef eviction bug.
