### PR TITLE
fix(ui): honour reduced motion and fix the feed card's accessibility tree

### DIFF
--- a/src/Providers/Providers.tsx
+++ b/src/Providers/Providers.tsx
@@ -143,6 +143,10 @@ export function Providers({ children }: PropsWithChildren) {
                             keep their weight. Haptics are opt-in per
                             control via lib/haptics. */}
                         <PressablesConfig
+                          animationConfig={{
+                            duration: motion.instant,
+                            easing: motion.easing.out,
+                          }}
                           config={{ minScale: motion.pressMinScale }}
                         >
                           {children}

--- a/src/Providers/Providers.web.tsx
+++ b/src/Providers/Providers.web.tsx
@@ -53,6 +53,10 @@ export function Providers({ children }: PropsWithChildren) {
                   <QueryProvider>
                     <QueryDevTools>
                       <PressablesConfig
+                        animationConfig={{
+                          duration: motion.instant,
+                          easing: motion.easing.out,
+                        }}
                         config={{ minScale: motion.pressMinScale }}
                       >
                         {children}

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -23,7 +23,11 @@ export default function IndexRoute() {
 
   if (!ready) {
     return (
-      <View style={styles.skeletonContainer}>
+      <View
+        accessibilityLabel='Loading streams'
+        accessibilityRole='progressbar'
+        style={styles.skeletonContainer}
+      >
         {Array.from({ length: 6 }).map((_, index) => (
           // eslint-disable-next-line react/no-array-index-key
           <LiveStreamCardSkeleton key={index} />
@@ -36,7 +40,7 @@ export default function IndexRoute() {
     return (
       <View style={styles.container}>
         <Text type='lg' align='center' style={styles.message}>
-          Authentication state is not ready.
+          Unable to load your account.
         </Text>
         <Button
           onPress={() => {
@@ -44,7 +48,7 @@ export default function IndexRoute() {
           }}
         >
           <Text type='md' color='accent' contrast align='center'>
-            Continue
+            Continue without signing in
           </Text>
         </Button>
       </View>

--- a/src/components/Chat/components/ChatComposer/components/SuggestionRail.styles.ts
+++ b/src/components/Chat/components/ChatComposer/components/SuggestionRail.styles.ts
@@ -12,7 +12,7 @@ export const suggestionRailColors = {
   containerBorder: theme.color.border.dark,
   richContainerBackground: theme.color.surfaceElevated.dark,
   secondaryText: theme.color.textSecondary.dark,
-  shadow: '0 8px 18px rgba(0, 0, 0, 0.28)',
+  shadow: theme.shadow.md.dark,
   text: theme.color.text.dark,
 } as const;
 

--- a/src/components/Chat/components/ChatInputSection.ios.tsx
+++ b/src/components/Chat/components/ChatInputSection.ios.tsx
@@ -222,7 +222,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     paddingHorizontal: theme.space16,
     paddingVertical: theme.space12,
-    boxShadow: '0 10px 20px rgba(0, 0, 0, 0.18)',
+    boxShadow: theme.shadow.md.dark,
   },
   wrapper: {
     gap: theme.space8,

--- a/src/components/Chat/components/ResumeScroll.tsx
+++ b/src/components/Chat/components/ResumeScroll.tsx
@@ -55,7 +55,7 @@ const styles = StyleSheet.create({
     borderCurve: 'continuous',
     borderRadius: theme.borderRadius28,
     borderWidth: 1,
-    boxShadow: '0 2px 3.84px rgba(0, 0, 0, 0.25)',
+    boxShadow: theme.shadow.sm.dark,
     flexDirection: 'row',
     gap: theme.space8,
     paddingHorizontal: theme.space20,

--- a/src/components/EnergyOrb/EnergyOrb.tsx
+++ b/src/components/EnergyOrb/EnergyOrb.tsx
@@ -3,6 +3,7 @@ import { StyleSheet } from 'react-native';
 import {
   useDerivedValue,
   useFrameCallback,
+  useReducedMotion,
   useSharedValue,
 } from 'react-native-reanimated';
 
@@ -48,6 +49,7 @@ function EnergyOrbComponent({
   glowRadius = DEFAULT_GLOW_RADIUS,
 }: EnergyOrbProps) {
   const focused = useScreenFocused();
+  const reduceMotion = useReducedMotion();
   const time = useSharedValue<number>(0);
 
   const frameCallback = useFrameCallback(frameInfo => {
@@ -55,9 +57,13 @@ function EnergyOrbComponent({
     time.set(time.get() + deltaSeconds * speed);
   });
 
+  /**
+   * Under reduced motion the shader holds at a fixed time rather than being
+   * removed: the orb still renders, it just stops moving.
+   */
   useEffect(() => {
-    frameCallback.setActive(focused);
-  }, [focused, frameCallback]);
+    frameCallback.setActive(focused && !reduceMotion);
+  }, [focused, frameCallback, reduceMotion]);
 
   const [c0r, c0g, c0b] = useMemo<RGB>(
     () => parseColor(colors[0] || DEFAULT_COLORS[0]),

--- a/src/components/IconButton/IconButtonIcon.tsx
+++ b/src/components/IconButton/IconButtonIcon.tsx
@@ -22,16 +22,24 @@ export function IconButtonIcon({
   loading?: boolean;
   size?: Spacing;
 }) {
+  const dimension = resolveSpacingValue(theme, size);
+
   if (loading) {
-    return <ActivityIndicator color={theme.color.text.dark} />;
+    return (
+      <ActivityIndicator
+        color={theme.colorGrey}
+        style={{ height: dimension, width: dimension }}
+      />
+    );
   }
 
   if (typeof icon === 'string' || !('type' in icon)) {
     return (
       <SymbolView
         name={icon}
-        size={resolveSpacingValue(theme, size)}
+        size={dimension}
         tintColor={theme.colorGrey}
+        weight='semibold'
       />
     );
   }
@@ -40,8 +48,9 @@ export function IconButtonIcon({
     return (
       <SymbolView
         name={icon.name}
-        size={icon.size ?? resolveSpacingValue(theme, size)}
+        size={icon.size ?? dimension}
         tintColor={icon.color ?? theme.colorGrey}
+        weight='semibold'
       />
     );
   }

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -37,7 +37,7 @@ export const Image = function Image({
   contentFit = 'cover',
   containerStyle,
   placeholderContentFit,
-  transition = 500,
+  transition = 150,
   source,
   cachePolicy,
   cacheToFile = true,

--- a/src/components/Image/Image.web.tsx
+++ b/src/components/Image/Image.web.tsx
@@ -32,7 +32,7 @@ export const Image = function Image({
   contentFit = 'cover',
   containerStyle,
   placeholderContentFit,
-  transition = 500,
+  transition = 150,
   source,
   cachePolicy,
   cacheToFile = true,

--- a/src/components/LiveStreamCard/LiveStreamCard.tsx
+++ b/src/components/LiveStreamCard/LiveStreamCard.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import { useQueryClient } from '@tanstack/react-query';
@@ -19,7 +19,6 @@ import {
   formatViewCountCompact,
 } from '@app/utils/string/formatViewCount';
 
-import { Button } from '../Button/Button';
 import { Image } from '../Image/Image';
 import { PressableArea } from '../PressableArea/PressableArea';
 import { COMPACT_THUMBNAIL_SIZE, MEDIA_THUMBNAIL_SIZE } from './thumbnailSizes';
@@ -123,6 +122,32 @@ function LiveStreamCard({ stream, layout = 'compact' }: Props) {
     stream.game_name
   }, ${formatViewCount(stream.viewer_count)} watching, ${stream.title}`;
 
+  /**
+   * The card is one accessibility element, so the nested profile and category
+   * pressables are merged into it and unreachable on their own. These expose
+   * the same two destinations through the rotor.
+   */
+  const cardAccessibilityActions = useMemo(
+    () => [
+      { name: 'viewProfile', label: `View ${stream.user_name}'s profile` },
+      { name: 'openCategory', label: `Open ${stream.game_name}` },
+    ],
+    [stream.game_name, stream.user_name],
+  );
+
+  const handleAccessibilityAction = useCallback(
+    (event: { nativeEvent: { actionName: string } }) => {
+      if (event.nativeEvent.actionName === 'viewProfile') {
+        handleStreamerPress();
+        return;
+      }
+      if (event.nativeEvent.actionName === 'openCategory') {
+        handleCategoryPress();
+      }
+    },
+    [handleCategoryPress, handleStreamerPress],
+  );
+
   if (layout === 'media') {
     // Only the media layout renders the language, so keep the tag scan out of
     // the (default) compact path.
@@ -131,11 +156,13 @@ function LiveStreamCard({ stream, layout = 'compact' }: Props) {
       LANGUAGE_NAMES[stream.language];
 
     return (
-      <Button
+      <PressableArea
+        accessibilityActions={cardAccessibilityActions}
+        accessibilityLabel={cardAccessibilityLabel}
+        onAccessibilityAction={handleAccessibilityAction}
         onPress={handleStreamPress}
         onPressIn={handleStreamPressIn}
         onLongPress={handleLongPress}
-        label={cardAccessibilityLabel}
         style={styles.mediaCardWrapper}
       >
         <View style={styles.mediaContainer}>
@@ -150,7 +177,12 @@ function LiveStreamCard({ stream, layout = 'compact' }: Props) {
               style={[styles.compactLiveBadge, styles.mediaLiveBadge]}
             />
             <View style={styles.viewerBadge}>
-              <Text type='sm' weight='bold' style={styles.viewerBadgeText}>
+              <Text
+                type='sm'
+                weight='bold'
+                tabular
+                style={styles.viewerBadgeText}
+              >
                 {formatViewCountCompact(stream.viewer_count)} watching
               </Text>
             </View>
@@ -185,7 +217,7 @@ function LiveStreamCard({ stream, layout = 'compact' }: Props) {
                 accessibilityLabel={`${stream.user_name}'s profile`}
                 onPress={handleStreamerPress}
                 onPressIn={handleStreamerPressIn}
-                hitSlop={6}
+                hitSlop={{ top: 6, bottom: 2, left: 8, right: 8 }}
               >
                 <Text
                   type='md'
@@ -207,7 +239,7 @@ function LiveStreamCard({ stream, layout = 'compact' }: Props) {
               <PressableArea
                 accessibilityLabel={`${stream.game_name} category`}
                 onPress={handleCategoryPress}
-                hitSlop={6}
+                hitSlop={{ top: 6, bottom: 6, left: 8, right: 8 }}
               >
                 <Text
                   type='sm'
@@ -222,16 +254,18 @@ function LiveStreamCard({ stream, layout = 'compact' }: Props) {
             </View>
           </View>
         </View>
-      </Button>
+      </PressableArea>
     );
   }
 
   return (
-    <Button
+    <PressableArea
+      accessibilityActions={cardAccessibilityActions}
+      accessibilityLabel={cardAccessibilityLabel}
+      onAccessibilityAction={handleAccessibilityAction}
       onPress={handleStreamPress}
       onPressIn={handleStreamPressIn}
       onLongPress={handleLongPress}
-      label={cardAccessibilityLabel}
       style={styles.cardWrapper}
     >
       <View style={styles.container}>
@@ -251,7 +285,7 @@ function LiveStreamCard({ stream, layout = 'compact' }: Props) {
             onPress={handleStreamerPress}
             onPressIn={handleStreamerPressIn}
             style={styles.usernameButton}
-            hitSlop={8}
+            hitSlop={{ top: 6, bottom: 2, left: 8, right: 8 }}
           >
             <Text
               type='sm'
@@ -274,14 +308,19 @@ function LiveStreamCard({ stream, layout = 'compact' }: Props) {
 
           <View style={styles.metadataRow}>
             <View style={styles.liveMeta}>
-              <Text type='xs' style={styles.liveText}>
+              <Text type='xs' tabular style={styles.liveText}>
                 {elapsedStreamTime(stream.started_at)}
               </Text>
             </View>
             <Text type='xs' style={styles.metaDivider}>
               •
             </Text>
-            <Text type='xs' numberOfLines={1} style={styles.viewersText}>
+            <Text
+              type='xs'
+              tabular
+              numberOfLines={1}
+              style={styles.viewersText}
+            >
               {formatViewCountCompact(stream.viewer_count)} watching
             </Text>
           </View>
@@ -289,7 +328,7 @@ function LiveStreamCard({ stream, layout = 'compact' }: Props) {
           <PressableArea
             onPress={handleCategoryPress}
             style={styles.categoryButton}
-            hitSlop={6}
+            hitSlop={{ top: 6, bottom: 6, left: 8, right: 8 }}
           >
             <Text type='xs' numberOfLines={1} style={styles.categoryText}>
               {stream.game_name}
@@ -297,7 +336,7 @@ function LiveStreamCard({ stream, layout = 'compact' }: Props) {
           </PressableArea>
         </View>
       </View>
-    </Button>
+    </PressableArea>
   );
 }
 
@@ -338,6 +377,7 @@ const styles = StyleSheet.create({
   },
   categoryButton: {
     alignSelf: 'flex-start',
+    marginTop: theme.space4,
     minWidth: 0,
   },
   categoryText: {
@@ -349,7 +389,7 @@ const styles = StyleSheet.create({
     backgroundColor: Color.zinc[900],
     borderColor: theme.color.border.dark,
     borderCurve: 'continuous',
-    borderRadius: theme.borderRadius10,
+    borderRadius: theme.borderRadius14,
     borderWidth: StyleSheet.hairlineWidth,
     flexDirection: 'row',
     flexWrap: 'nowrap',
@@ -413,6 +453,7 @@ const styles = StyleSheet.create({
   mediaCategory: {
     color: Color.zinc[300],
     lineHeight: 20,
+    marginTop: theme.space4,
   },
   mediaContainer: {
     marginHorizontal: theme.space16,
@@ -450,7 +491,7 @@ const styles = StyleSheet.create({
   },
   mediaTitle: {
     color: Color.zinc[100],
-    lineHeight: 19,
+    lineHeight: 23,
   },
   mediaUsername: {
     color: Color.zinc[50],
@@ -458,18 +499,17 @@ const styles = StyleSheet.create({
   },
   metaDivider: {
     color: Color.zinc[400],
-    opacity: 0.5,
   },
   metadataRow: {
     alignItems: 'center',
     flexDirection: 'row',
     flexWrap: 'nowrap',
     gap: 6,
-    marginTop: theme.space4,
+    marginTop: theme.space8,
   },
   title: {
     color: Color.zinc[100],
-    lineHeight: 19,
+    lineHeight: 23,
   },
   username: {
     color: Color.zinc[50],

--- a/src/components/LiveStreamCard/LiveStreamCardSkeleton.tsx
+++ b/src/components/LiveStreamCard/LiveStreamCardSkeleton.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet, View } from 'react-native';
 
 import { Skeleton } from '@app/components/ui/Skeleton/Skeleton';
+import { Color } from '@app/styles/palette';
 import { theme } from '@app/styles/themes';
 
 export function LiveStreamCardSkeleton({
@@ -8,31 +9,48 @@ export function LiveStreamCardSkeleton({
 }: {
   layout?: 'compact' | 'media';
 }) {
-  const isMediaLayout = layout === 'media';
-  const imageStyle = isMediaLayout
-    ? { ...styles.imageSkeleton, ...styles.imageMedia }
-    : styles.imageSkeleton;
+  if (layout === 'media') {
+    return (
+      <View
+        accessibilityElementsHidden
+        importantForAccessibility='no-hide-descendants'
+        style={styles.mediaContainer}
+        testID='stream-skeleton'
+      >
+        <Skeleton style={styles.mediaImageSkeleton} />
+
+        <View style={styles.mediaDetailsRow}>
+          <Skeleton style={styles.avatarSkeleton} />
+
+          <View style={styles.mediaTextColumn}>
+            <Skeleton style={styles.mediaUsernameSkeleton} />
+            <Skeleton style={styles.mediaTitleSkeleton} />
+            <Skeleton style={styles.mediaTitleSecondLineSkeleton} />
+            <Skeleton style={styles.mediaCategorySkeleton} />
+          </View>
+        </View>
+      </View>
+    );
+  }
 
   return (
     <View
-      style={[styles.container, isMediaLayout && styles.containerMedia]}
+      accessibilityElementsHidden
+      importantForAccessibility='no-hide-descendants'
+      style={styles.container}
       testID='stream-skeleton'
     >
       <View style={styles.imageContainer}>
-        <Skeleton style={imageStyle} />
+        <Skeleton style={styles.imageSkeleton} />
       </View>
 
       <View style={styles.details}>
-        <View style={styles.headerRow}>
-          <Skeleton style={styles.usernameSkeleton} />
-        </View>
+        <Skeleton style={styles.usernameSkeleton} />
         <Skeleton style={styles.titleSkeleton} />
-        <View style={styles.metadata}>
-          <View style={styles.info}>
-            <Skeleton style={styles.metaTextSkeleton} />
-            <Skeleton style={styles.metaDividerSkeleton} />
-            <Skeleton style={styles.metaWideSkeleton} />
-          </View>
+        <View style={styles.metadataRow}>
+          <Skeleton style={styles.metaTextSkeleton} />
+          <Skeleton style={styles.metaDividerSkeleton} />
+          <Skeleton style={styles.metaWideSkeleton} />
         </View>
         <Skeleton style={styles.categoryLineSkeleton} />
       </View>
@@ -41,48 +59,49 @@ export function LiveStreamCardSkeleton({
 }
 
 const styles = StyleSheet.create({
+  avatarSkeleton: {
+    borderRadius: theme.borderRadius999,
+    flexShrink: 0,
+    height: 44,
+    marginTop: 2,
+    width: 44,
+  },
   categoryLineSkeleton: {
-    borderRadius: theme.borderRadius12,
-    height: 20,
+    borderRadius: theme.borderRadius4,
+    height: 16,
+    marginTop: theme.space4,
     width: 88,
   },
   container: {
     alignItems: 'flex-start',
-    backgroundColor: 'rgba(255,255,255,0.035)',
-    borderColor: 'rgba(255,255,255,0.13)',
+    backgroundColor: Color.zinc[900],
+    borderColor: theme.color.border.dark,
     borderCurve: 'continuous',
-    borderRadius: theme.borderRadius10,
-    borderWidth: 1,
-    columnGap: theme.space12,
+    borderRadius: theme.borderRadius14,
+    borderWidth: StyleSheet.hairlineWidth,
     flexDirection: 'row',
     marginHorizontal: theme.space16,
-    marginVertical: 5,
+    marginVertical: theme.space4,
     minHeight: 112,
     overflow: 'hidden',
-    paddingHorizontal: theme.space12,
-    paddingVertical: 10,
-  },
-  containerMedia: {
-    minHeight: 124,
+    paddingHorizontal: theme.space8,
+    paddingVertical: theme.space8,
   },
   details: {
     flex: 1,
-    gap: 6,
+    gap: theme.space2,
     justifyContent: 'flex-start',
-    minHeight: 76,
+    minHeight: 88,
     minWidth: 0,
   },
-  headerRow: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: theme.space8,
-  },
   imageContainer: {
-    position: 'relative',
-  },
-  imageMedia: {
-    height: 98,
-    width: 164,
+    borderCurve: 'continuous',
+    borderRadius: theme.borderRadius6,
+    flexShrink: 0,
+    height: 88,
+    marginRight: theme.space12,
+    overflow: 'hidden',
+    width: 132,
   },
   imageSkeleton: {
     borderCurve: 'continuous',
@@ -90,33 +109,76 @@ const styles = StyleSheet.create({
     height: 88,
     width: 132,
   },
-  info: {
-    alignItems: 'center',
+  mediaCategorySkeleton: {
+    borderRadius: theme.borderRadius4,
+    height: 20,
+    marginTop: theme.space4,
+    width: 148,
+  },
+  mediaContainer: {
+    marginHorizontal: theme.space16,
+    marginVertical: theme.space12,
+  },
+  mediaDetailsRow: {
     flexDirection: 'row',
-    gap: theme.space8,
+    gap: theme.space12,
+    marginTop: theme.space12,
+  },
+  mediaImageSkeleton: {
+    aspectRatio: 16 / 9,
+    borderCurve: 'continuous',
+    borderRadius: theme.borderRadius8,
+    width: '100%',
+  },
+  mediaTextColumn: {
+    flex: 1,
+    gap: 2,
+    minWidth: 0,
+  },
+  mediaTitleSecondLineSkeleton: {
+    borderRadius: theme.borderRadius4,
+    height: 23,
+    width: '64%',
+  },
+  mediaTitleSkeleton: {
+    borderRadius: theme.borderRadius4,
+    height: 23,
+    width: '100%',
+  },
+  mediaUsernameSkeleton: {
+    borderRadius: theme.borderRadius4,
+    height: 21,
+    width: 128,
   },
   metaDividerSkeleton: {
     borderRadius: theme.borderRadius999,
     height: 10,
     width: 10,
   },
-  metadata: {
-    marginVertical: theme.space8,
-  },
   metaTextSkeleton: {
+    borderRadius: theme.borderRadius4,
     height: 12,
     width: 48,
   },
   metaWideSkeleton: {
+    borderRadius: theme.borderRadius4,
     height: 12,
     width: 96,
   },
+  metadataRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 6,
+    marginTop: theme.space8,
+  },
   titleSkeleton: {
-    height: 18,
+    borderRadius: theme.borderRadius4,
+    height: 23,
     width: '72%',
   },
   usernameSkeleton: {
-    height: 14,
+    borderRadius: theme.borderRadius4,
+    height: 24,
     width: 74,
   },
 });

--- a/src/components/LoadingState/LoadingState.tsx
+++ b/src/components/LoadingState/LoadingState.tsx
@@ -9,6 +9,7 @@ import {
   cancelAnimation,
   Easing,
   useDerivedValue,
+  useReducedMotion,
   useSharedValue,
   withRepeat,
   withTiming,
@@ -30,6 +31,7 @@ const SPINNER_SIZES: Record<'small' | 'large', number> = {
 };
 const STROKE_WIDTH = 3;
 const ROTATION_DURATION_MS = 900;
+const PULSE_DURATION_MS = 750;
 const ARC_SWEEP_DEGREES = 270;
 
 export function LoadingState({
@@ -50,13 +52,37 @@ export function LoadingState({
 
 function Spinner({ size }: { size: number }) {
   const focused = useScreenFocused();
+  const reduceMotion = useReducedMotion();
   const rotation = useSharedValue(0);
+  const opacity = useSharedValue(1);
 
   useEffect(() => {
     if (!focused) {
       cancelAnimation(rotation);
+      cancelAnimation(opacity);
       return;
     }
+
+    /**
+     * A continuous rotation is exactly the vestibular trigger the preference
+     * exists to suppress, so under reduced motion the arc holds still and
+     * pulses instead - the sanctioned opacity substitute keeps the "still
+     * working" signal a frozen spinner would lose.
+     */
+    if (reduceMotion) {
+      opacity.set(
+        withRepeat(
+          withTiming(0.3, {
+            duration: PULSE_DURATION_MS,
+            easing: Easing.inOut(Easing.ease),
+          }),
+          -1,
+          true,
+        ),
+      );
+      return () => cancelAnimation(opacity);
+    }
+
     rotation.set(
       withRepeat(
         withTiming(2 * Math.PI, {
@@ -67,9 +93,10 @@ function Spinner({ size }: { size: number }) {
       ),
     );
     return () => cancelAnimation(rotation);
-  }, [focused, rotation]);
+  }, [focused, opacity, reduceMotion, rotation]);
 
   const transform = useDerivedValue(() => [{ rotate: rotation.get() }]);
+  const arcOpacity = useDerivedValue(() => opacity.get());
 
   const arc = useMemo(() => {
     const inset = STROKE_WIDTH / 2;
@@ -90,6 +117,7 @@ function Spinner({ size }: { size: number }) {
         strokeWidth={STROKE_WIDTH}
         strokeCap='round'
         color={theme.color.text.dark}
+        opacity={arcOpacity}
         transform={transform}
         origin={{ x: size / 2, y: size / 2 }}
       />

--- a/src/components/OfflineBanner/OfflineBanner.tsx
+++ b/src/components/OfflineBanner/OfflineBanner.tsx
@@ -1,9 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Animated, {
   useAnimatedStyle,
+  useReducedMotion,
   useSharedValue,
   withSpring,
+  withTiming,
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -17,24 +19,38 @@ const HIDDEN_OFFSET = 80;
 
 export function OfflineBanner() {
   const insets = useSafeAreaInsets();
-  const online = onlineManager.isOnline();
+  const reduceMotion = useReducedMotion();
+  const [online, setOnline] = useState(() => onlineManager.isOnline());
   const progress = useSharedValue(online ? 0 : 1);
 
   useEffect(() => {
     return onlineManager.subscribe(isOnline => {
-      progress.set(withSpring(isOnline ? 0 : 1, motion.spring.gentle));
+      setOnline(isOnline);
+      progress.set(
+        reduceMotion
+          ? withTiming(isOnline ? 0 : 1, { duration: motion.fast })
+          : withSpring(isOnline ? 0 : 1, motion.spring.gentle),
+      );
     });
-  }, [progress]);
+  }, [progress, reduceMotion]);
 
   const animatedStyle = useAnimatedStyle(() => ({
     opacity: progress.get(),
-    transform: [
-      { translateY: (progress.get() - 1) * (insets.top + HIDDEN_OFFSET) },
-    ],
+    transform: reduceMotion
+      ? []
+      : [{ translateY: (progress.get() - 1) * (insets.top + HIDDEN_OFFSET) }],
   }));
 
+  /**
+   * `opacity: 0` does not take a node out of the native accessibility tree the
+   * way `display: none` does on the web, so without these flags VoiceOver reads
+   * "No internet connection" on every screen while the device is online.
+   */
   return (
     <Animated.View
+      accessibilityElementsHidden={online}
+      accessibilityLiveRegion='polite'
+      importantForAccessibility={online ? 'no-hide-descendants' : 'yes'}
       pointerEvents='none'
       style={[
         styles.wrapper,
@@ -67,7 +83,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingHorizontal: theme.space16,
     paddingVertical: theme.space8,
-    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.25)',
+    boxShadow: theme.shadow.md.dark,
   },
   text: {
     color: theme.colorBlack,

--- a/src/components/PressableArea/PressableArea.tsx
+++ b/src/components/PressableArea/PressableArea.tsx
@@ -1,4 +1,11 @@
-import { PropsWithChildren, type Ref, useState } from 'react';
+import {
+  createContext,
+  PropsWithChildren,
+  type Ref,
+  use,
+  useCallback,
+  useState,
+} from 'react';
 import { StyleSheet, View } from 'react-native';
 import { EaseView } from 'react-native-ease';
 import type { PressableProps } from 'react-native-gesture-handler';
@@ -7,6 +14,15 @@ import { Pressable } from 'react-native-gesture-handler';
 import { motion } from '@app/styles/motion';
 
 const isAndroid = process.env.EXPO_OS === 'android';
+
+/**
+ * Nested pressables both begin on the same touch-down, so without this an
+ * inner target dims itself while the row it sits in dims too. A descendant
+ * claims the touch and every ancestor stands down.
+ */
+const NestedPressContext = createContext<
+  ((pressed: boolean) => void) | undefined
+>(undefined);
 
 /**
  * `feedback='highlight'` fills the row background while pressed instead of
@@ -25,8 +41,19 @@ export function PressableArea({
   ref?: Ref<View>;
   feedback?: 'dim' | 'highlight';
 }) {
+  const notifyAncestor = use(NestedPressContext);
   const [pressed, setPressed] = useState(false);
-  const iosPressed = pressed && !isAndroid;
+  const [descendantPressed, setDescendantPressed] = useState(false);
+
+  const handleDescendantPress = useCallback(
+    (isPressed: boolean) => {
+      setDescendantPressed(isPressed);
+      notifyAncestor?.(isPressed);
+    },
+    [notifyAncestor],
+  );
+
+  const iosPressed = pressed && !descendantPressed && !isAndroid;
 
   return (
     <Pressable
@@ -40,10 +67,12 @@ export function PressableArea({
       style={style}
       onPressIn={e => {
         setPressed(true);
+        notifyAncestor?.(true);
         onPressIn?.(e);
       }}
       onPressOut={e => {
         setPressed(false);
+        notifyAncestor?.(false);
         onPressOut?.(e);
       }}
     >
@@ -60,7 +89,9 @@ export function PressableArea({
         transition={{ type: 'timing', duration: motion.instant }}
         style={styles.pressable}
       >
-        {children}
+        <NestedPressContext.Provider value={handleDescendantPress}>
+          {children}
+        </NestedPressContext.Provider>
       </EaseView>
     </Pressable>
   );

--- a/src/components/ScreenHeader/ScreenHeader.tsx
+++ b/src/components/ScreenHeader/ScreenHeader.tsx
@@ -347,7 +347,7 @@ const styles = StyleSheet.create({
     borderRadius: theme.borderRadius20,
     borderWidth: 1,
     height: 134,
-    boxShadow: '0 4px 18px rgba(0, 0, 0, 0.4)',
+    boxShadow: theme.shadow.md.dark,
     width: 100,
   },
   heroBackground: {

--- a/src/components/StreamListLayoutToggle/StreamListLayoutMenu.ios.tsx
+++ b/src/components/StreamListLayoutToggle/StreamListLayoutMenu.ios.tsx
@@ -1,5 +1,5 @@
 import { Host, Image, Menu, Picker, Text } from '@expo/ui/swift-ui';
-import { tag, tint } from '@expo/ui/swift-ui/modifiers';
+import { accessibilityLabel, tag, tint } from '@expo/ui/swift-ui/modifiers';
 
 import { selection } from '@app/lib/haptics';
 import {
@@ -20,7 +20,10 @@ export function StreamListLayoutMenu() {
             systemName={
               streamListLayout === 'compact' ? 'list.bullet' : 'square.grid.2x2'
             }
-            modifiers={[tint(theme.color.text.dark)]}
+            modifiers={[
+              tint(theme.color.text.dark),
+              accessibilityLabel('Change stream layout'),
+            ]}
           />
         }
       >

--- a/src/components/StreamPlayer/ControlsOverlay.tsx
+++ b/src/components/StreamPlayer/ControlsOverlay.tsx
@@ -416,7 +416,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     height: 44,
     justifyContent: 'center',
-    boxShadow: '0 8px 18px rgba(0, 0, 0, 0.28)',
+    boxShadow: theme.shadow.md.dark,
     width: 44,
   },
   liquidGlassButton: {
@@ -487,7 +487,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     height: 96,
     justifyContent: 'center',
-    boxShadow: '0 18px 30px rgba(0, 0, 0, 0.42)',
+    boxShadow: theme.shadow.lg.dark,
     width: 96,
   },
   playPauseButtonPortrait: {

--- a/src/components/ui/EmptyState/EmptyState.tsx
+++ b/src/components/ui/EmptyState/EmptyState.tsx
@@ -250,6 +250,7 @@ const styles = {
     flex: 1,
   },
   image: {
+    borderCurve: 'continuous',
     borderRadius: theme.borderRadius20,
     height: 112,
     width: 112,

--- a/src/components/ui/Skeleton/Skeleton.tsx
+++ b/src/components/ui/Skeleton/Skeleton.tsx
@@ -10,6 +10,7 @@ import Animated, {
   cancelAnimation,
   Easing,
   useAnimatedStyle,
+  useReducedMotion,
   useSharedValue,
   withRepeat,
   withTiming,
@@ -33,6 +34,7 @@ const SHIMMER_DURATION_MS = 1450;
 
 export function Skeleton({ shimmer = true, style, testID }: SkeletonProps) {
   const [width, setWidth] = useState(0);
+  const reduceMotion = useReducedMotion();
 
   return (
     <View
@@ -40,7 +42,9 @@ export function Skeleton({ shimmer = true, style, testID }: SkeletonProps) {
       testID={testID}
       onLayout={(e: LayoutChangeEvent) => setWidth(e.nativeEvent.layout.width)}
     >
-      {shimmer ? <SkeletonShimmer containerWidth={width} /> : null}
+      {shimmer && !reduceMotion ? (
+        <SkeletonShimmer containerWidth={width} />
+      ) : null}
     </View>
   );
 }

--- a/src/screens/CategoryScreen.tsx
+++ b/src/screens/CategoryScreen.tsx
@@ -128,8 +128,8 @@ export const CategoryScreen: FC<CategoryScreenProps> = ({ id }) => {
   if (isCategoryError || isErrorStreams) {
     return (
       <EmptyState
-        content='Failed to fetch categories'
-        heading='No Categories'
+        content='Check your connection and try again.'
+        heading='Unable to load this category'
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         buttonOnPress={() => refetch()}
       />
@@ -141,7 +141,13 @@ export const CategoryScreen: FC<CategoryScreenProps> = ({ id }) => {
   }
 
   if (allStreams.length === 0 || !category) {
-    return <EmptyState content='No Top Streams found' />;
+    return (
+      <EmptyState
+        heading='No live streams'
+        content='Nothing is live in this category right now.'
+        button={null}
+      />
+    );
   }
 
   return (

--- a/src/screens/FollowingScreen.tsx
+++ b/src/screens/FollowingScreen.tsx
@@ -38,7 +38,11 @@ function FollowingSkeleton({
   streamListLayout: 'compact' | 'media';
 }) {
   return (
-    <View style={styles.container}>
+    <View
+      accessibilityLabel='Loading streams'
+      accessibilityRole='progressbar'
+      style={styles.container}
+    >
       {showHeader && (
         <View style={styles.header}>
           <View style={styles.headerEyebrow} />

--- a/src/screens/Preferences/ChatPreferencesPreview.tsx
+++ b/src/screens/Preferences/ChatPreferencesPreview.tsx
@@ -640,7 +640,7 @@ const styles = StyleSheet.create({
     backgroundColor: theme.colorBlackOverlay,
     borderCurve: 'continuous',
     borderRadius: theme.borderRadius28,
-    boxShadow: '0 2px 3.84px rgba(0, 0, 0, 0.25)',
+    boxShadow: theme.shadow.sm.dark,
     flexDirection: 'row',
     paddingHorizontal: theme.space20,
     paddingVertical: theme.space12,

--- a/src/screens/Top/TopCategoriesScreen.tsx
+++ b/src/screens/Top/TopCategoriesScreen.tsx
@@ -90,8 +90,8 @@ export function TopCategoriesScreen() {
     return (
       <View style={styles.wrapper}>
         <EmptyState
-          heading='Failed to fetch categories'
-          content='Failed to fetch top categories'
+          heading='Unable to load categories'
+          content='Check your connection and try again.'
         />
       </View>
     );
@@ -101,7 +101,8 @@ export function TopCategoriesScreen() {
     return (
       <View style={styles.wrapper}>
         <EmptyState
-          content='No categories found'
+          heading='No categories'
+          content='Nothing to browse right now. Refresh to check again.'
           buttonOnPress={() => void onRefresh()}
         />
       </View>

--- a/src/screens/Top/TopStreamsScreen.tsx
+++ b/src/screens/Top/TopStreamsScreen.tsx
@@ -71,6 +71,8 @@ export function TopStreamsScreen() {
   if (showSkeleton) {
     return (
       <ScrollView
+        accessibilityLabel='Loading streams'
+        accessibilityRole='progressbar'
         contentInsetAdjustmentBehavior='automatic'
         scrollEnabled={false}
         style={styles.container}
@@ -88,7 +90,11 @@ export function TopStreamsScreen() {
     return (
       <View style={styles.container}>
         {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
-        <EmptyState content='No Top Streams found' buttonOnPress={onRefresh} />
+        <EmptyState
+          heading='No live streams'
+          content='Nothing is live right now. Refresh to check again.'
+          buttonOnPress={onRefresh}
+        />
       </View>
     );
   }

--- a/src/screens/Top/__tests__/TopCategoriesScreen.test.tsx
+++ b/src/screens/Top/__tests__/TopCategoriesScreen.test.tsx
@@ -45,7 +45,7 @@ describe('TopCategoriesScreen', () => {
     render(<TopCategoriesScreen />);
 
     expect(
-      await screen.findByText('Failed to fetch top categories'),
+      await screen.findByText('Check your connection and try again.'),
     ).toBeOnTheScreen();
   });
 
@@ -54,7 +54,11 @@ describe('TopCategoriesScreen', () => {
 
     render(<TopCategoriesScreen />);
 
-    expect(await screen.findByText('No categories found')).toBeOnTheScreen();
+    expect(
+      await screen.findByText(
+        'Nothing to browse right now. Refresh to check again.',
+      ),
+    ).toBeOnTheScreen();
   });
 
   test('renders multiple categories', async () => {

--- a/src/screens/Top/__tests__/TopStreamsScreen.test.tsx
+++ b/src/screens/Top/__tests__/TopStreamsScreen.test.tsx
@@ -41,7 +41,11 @@ describe('TopStreamsScreen', () => {
 
     render(<TopStreamsScreen />);
 
-    expect(screen.getAllByTestId('stream-skeleton').length).toBeGreaterThan(0);
+    expect(screen.getByLabelText('Loading streams')).toBeOnTheScreen();
+    expect(
+      screen.getAllByTestId('stream-skeleton', { includeHiddenElements: true })
+        .length,
+    ).toBeGreaterThan(0);
   });
 
   test('renders stream list when data is available', async () => {
@@ -57,7 +61,11 @@ describe('TopStreamsScreen', () => {
 
     render(<TopStreamsScreen />);
 
-    expect(await screen.findByText('No Top Streams found')).toBeOnTheScreen();
+    expect(
+      await screen.findByText(
+        'Nothing is live right now. Refresh to check again.',
+      ),
+    ).toBeOnTheScreen();
   });
 
   test('shows empty state when the fetch fails', async () => {
@@ -65,7 +73,11 @@ describe('TopStreamsScreen', () => {
 
     render(<TopStreamsScreen />);
 
-    expect(await screen.findByText('No Top Streams found')).toBeOnTheScreen();
+    expect(
+      await screen.findByText(
+        'Nothing is live right now. Refresh to check again.',
+      ),
+    ).toBeOnTheScreen();
   });
 
   test('renders multiple streams', async () => {

--- a/src/screens/__tests__/CategoryScreen.test.tsx
+++ b/src/screens/__tests__/CategoryScreen.test.tsx
@@ -57,7 +57,7 @@ describe('CategoryScreen', () => {
     render(<CategoryScreen id='cat1' />);
 
     expect(
-      await screen.findByText('Failed to fetch categories'),
+      await screen.findByText('Check your connection and try again.'),
     ).toBeOnTheScreen();
   });
 
@@ -70,7 +70,7 @@ describe('CategoryScreen', () => {
     render(<CategoryScreen id='cat1' />);
 
     expect(
-      await screen.findByText('Failed to fetch categories'),
+      await screen.findByText('Check your connection and try again.'),
     ).toBeOnTheScreen();
   });
 
@@ -93,6 +93,8 @@ describe('CategoryScreen', () => {
 
     render(<CategoryScreen id='cat1' />);
 
-    expect(await screen.findByText('No Top Streams found')).toBeOnTheScreen();
+    expect(
+      await screen.findByText('Nothing is live in this category right now.'),
+    ).toBeOnTheScreen();
   });
 });

--- a/src/screens/__tests__/FollowingScreen.test.tsx
+++ b/src/screens/__tests__/FollowingScreen.test.tsx
@@ -101,7 +101,11 @@ describe('FollowingScreen', () => {
 
     renderFollowingScreen({ loggedIn: true });
 
-    expect(screen.getAllByTestId('stream-skeleton').length).toBeGreaterThan(0);
+    expect(screen.getByLabelText('Loading streams')).toBeOnTheScreen();
+    expect(
+      screen.getAllByTestId('stream-skeleton', { includeHiddenElements: true })
+        .length,
+    ).toBeGreaterThan(0);
   });
 
   test('renders followed streams for authenticated user', async () => {

--- a/src/styles/motion.ts
+++ b/src/styles/motion.ts
@@ -21,5 +21,5 @@ export const motion = {
     gentle: { damping: 22, stiffness: 240, mass: 0.55 },
   },
 
-  pressMinScale: 0.97,
+  pressMinScale: 0.96,
 } as const;

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -281,6 +281,7 @@ jest.mock('react-native-reanimated', () => {
     runOnUI: (fn: (...args: unknown[]) => unknown) => fn,
     useAnimatedReaction: jest.fn(),
     useAnimatedRef: () => ({ current: null }),
+    useReducedMotion: () => false,
     useFrameCallback: jest.fn(() => ({ setActive: jest.fn() })),
     useAnimatedStyle: (updater: () => unknown) => updater(),
     useDerivedValue: (updater: () => unknown) => {


### PR DESCRIPTION
Ran a UI-polish pass and then a full six-domain interface review over the shared component layer and the feed entry flow (launch -> Top/Following -> card). Player and chat are out of scope.

## Accessibility

Nothing in the app checked the reduced-motion preference. Gated the transform-driven motion on `useReducedMotion`: the skeleton drops its shimmer sweep, the spinner swaps its continuous rotation for an opacity pulse, the orb freezes its shader, the offline banner fades without the slide. `ChatImageShimmer` already pulses opacity only, and Reanimated defaults layout animations to `ReduceMotion.System`, so neither needed touching.

`opacity: 0` does not take a node out of the native accessibility tree the way `display: none` does on the web, so VoiceOver read "No internet connection" on every screen regardless of connectivity, and never announced actually going offline. The banner now tracks `online` in state so `accessibilityElementsHidden` can flip with it, plus a polite live region.

RNGH's `Pressable` renders `accessible: accessible !== false`, so the card root is one accessibility element and the nested profile/category pressables were merged into it and unreachable. Both are now exposed as `accessibilityActions`.

Loading skeletons are hidden from the tree and their containers announce as a `progressbar` instead of rendering silence. The iOS layout menu had no accessible name while the fallback path already had one, so the two platforms announced different things.

## Press feedback

`PressablesConfig` only passed `config`, so every button in the app ran on pressto's `DefaultAnimationConfigs.timing` default: 250ms on an ease-in-out ramp, which reads as lag on touch-down. Now `motion.instant` with ease-out. `pressMinScale` 0.97 -> 0.96.

Nested pressables both begin on the same touch-down, so an inner target dimmed itself while the row it sits in dimmed too. `PressableArea` now suppresses ancestor feedback when a descendant claims the touch, and the card uses it so it can participate.

## Feed card

The media-layout skeleton was the compact layout with a bigger image, so the list reflowed by over 100pt per row when data landed. It now mirrors the real media card, and the compact one matches the card's insets exactly.

Radius 10 -> 14 to sit concentric with the 6-radius thumbnail at 8pt padding. The username's hit slop reached 6pt into the title, so the top of the title opened the profile; per-edge slop that stops at the gap. Four rows sat at a uniform 2px gap, stepped up so they read as three groups. 16px titles wrapping to two lines were at 1.19 leading, now 1.44. Tabular figures on the values that change while mounted. The metadata divider double-dimmed an already-low token down to 2.71:1.

## Elsewhere

`theme.shadow` had zero call sites while eight surfaces hand-rolled their own single-layer shadow. Consolidated. Left the two purple glows in `AuthSheetScreen` alone, they are brand, not elevation.

`Image` transition default 500ms -> 150ms, in band with every deliberate call site. `IconButton`'s loading spinner changed tint and footprint mid-swap. Empty and error copy across five call sites: no more "Failed to fetch" or "Authentication state is not ready", sentence case, a recovery step, modelled on the ones `FollowingScreen` already got right.

## Deliberately not done

The card dims rather than scales on press now. Restoring scale means going back to pressto, which drives its animation inside `BaseButton.onBegan` and cannot participate in the nested-press suppression, so it would bring the double-feedback back. Say the word if you would rather have the scale.

Leading was raised only on the two wrapping title styles. The single-line labels do not wrap, so the 1.4 floor does not apply, and removing every `lineHeight` override would have grown each row by about a third for no reason.

Radii deliberately stay raw literals rather than going through `spaceScale()`.

## Testing

`bun run ci:local` green across all eleven jobs. Six assertions updated for the new copy and for the skeletons now being accessibility-hidden (testing-library excludes hidden elements by default), and `useReducedMotion` added to the Reanimated mock.

Not verified: none of this has been on a device. The VoiceOver behaviour, the SwiftUI menu label and the new feed density all want a real screen.
