### PR TITLE
fix(app): size the auth sheet to its content and align hosted form rows

### DIFF
--- a/.github/workflows/detect-fp-changes.yml
+++ b/.github/workflows/detect-fp-changes.yml
@@ -1,15 +1,15 @@
 name: Detect fingerprint changes
 on:
-# on:
-#   pull_request:
-#     types: [opened, synchronize, reopened, ready_for_review]
-#     paths-ignore:
-#       - 'src/**'
-#       - 'e2e/**'
-#       - 'docs/**'
-#       - '**/*.md'
-#       - '.claude/**'
-#       - '.rnstorybook/**'
+  # on:
+  #   pull_request:
+  #     types: [opened, synchronize, reopened, ready_for_review]
+  #     paths-ignore:
+  #       - 'src/**'
+  #       - 'e2e/**'
+  #       - 'docs/**'
+  #       - '**/*.md'
+  #       - '.claude/**'
+  #       - '.rnstorybook/**'
   workflow_dispatch:
 
 concurrency:

--- a/app.config.ts
+++ b/app.config.ts
@@ -78,7 +78,7 @@ export const VARIANT_CONFIG: Record<Variant, AppVariantConfig> = {
 const variant =
   (process.env.EXPO_PUBLIC_APP_VARIANT as Variant) || 'development';
 
-const VERSION = '1.0.7';
+const VERSION = '1.0.8';
 
 const appConfig = VARIANT_CONFIG[variant];
 const twitchClientId = process.env.EXPO_PUBLIC_TWITCH_CLIENT_ID;

--- a/src/components/RootLayout/RootLayoutNav.tsx
+++ b/src/components/RootLayout/RootLayoutNav.tsx
@@ -1,6 +1,5 @@
 import { SystemBars } from 'react-native-edge-to-edge';
 
-import { isLiquidGlassAvailable } from 'expo-glass-effect';
 import { DarkTheme, Stack, ThemeProvider } from 'expo-router';
 
 import { ForceUpdateModal } from '@app/components/ForceUpdateModal/ForceUpdateModal';
@@ -66,12 +65,10 @@ export function RootLayoutNav() {
             options={{
               presentation: 'formSheet',
               sheetGrabberVisible: true,
-              sheetAllowedDetents: [0.85],
+              sheetAllowedDetents: 'fitToContents',
               sheetCornerRadius: theme.borderRadius28,
               contentStyle: {
-                backgroundColor: isLiquidGlassAvailable()
-                  ? theme.color.transparent.dark
-                  : theme.color.background.dark,
+                backgroundColor: theme.color.background.dark,
               },
             }}
           />

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -638,11 +638,9 @@ function useAuthContextValue({
     setState({ ready: true });
     setUser(undefined);
     twitchApi.removeAuthToken();
-    await Promise.all([
-      queryClient.invalidateQueries(),
-      queryClient.resetQueries(),
-      doAnonAuthRef.current(),
-    ]);
+    await queryClient.cancelQueries();
+    queryClient.removeQueries();
+    await doAnonAuthRef.current();
   }, [doAnonAuthRef]);
 
   const contextState: AuthContextState = useMemo(

--- a/src/context/__tests__/AuthContext.test.tsx
+++ b/src/context/__tests__/AuthContext.test.tsx
@@ -10,6 +10,7 @@ import {
 import { type AuthSessionResult, TokenResponse } from 'expo-auth-session';
 
 import { Text } from '@app/components/ui/Text/Text';
+import { queryClient } from '@app/lib/react-query/query-client';
 import { twitchApi as _twitchApi } from '@app/services/api/clients';
 import { twitchService as _twitchService } from '@app/services/twitch-service';
 import type { DefaultTokenResponse } from '@app/types/twitch/auth';
@@ -842,6 +843,38 @@ describe('AuthContext', () => {
         );
         expect(screen.getByText('Anon')).toBeOnTheScreen();
       });
+    });
+  });
+
+  describe('logout', () => {
+    test('drops the query cache instead of refetching it token-less', async () => {
+      const cancelQueries = jest.spyOn(queryClient, 'cancelQueries');
+      const removeQueries = jest.spyOn(queryClient, 'removeQueries');
+      const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+      const resetQueries = jest.spyOn(queryClient, 'resetQueries');
+
+      SecureStore.getItemAsync.mockResolvedValue(null);
+      twitchService.getDefaultToken.mockResolvedValue({
+        access_token: 'anon',
+        expires_in: 3600,
+        token_type: 'bearer',
+      });
+
+      const { result } = renderHook(() => useAuthContext(), {
+        wrapper,
+        initialProps,
+      });
+
+      await waitFor(() => expect(result.current.ready).toBe(true));
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      expect(cancelQueries).toHaveBeenCalledTimes(1);
+      expect(removeQueries).toHaveBeenCalledTimes(1);
+      expect(invalidateQueries).not.toHaveBeenCalled();
+      expect(resetQueries).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/screens/Other/AboutScreen.tsx
+++ b/src/screens/Other/AboutScreen.tsx
@@ -20,6 +20,7 @@ import {
 } from '@app/components/SettingsSection/SettingsSection';
 import { Text } from '@app/components/ui/Text/Text';
 import { useScrollToTop } from '@app/hooks/useScrollToTop';
+import { SWIFTUI_ROW_CONTENT_INSET } from '@app/styles/nativeForm';
 import { theme } from '@app/styles/themes';
 import { openLinkInBrowser } from '@app/utils/browser/openLinkInBrowser';
 
@@ -37,7 +38,7 @@ export function AboutScreen() {
         <Form>
           <Section>
             <RNHostView matchContents>
-              <View style={styles.identityRow}>
+              <View style={[styles.identityRow, styles.hostedRowInset]}>
                 <Image source={appIconProduction} style={styles.appIcon} />
                 <View style={styles.identityText}>
                   <Text type='lg' weight='bold' numberOfLines={1}>
@@ -179,6 +180,9 @@ const styles = StyleSheet.create({
   container: {
     backgroundColor: theme.color.background.dark,
     flex: 1,
+  },
+  hostedRowInset: {
+    paddingHorizontal: SWIFTUI_ROW_CONTENT_INSET,
   },
   identityRow: {
     alignItems: 'center',

--- a/src/screens/SettingsScreen/components/profile/ProfileCard.ios.tsx
+++ b/src/screens/SettingsScreen/components/profile/ProfileCard.ios.tsx
@@ -15,6 +15,7 @@ import { Image } from '@app/components/Image/Image';
 import { SymbolView } from '@app/components/ui/Icon/Icon';
 import { Text } from '@app/components/ui/Text/Text';
 import { useAuthContext } from '@app/context/AuthContext';
+import { SWIFTUI_ROW_CONTENT_INSET } from '@app/styles/nativeForm';
 import { theme } from '@app/styles/themes';
 import { openLinkInBrowser } from '@app/utils/browser/openLinkInBrowser';
 
@@ -227,9 +228,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     gap: theme.space12,
-    // RNHostView content doesn't inherit the SwiftUI row's insets; match them.
     minHeight: 52,
-    paddingHorizontal: theme.space16,
+    paddingHorizontal: SWIFTUI_ROW_CONTENT_INSET,
     paddingVertical: theme.space8,
   },
   identityText: {

--- a/src/services/api/Client.ts
+++ b/src/services/api/Client.ts
@@ -78,11 +78,17 @@ export function createApiClient({
 }: ClientOptions) {
   let authToken: string | undefined;
   let resolveTokenReady: (() => void) | undefined;
-  let tokenReady: Promise<void> | undefined = requiresAuth
-    ? new Promise<void>(resolve => {
-        resolveTokenReady = resolve;
-      })
-    : undefined;
+
+  function armTokenReady() {
+    if (!requiresAuth) {
+      return undefined;
+    }
+    return new Promise<void>(resolve => {
+      resolveTokenReady = resolve;
+    });
+  }
+
+  let tokenReady = armTokenReady();
 
   function settleTokenReady() {
     resolveTokenReady?.();
@@ -323,6 +329,7 @@ export function createApiClient({
     },
     removeAuthToken: () => {
       authToken = undefined;
+      tokenReady ??= armTokenReady();
     },
     getAuthToken: () => authToken,
   };

--- a/src/services/api/__tests__/Client.test.ts
+++ b/src/services/api/__tests__/Client.test.ts
@@ -173,6 +173,29 @@ describe('createApiClient', () => {
     expect(requestInit.headers.Authorization).toBe('Bearer anon-token');
   });
 
+  test('requiresAuth re-arms the gate after removeAuthToken', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: [] }));
+    const client = createApiClient({
+      baseURL: 'https://api.test/helix',
+      requiresAuth: true,
+    });
+    client.setAuthToken('user-token');
+    client.removeAuthToken();
+
+    const pending = client.get('/channels/followed');
+    await Promise.resolve();
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    client.setAuthToken('anon-token');
+    await expect(pending).resolves.toEqual({ data: [] });
+
+    const [, requestInit] = mockFetch.mock.calls[0] as [
+      string,
+      { headers: Record<string, string> },
+    ];
+    expect(requestInit.headers.Authorization).toBe('Bearer anon-token');
+  });
+
   test('requiresAuth does not defer when an explicit Authorization header is set', async () => {
     jest.useFakeTimers();
     mockFetch.mockResolvedValueOnce(jsonResponse({ data: [] }));

--- a/src/styles/nativeForm.ts
+++ b/src/styles/nativeForm.ts
@@ -1,0 +1,6 @@
+/**
+ * Leading/trailing inset an `@expo/ui` `Form` row gives its content: the
+ * section's margin from the screen edge plus the row's own inset. A screen-width
+ * `RNHostView` needs this much padding to line up with the native rows.
+ */
+export const SWIFTUI_ROW_CONTENT_INSET = 32;


### PR DESCRIPTION
# Why

Three things, all visible on a real device:

- The sign-in sheet drew its content at natural height inside an `0.85` detent and left the bottom third of the sheet unpainted, so the dimmed screen behind showed through it.
- The avatar on Settings > Profile (and the app icon on About) sat flush against the card edge instead of lining up with the `Channel` / `Member Since` rows below it.
- Logging out threw a 401 (`OAuth token is missing`) into Sentry - closes #873.

# How

**Sheet.** We run expo-router with `disableSynchronousScreensUpdates`, which makes react-native-screens position iOS form sheets absolutely with no `bottom`, so the RN subtree is sized to itself rather than to the detent. `fitToContents` is the detent that matches that, and it works whether or not the flag is on - so I'd rather not go near the flag, it's there for a reason. Dropped the liquid-glass `contentStyle` while I was in there: RNS moves `backgroundColor` off `contentStyle` onto the Screen, so a transparent Screen under an opaque root can only ever be the hole we were seeing.

**Rows.** `RNHostView matchContents` frames itself to the hosted view's Yoga bounds, and Yoga measures that subtree at the `Host`'s width - the full screen. So the row is wider than the SwiftUI row it sits in, centres inside it, and its content lands at screen x=0. It needs 32pt of padding (16 section margin + 16 row inset), not 16. `ChatPreferenceForm` already gets this right by passing an explicit card width, so it's untouched.

**Logout.** `logout()` called `invalidateQueries()` and `resetQueries()`, both of which refetch active queries. `setUser(undefined)` only disables the user-scoped observers on the next render, so `followedChannels` refetched in between with no token. Swapped for `cancelQueries()` + `removeQueries()`, neither of which refetches. `removeAuthToken()` now also re-arms the `requiresAuth` gate so anything firing in the logout -> anon-token window waits for the replacement instead of going out bare.

Also reformatted `detect-fp-changes.yml` - it was failing `prettier --check` on main.

# Test Plan

`bun run ci:local` green.

New tests: the client re-arms its auth gate after `removeAuthToken`, and `logout` drops the cache without invalidating or resetting.

Checked on the iPhone 17e simulator (iOS 26.5):

- `foam://auth-sheet` - sheet hugs its content, no transparent gap.
- Settings > Profile - avatar's left edge and the `Channel` label both land at 32pt; pixel-scanned the screenshot to confirm rather than eyeballing it.
- Settings > About - same for the app icon.
