### PR TITLE
fix(player): stop the live-sync seek freezing video on android

### DIFF
--- a/src/components/StreamPlayer/twitchPlayerSource/__tests__/buildTwitchLiveSyncScript.test.ts
+++ b/src/components/StreamPlayer/twitchPlayerSource/__tests__/buildTwitchLiveSyncScript.test.ts
@@ -1,15 +1,63 @@
+import { createContext, runInContext } from 'node:vm';
+
 import { buildTwitchLiveSyncScript } from '../buildTwitchLiveSyncScript';
 
+interface FakeTimeRanges {
+  length: number;
+  end: (index: number) => number;
+}
+
+interface FakeVideo {
+  buffered: FakeTimeRanges;
+  currentTime: number;
+  seekable: FakeTimeRanges;
+}
+
+function timeRanges(...ends: number[]): FakeTimeRanges {
+  return { length: ends.length, end: index => ends[index] ?? NaN };
+}
+
+function makeVideo(video: Partial<FakeVideo>): FakeVideo {
+  return {
+    buffered: timeRanges(),
+    currentTime: 0,
+    seekable: timeRanges(),
+    ...video,
+  };
+}
+
+/**
+ * Runs the built script against a stub page so the seek target is asserted as
+ * behaviour rather than as source text.
+ */
+function installLiveSync(video: FakeVideo): () => boolean {
+  const window: {
+    ReactNativeWebView: { postMessage: () => void };
+    __foamSyncToLive?: () => boolean;
+  } = {
+    ReactNativeWebView: { postMessage: () => undefined },
+  };
+  const document = {
+    querySelector: (selector: string) => (selector === 'video' ? video : null),
+  };
+
+  runInContext(
+    buildTwitchLiveSyncScript({}),
+    createContext({ document, setTimeout: () => 0, window }),
+  );
+
+  const syncToLive = window.__foamSyncToLive;
+  if (!syncToLive) {
+    throw new Error('live sync script did not install __foamSyncToLive');
+  }
+  return syncToLive;
+}
+
 describe('buildTwitchLiveSyncScript', () => {
-  test('live sync seeks to the live edge and exposes a re-trigger hook', () => {
+  test('live sync exposes a re-trigger hook and runs once rather than on an interval', () => {
     const script = buildTwitchLiveSyncScript({ targetSeconds: 3 });
 
-    // Measures client drift from the newest seekable segment.
-    expect(script).toContain('seekable.end(seekable.length - 1)');
-    expect(script).toContain('var drift = liveEdge - video.currentTime');
     expect(script).toContain('var TARGET_S = 3');
-    // Seeks to the live edge, leaving the target buffer.
-    expect(script).toContain('video.currentTime = liveEdge - TARGET_S');
     // Re-triggerable on demand from chat settings.
     expect(script).toContain('window.__foamSyncToLive = function()');
     // Runs once at start, not on a continuous interval.
@@ -17,5 +65,67 @@ describe('buildTwitchLiveSyncScript', () => {
     // Skips ads so the start-sync targets the real stream, not a pre-roll.
     expect(script).toContain('function isAdActive()');
     expect(script).toContain('skipped (ad playing)');
+  });
+
+  test('seeks to the live edge less the latency target', () => {
+    const video = makeVideo({
+      buffered: timeRanges(100),
+      currentTime: 40,
+      seekable: timeRanges(100),
+    });
+
+    expect(installLiveSync(video)()).toBe(true);
+    expect(video.currentTime).toBe(97);
+  });
+
+  test('caps the live edge at the buffered end, so an MSE sentinel cannot strand the video', () => {
+    const video = makeVideo({
+      // Android's MSE embed ends a live seekable range at 2^30.
+      seekable: timeRanges(1_073_741_824),
+      buffered: timeRanges(42),
+      currentTime: 10,
+    });
+
+    expect(installLiveSync(video)()).toBe(true);
+    expect(video.currentTime).toBe(39);
+  });
+
+  test('does not seek when only the sentinel seekable range is known', () => {
+    const video = makeVideo({
+      seekable: timeRanges(1_073_741_824),
+      currentTime: 10,
+    });
+
+    expect(installLiveSync(video)()).toBe(false);
+    expect(video.currentTime).toBe(10);
+  });
+
+  test('does not seek when already inside the latency target', () => {
+    const video = makeVideo({
+      buffered: timeRanges(100),
+      currentTime: 98,
+      seekable: timeRanges(100),
+    });
+
+    expect(installLiveSync(video)()).toBe(false);
+    expect(video.currentTime).toBe(98);
+  });
+
+  test('does not seek backwards when the buffered end trails the playhead', () => {
+    const video = makeVideo({
+      buffered: timeRanges(50),
+      currentTime: 80,
+      seekable: timeRanges(1_073_741_824),
+    });
+
+    expect(installLiveSync(video)()).toBe(false);
+    expect(video.currentTime).toBe(80);
+  });
+
+  test('does not seek with nothing buffered or seekable', () => {
+    const video = makeVideo({ currentTime: 12 });
+
+    expect(installLiveSync(video)()).toBe(false);
+    expect(video.currentTime).toBe(12);
   });
 });

--- a/src/components/StreamPlayer/twitchPlayerSource/buildTwitchLiveSyncScript.ts
+++ b/src/components/StreamPlayer/twitchPlayerSource/buildTwitchLiveSyncScript.ts
@@ -30,6 +30,21 @@ export function buildTwitchLiveSyncScript(options: {
     );
   }
 
+  // Android plays the embed through MSE, where a live seekable range ends at a
+  // 2^30 sentinel rather than the live edge. Only the buffered range names a
+  // position the element can actually play, so it caps the seek.
+  function getLiveEdge(video) {
+    var buffered = video.buffered;
+    if (!buffered || buffered.length === 0) {
+      return NaN;
+    }
+    var seekable = video.seekable;
+    var seekableEnd = seekable && seekable.length > 0
+      ? seekable.end(seekable.length - 1)
+      : Infinity;
+    return Math.min(seekableEnd, buffered.end(buffered.length - 1));
+  }
+
   // Seek to the live edge once; no-op if within target or during an ad.
   window.__foamSyncToLive = function() {
     if (isAdActive()) {
@@ -41,14 +56,13 @@ export function buildTwitchLiveSyncScript(options: {
       post('trace', { step: 'livesync', detail: 'no video element' });
       return false;
     }
-    var seekable = video.seekable;
-    if (!seekable || seekable.length === 0) {
-      // Low-latency live can expose no seekable range — can't seek.
-      post('trace', { step: 'livesync', detail: 'no seekable range' });
+
+    var liveEdge = getLiveEdge(video);
+    if (!isFinite(liveEdge)) {
+      post('trace', { step: 'livesync', detail: 'no live edge' });
       return false;
     }
 
-    var liveEdge = seekable.end(seekable.length - 1);
     var drift = liveEdge - video.currentTime;
     // Report drift: a small one means server-side latency no seek can cut.
     post('trace', {
@@ -73,7 +87,7 @@ export function buildTwitchLiveSyncScript(options: {
     attempts += 1;
     if (!isAdActive()) {
       var video = document.querySelector('video');
-      if (video && !video.paused && video.seekable && video.seekable.length > 0) {
+      if (video && !video.paused && isFinite(getLiveEdge(video))) {
         window.__foamSyncToLive();
         return;
       }


### PR DESCRIPTION
# Why

On Android the player got audio and one frame, then the picture froze for good.

The live-sync seek did it. It trims latency with
`video.currentTime = seekable.end(...) - 3`. iOS plays the embed through native
HLS, where that is the real live edge. Android plays it through MSE, where a live
seekable range ends at a 2^30 sentinel, so ~2s after playback started we seeked
the video to 1073741821s and it never came back. `isFinite()` does not catch it -
2^30 is finite.

Instrumenting the page confirmed it:

```
probe dt=1073741821.00 df=0 drop=0 paused=true ready=1
```

`currentTime` jumps by 2^30, no frames decode after, element sits paused at
`readyState=1`. Everyone gets this: `customPlayerEnabled` defaults on, so the
script is always injected on live. The "sync to live" action hit the same path.

Same symptom as #795 but a different cause - that `androidLayerType='hardware'`
fix was right and still stands.

# How

Take the live edge from `video.buffered`, the only range naming a position the
element can actually play, and cap `seekable.end()` with it. Skip the seek when
nothing is buffered.

# Test Plan

New tests run the built script in a `node:vm` sandbox against a fake video
element and assert the seek target, including the 2^30 case, rather than matching
source strings.

On an Android emulator, screenshotting every 3s and pixel-diffing the video band:

- before: `0.0000` diff on every sample across 16s, chat band still changing
- after: 24-85% of sampled pixels change on every sample across 42s, and the
  latency pill reads `3.8s` instead of `-`

`bun run ci:local` green.
