### PR TITLE
chore: strip non-essential comments across src

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -18,7 +18,6 @@ interface AppVariantConfig {
 export type Variant =
   'development' | 'internal' | 'testflight' | 'e2e' | 'production';
 
-// https://docs.expo.dev/tutorial/eas/multiple-app-variants
 export const VARIANT_CONFIG = {
   development: {
     name: 'Foam (dev)',
@@ -201,15 +200,12 @@ const config: ExpoConfig = {
   userInterfaceStyle: 'dark',
   updates: {
     url: 'https://u.expo.dev/950a1e2f-6b25-4be7-adb2-3c16287a2b5e',
-    // Configure the channel to "local" for local development, if we
-    // compile/run locally EAS Build will configure this for us automatically
-    // based on the value provided in the build profile, and that will
-    // overwrite this value.
     requestHeaders: {
       'expo-channel-name': 'local',
     },
-    // Disable automatic update checks on launch to prevent blank screen issues
-    // Updates are checked manually after the app has fully loaded
+    /**
+     * Manual update checks only; auto-check on launch left a blank screen.
+     */
     checkAutomatically: 'NEVER',
     fallbackToCacheTimeout: 30000,
     disableAntiBrickingMeasures: variant !== 'production',
@@ -347,7 +343,6 @@ const config: ExpoConfig = {
       },
     ],
     '@bacons/apple-colors',
-    // '@bacons/apple-targets',
     'react-native-legal',
     'react-native-edge-to-edge',
     [
@@ -388,9 +383,6 @@ const config: ExpoConfig = {
     './src/plugins/withAndroidAccentColor.js',
     './src/plugins/withAndroidLibsActivityTheme.js',
     './plugins/with-fix-dev-launcher-cycle.js',
-    // ['./src/plugins/withAnimatedWebPSupport.js'],
-    // ['./src/plugins/withFastImageWebPSupportIOS.js'],
-    // ['./src/plugins/withFastImageWebPSupportAndroid.js'],
   ],
   experiments: {
     reactCompiler: true,
@@ -406,7 +398,6 @@ const config: ExpoConfig = {
       : undefined,
     icon: './assets/app-icon.icon',
     config: {
-      // needed for expo-secure-store
       usesNonExemptEncryption: false,
     },
     infoPlist: {

--- a/src/Providers/CachedEmotesProvider/cache-service.ts
+++ b/src/Providers/CachedEmotesProvider/cache-service.ts
@@ -557,7 +557,6 @@ function handleAppStateForMemory(nextAppState: AppStateStatus): void {
     startMemoryMonitor();
     return;
   }
-  // background/inactive: shed the unpinned set and stop the background timer.
   stopMemoryMonitor();
   if (nextAppState === 'background') {
     trimDecodedEmotes('reclaim');
@@ -598,9 +597,6 @@ export function getCachedEmoteStats(): CachedEmoteStats {
   return { decoded: refs.size, inflight: inflight.size, pinned: pinned.size };
 }
 
-/**
- * Estimated resident decoded-bitmap bytes, for the chat-perf harness.
- */
 export function getCachedEmoteByteEstimate(): number {
   return totalBytes;
 }

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -15,7 +15,6 @@ export default function IndexRoute() {
   const { authState, ready } = useAuthContext();
   const hasSeenOnboarding = storage.getBoolean(ONBOARDING_SEEN_KEY);
 
-  // E2E builds wipe app data every launch; onboarding would gate every test behind the intro screen.
   if (!hasSeenOnboarding && !isE2EMode) {
     return <Redirect href='/onboarding' />;
   }

--- a/src/components/Chat/components/EmoteSheet/EmoteSheet.tsx
+++ b/src/components/Chat/components/EmoteSheet/EmoteSheet.tsx
@@ -164,7 +164,7 @@ export function EmoteSheet({
                   drawDistance={emoteRowSize * 3}
                   showsVerticalScrollIndicator
                   nestedScrollEnabled
-                  indicatorStyle='white' // todo - once we have light theme, adjust this
+                  indicatorStyle='white'
                   style={styles.list}
                 />
               )}

--- a/src/components/Chat/hooks/useChatImageUpload.ts
+++ b/src/components/Chat/hooks/useChatImageUpload.ts
@@ -6,10 +6,6 @@ import { toast } from 'sonner-native';
 import { kappaService } from '@app/services/kappa-service';
 import { logger } from '@app/utils/logger';
 
-/**
- * Picks a library image, uploads it to kappa.lol, and hands the public URL
- * back for the chat composer.
- */
 export function useChatImageUpload(onUploaded: (url: string) => void) {
   const [isUploading, setIsUploading] = useState(false);
 

--- a/src/components/Chat/hooks/useChatScroll.ts
+++ b/src/components/Chat/hooks/useChatScroll.ts
@@ -34,10 +34,6 @@ interface UseChatScrollOptions {
   getMessagesLength: () => number;
 }
 
-/**
- * Stable scroll-position readers for the ingest and message-processing paths,
- * threaded through the chat hook bags as one value instead of four.
- */
 export interface ChatScrollAnchor {
   isAtBottomRef: MutableRefObject<boolean>;
   isScrollingToBottomRef: MutableRefObject<boolean>;

--- a/src/components/Chat/hooks/useChatScrollActive.ts
+++ b/src/components/Chat/hooks/useChatScrollActive.ts
@@ -2,10 +2,6 @@ import { useSyncExternalStore } from 'react';
 
 import { chatScrollActivity } from '@app/components/Chat/util/chatScrollActivity';
 
-/**
- * Subscribes to the global chat scroll-activity signal (fling start, ~150ms
- * settle window), used to shed expensive render work during scroll.
- */
 export function useChatScrollActive(): boolean {
   return useSyncExternalStore(
     chatScrollActivity.subscribe,

--- a/src/components/Chat/hooks/useEnsureSevenTvCosmetics.ts
+++ b/src/components/Chat/hooks/useEnsureSevenTvCosmetics.ts
@@ -8,10 +8,6 @@ import {
 } from '@app/store/chat/actions/cosmetics';
 import { logger } from '@app/utils/logger';
 
-/**
- * Resolves and caches a user's 7TV cosmetics when unknown; the observable
- * store re-renders consumers once data lands.
- */
 export function useEnsureSevenTvCosmetics(twitchUserId?: string) {
   useEffect(() => {
     if (!twitchUserId) {

--- a/src/components/Chat/util/messageBuffer.ts
+++ b/src/components/Chat/util/messageBuffer.ts
@@ -37,10 +37,6 @@ export interface MessageBuffer {
   moderateByLogin(login: string, moderationNotice: string): void;
 }
 
-/**
- * Live-chat ingest buffer: dedup-by-key list with an O(1) index and an
- * oldest-drop cap. Owns only data - the hook drives flush timing and publishing.
- */
 export const createMessageBuffer = (
   getMaxBufferedMessages: () => number = getMaxChatMessages,
 ): MessageBuffer => {

--- a/src/components/Chat/util/modCommands/executeModCommand.ts
+++ b/src/components/Chat/util/modCommands/executeModCommand.ts
@@ -16,10 +16,6 @@ async function resolveUserId(login: string): Promise<string> {
   return userId;
 }
 
-/**
- * Runs a parsed moderation command against Helix and resolves with the success
- * toast text; a Helix 403 here simply means the sender is not a moderator.
- */
 export async function executeModCommand(
   command: ModCommand,
   context: ModCommandContext,

--- a/src/components/Chat/util/modCommands/runModCommand.ts
+++ b/src/components/Chat/util/modCommands/runModCommand.ts
@@ -6,10 +6,6 @@ import { logger } from '@app/utils/logger';
 import { executeModCommand } from './executeModCommand';
 import type { ModCommand } from './parseModCommand';
 
-/**
- * Fire-and-forget wrapper: runs a parsed moderation command against Helix and
- * shows the outcome as a success/failure toast.
- */
 export function runModCommand(
   command: ModCommand,
   channelId: string,

--- a/src/components/Chat/util/roomState/ROOM_STATE_MODES.ts
+++ b/src/components/Chat/util/roomState/ROOM_STATE_MODES.ts
@@ -1,9 +1,5 @@
 import type { RoomStateModeDefinition } from '@app/components/Chat/util/roomState/types';
 
-/**
- * Single source of truth for the chat modes a room state activates; table
- * order is the notice order, and adding a mode is one new entry here.
- */
 export const ROOM_STATE_MODES = {
   emote: {
     getStatus: state => ({ active: state.emoteOnly }),

--- a/src/components/Chat/util/slashCommandDefinitions/isRefreshCommand.ts
+++ b/src/components/Chat/util/slashCommandDefinitions/isRefreshCommand.ts
@@ -1,9 +1,5 @@
 import { REFRESH_COMMAND } from '@app/components/Chat/util/slashCommandDefinitions/REFRESH_COMMAND';
 
-/**
- * Matches `/refresh` on the first token so trailing text is tolerated,
- * mirroring `parseModCommand`'s argument-less commands.
- */
 export function isRefreshCommand(input: string): boolean {
   const [firstToken = ''] = input.trim().toLowerCase().split(/\s+/);
   return firstToken === REFRESH_COMMAND;

--- a/src/components/EnergyOrb/conf.ts
+++ b/src/components/EnergyOrb/conf.ts
@@ -50,7 +50,6 @@ const NAMED_COLORS: NamedColorTable = {
   pink: [1, 0.75, 0.8],
 };
 
-// Sky-blue accent family, matching the app theme.
 const DEFAULT_COLORS = [
   theme.color.accent.light,
   theme.color.accent.dark,

--- a/src/components/ShakeToReport/ShakeToReport.tsx
+++ b/src/components/ShakeToReport/ShakeToReport.tsx
@@ -10,10 +10,6 @@ const SHAKE_COOLDOWN_MS = 30_000;
 // Detox shakes the simulator during scroll synthesis; keep e2e inert.
 const isE2E = process.env.EXPO_PUBLIC_APP_VARIANT === 'e2e';
 
-/**
- * Opens the feedback screen on device shake; toggled via the shakeToReport
- * preference.
- */
 export function ShakeToReport() {
   const shakeToReport = usePreference('shakeToReport');
   const lastTriggeredAtRef = useRef(0);

--- a/src/components/StreamPlayer/stabilityRecovery.ts
+++ b/src/components/StreamPlayer/stabilityRecovery.ts
@@ -13,10 +13,6 @@ interface StabilityRecoveryOptions {
   onRefresh: (reason: StabilityRefreshReason, attempt: number) => void;
 }
 
-/**
- * Decides when playback trouble should force a WebView refresh and when to
- * give up; refreshes are capped per rolling window.
- */
 export function createStabilityRecovery({
   now = Date.now,
   onGiveUp,

--- a/src/components/ui/Skeleton/shimmerGradient.ts
+++ b/src/components/ui/Skeleton/shimmerGradient.ts
@@ -1,7 +1,3 @@
-/**
- * Shared shimmer sweep gradient for the native and web Skeleton variants -
- * keep both platforms visually in sync.
- */
 export const SHIMMER_GRADIENT_COLORS = [
   'rgba(255,255,255,0)',
   'rgba(255,255,255,0.18)',

--- a/src/context/AccentColorContext.tsx
+++ b/src/context/AccentColorContext.tsx
@@ -70,7 +70,6 @@ export function AccentColorProvider({
       : colors[scheme].background;
   }, [selectedHex, scheme]);
 
-  // Memoized so consumers re-render only when the accent changes, not on every provider render.
   const contextValue = useMemo(
     () =>
       ({

--- a/src/hooks/firebase/analytics.ts
+++ b/src/hooks/firebase/analytics.ts
@@ -17,9 +17,6 @@ import type {
 
 const analytics = getAnalytics(getApp());
 
-/**
- * The single privacy gate: when disabled the SDK drops every event, so the log helpers never re-check the preference.
- */
 export async function setAnalyticsEnabled(enabled: boolean): Promise<void> {
   try {
     await setAnalyticsCollectionEnabled(analytics, enabled);
@@ -28,9 +25,6 @@ export async function setAnalyticsEnabled(enabled: boolean): Promise<void> {
   }
 }
 
-/**
- * Logs an allow-listed event from analyticsEvents.ts; an unlisted name or wrong param shape fails to compile.
- */
 export async function logAnalyticsEvent<K extends AnalyticsEventName>(
   name: K,
   params: AnalyticsEventParams[K],

--- a/src/hooks/firebase/analyticsEvents.ts
+++ b/src/hooks/firebase/analyticsEvents.ts
@@ -1,6 +1,3 @@
-/**
- * Allow-list of custom analytics events; `logAnalyticsEvent` accepts only these keys. Names follow GA4 rules (snake_case, <=40 chars, not reserved), params must be primitives, and reserved `screen_view` goes through `logAnalyticsScreenView`.
- */
 export interface AnalyticsEventParams {
   experiment_exposure: { experiment: string; variant: string };
 }

--- a/src/hooks/useDebouncedCallback.ts
+++ b/src/hooks/useDebouncedCallback.ts
@@ -10,9 +10,6 @@ export type UseDebouncedCallbackReturn<Args extends unknown[]> = [
   () => void,
 ];
 
-/**
- * Runs `callback` only after `timeout` ms; re-invoking resets the timer and swaps in the new arguments.
- */
 export function useDebouncedCallback<Args extends unknown[] = []>(
   callback: (...args: Args) => void,
   timeout = 0,

--- a/src/hooks/useMountedRef.ts
+++ b/src/hooks/useMountedRef.ts
@@ -1,8 +1,5 @@
 import { RefObject, useEffect, useRef } from 'react';
 
-/**
- * Ref that reports whether the component is currently mounted.
- */
 export function useMountedRef(): RefObject<boolean> {
   const isMountedRef = useRef(false);
 

--- a/src/hooks/useOnAppStateChange.ts
+++ b/src/hooks/useOnAppStateChange.ts
@@ -4,9 +4,6 @@ import { useSyncRef } from '@app/hooks/useSyncRef';
 import type { AppStateTransition } from '@app/utils/appState/appStateTransitions';
 import { subscribeToAppStateTransitions } from '@app/utils/appState/appStateTransitions';
 
-/**
- * Runs `onTransition` on every app-state change; the latest callback is always invoked and the subscription lives for the component's lifetime.
- */
 export function useOnAppStateChange(
   onTransition: (transition: AppStateTransition) => void,
 ): void {

--- a/src/hooks/useOnReconnect.ts
+++ b/src/hooks/useOnReconnect.ts
@@ -1,11 +1,6 @@
 import { onlineManager } from '@tanstack/react-query';
 import * as Network from 'expo-network';
 
-/**
- * Wires react-query's online status to expo-network so queries auto-refetch when connectivity returns. Runs once at module load - `onlineManager.setEventListener` stores its cleanup internally (same pattern as focusManager in query-provider).
- *
- * @see https://tanstack.com/query/latest/docs/framework/react/react-native#online-status-management
- */
 onlineManager.setEventListener(setOnline => {
   const eventSubscription = Network.addNetworkStateListener(state => {
     setOnline(!!state.isConnected);

--- a/src/hooks/useRefetchOnForeground.ts
+++ b/src/hooks/useRefetchOnForeground.ts
@@ -38,7 +38,6 @@ export function useRefetchOnForeground<TRefetched>({
         return undefined;
       }
 
-      // Refresh when the screen regains focus while the app is active.
       refetchIfDue();
 
       return subscribeToAppForeground(refetchIfDue);

--- a/src/hooks/useWatchTimeTracking.ts
+++ b/src/hooks/useWatchTimeTracking.ts
@@ -6,9 +6,6 @@ import {
 } from '@app/lib/expo-store-review';
 import { subscribeToAppStateTransitions } from '@app/utils/appState/appStateTransitions';
 
-/**
- * Accumulates foreground watch time for the store-review prompt gate. Mount once per player instance; the review request runs on player unmount, after a session rather than during one.
- */
 export function useWatchTimeTracking(): void {
   const segmentStartRef = useRef<number | null>(null);
 

--- a/src/hooks/ws/types.ts
+++ b/src/hooks/ws/types.ts
@@ -39,9 +39,6 @@ export type ReadyStateState = {
 export type WebSocketMessage = string | ArrayBuffer | Blob | ArrayBufferView;
 
 export type SendMessage = (message: WebSocketMessage) => void;
-/**
- * `TJsonMessage` defaults to `never` so callers that only use `sendMessage` (Twitch IRC) need not name an outbound type.
- */
 export type SendJsonMessage<TJsonMessage = never> = (
   jsonMessage: TJsonMessage,
 ) => void;

--- a/src/lib/experiments/experiments.ts
+++ b/src/lib/experiments/experiments.ts
@@ -5,10 +5,6 @@ interface ExperimentDefinition {
   readonly control: string;
 }
 
-/**
- * A/B experiment registry; each entry maps to a key inside the Remote Config
- * `experiments` object Firebase assigns per user.
- */
 const EXPERIMENTS = {
   chatComposerLayout: {
     variants: ['control', 'compact'],

--- a/src/lib/expo-store-review.ts
+++ b/src/lib/expo-store-review.ts
@@ -46,10 +46,6 @@ export function recordWatchTime(durationMs: number): void {
   setState({ ...state, watchTimeMs: state.watchTimeMs + durationMs });
 }
 
-/**
- * Safe to call opportunistically; the gate (reviewPromptGate) plus the
- * OS-level throttle decide whether anything is shown.
- */
 export async function maybeRequestStoreReview(): Promise<void> {
   if (Platform.OS === 'web' || requestInFlight) {
     return;

--- a/src/navigators/config.ts
+++ b/src/navigators/config.ts
@@ -11,8 +11,5 @@ export const BaseConfig: ConfigBaseProps = {
 
   catchErrors: __DEV__ ? 'dev' : 'always',
 
-  /**
-   * Route names where the Android back button exits the app.
-   */
   exitRoutes: [],
 };

--- a/src/plugins/withAndroidLibsActivityTheme.js
+++ b/src/plugins/withAndroidLibsActivityTheme.js
@@ -36,7 +36,6 @@ const withAndroidLibsActivityTheme = config => {
     if (libsActivity) {
       libsActivity.$['android:theme'] = MATERIAL_THEME;
     } else {
-      // Activity entry not yet present (e.g. first prebuild); add it.
       activities.push({
         $: {
           'android:name': LIBS_ACTIVITY,

--- a/src/screens/AuthCallbackScreen.tsx
+++ b/src/screens/AuthCallbackScreen.tsx
@@ -3,11 +3,6 @@ import { StyleSheet, View } from 'react-native';
 import { Text } from '@app/components/ui/Text/Text';
 import { theme } from '@app/styles/themes';
 
-/**
- * Shown when the app is opened via the Twitch OAuth redirect.
- * The actual token handling and navigation are done in the root router layout.
- * This screen may show briefly until the app redirects to the main tab flow.
- */
 export function AuthCallbackScreen() {
   return (
     <View style={styles.container}>

--- a/src/screens/DevTools/SyncedEmotesScreen.tsx
+++ b/src/screens/DevTools/SyncedEmotesScreen.tsx
@@ -17,9 +17,7 @@ import { usePreferences } from '@app/store/preferences/selectors';
 import { theme } from '@app/styles/themes';
 
 const emoteUrls = [
-  // om
   'https://cdn.7tv.app/emote/01GZ577RM8000DE3H3K22S8S7G/4x.avif',
-  // LOL
   'https://cdn.7tv.app/emote/01FZ975PV8000B4AWRZNMVNEXN/2x.avif',
 ];
 

--- a/src/screens/Other/ChangelogScreen.tsx
+++ b/src/screens/Other/ChangelogScreen.tsx
@@ -5,7 +5,6 @@ import { Text } from '@app/components/ui/Text/Text';
 import { useScrollToTop } from '@app/hooks/useScrollToTop';
 import { theme } from '@app/styles/themes';
 
-// todo - in the future, read from github md
 const mockChangelog = `
 # Changelog
 

--- a/src/services/bttv-emote-service.ts
+++ b/src/services/bttv-emote-service.ts
@@ -13,9 +13,6 @@ interface BttvChannelEmoteSet {
   id: string;
   bots: string[];
 
-  /**
-   * the user's twitch avatar
-   */
   avatar: string;
 
   channelEmotes: BttvEmote[];

--- a/src/services/emote-provider.ts
+++ b/src/services/emote-provider.ts
@@ -85,10 +85,6 @@ function buildHostedVariants(
   };
 }
 
-/**
- * The single constructor for a domain `SanitisedEmote`; returns `null` when
- * the source resolves no renderable url.
- */
 export function buildSanitisedEmote(
   source: SevenTvEmoteSource,
 ): SevenTvSanitisedEmote | null;

--- a/src/services/twitch-service.ts
+++ b/src/services/twitch-service.ts
@@ -122,9 +122,9 @@ interface EventSubscription {
   status: EventSubStatus;
   type: string;
   version: string;
-  condition: object; // todo - type better
+  condition: object;
   created_at: string;
-  transport: object; // todo - type better
+  transport: object;
   method: 'webhook' | 'websocket';
   callback: string;
   session_id: string;

--- a/src/services/twitch-ws-service.ts
+++ b/src/services/twitch-ws-service.ts
@@ -55,9 +55,6 @@ function hasEventSubscriptionData(
   return Array.isArray(response?.data);
 }
 
-/**
- * TODO: abstract to a provider-typed interface via discriminated unions
- */
 class TwitchWsService {
   private static instance: WebSocket | null = null;
 
@@ -144,9 +141,6 @@ class TwitchWsService {
       });
     };
 
-    /**
-     * TODO: type more strictly
-     */
     TwitchWsService.instance.onmessage = (event: MessageEvent) => {
       TwitchWsService.onMessage(event);
     };
@@ -183,9 +177,6 @@ class TwitchWsService {
     };
   }
 
-  /**
-   * TODO: type MessageEvent better
-   */
   private static onMessage(event: MessageEvent) {
     try {
       // SAFETY: every frame on this socket is a Helix EventSub envelope; a body that is not one fails on `message.metadata` inside this try and is handled by the catch below.
@@ -318,9 +309,6 @@ class TwitchWsService {
     TwitchWsService.reconnectUrl = session.reconnect_url;
     TwitchWsService.isReconnecting = true;
 
-    /**
-     * TODO: expose this so chat can show a reconnecting message
-     */
     if (TwitchWsService.instance) {
       TwitchWsService.instance.close(1000, 'Reconnecting');
     }

--- a/src/store/chat/actions/channelRefreshPlan.ts
+++ b/src/store/chat/actions/channelRefreshPlan.ts
@@ -37,10 +37,6 @@ const GLOBAL_EMOTE_SLICES = [
 
 const GLOBAL_BADGE_SLICES = ['twitchGlobalBadges', 'ffzGlobalBadges'] as const;
 
-/**
- * Pure freshness policy for a channel's cached resources; global provider
- * slices carry their own stamp, judged separately from the channel's TTL.
- */
 export const planChannelRefresh = ({
   cache,
   forceRefresh,

--- a/src/store/chat/actions/channelResources.ts
+++ b/src/store/chat/actions/channelResources.ts
@@ -18,10 +18,6 @@ export type ProviderResourceType = 'badges' | 'emotes';
 
 export type Identifiable = { id: string };
 
-/**
- * What a resource fetch rejects with: a service-layer error, or a bare
- * string from a rejection that never carried one.
- */
 export type ProviderFailureReason = Error | string;
 
 export type ChannelEmoteCacheKey =
@@ -56,13 +52,7 @@ export interface ResourceSpec<
   TItem extends Identifiable,
 > {
   key: TKey;
-  /**
-   * snake_case identifier used for failure reporting (`resource_name`).
-   */
   name: string;
-  /**
-   * Human-readable name used for the cache-fallback breadcrumb.
-   */
   label: string;
   provider: ProviderName;
   resourceType: ProviderResourceType;

--- a/src/store/chat/actions/channelSession.ts
+++ b/src/store/chat/actions/channelSession.ts
@@ -10,10 +10,6 @@ import { clearFetchedCosmeticsUsers } from '@app/store/chat/actions/userCosmetic
 import { clearVisibleAssetHydration } from '@app/store/chat/actions/visibleAssetHydration';
 import { resetMentionLoginResolver } from '@app/utils/chat/mentionLoginResolver/resetMentionLoginResolver';
 
-/**
- * The four ways a channel session ends: navigation `beforeRemove`, chat
- * surface unmount, in-place channel switch, and the IRC PART echo.
- */
 export type ChannelSessionResetTrigger =
   'leave' | 'unmount' | 'switch' | 'part';
 

--- a/src/store/chat/actions/missingBadges.ts
+++ b/src/store/chat/actions/missingBadges.ts
@@ -42,9 +42,6 @@ export const clearAllMissingBadges = (): void => {
   loggedMissingBadgeIds.clear();
 };
 
-/**
- * Badge ids referenced by an entitlement whose definition never loaded.
- */
 export const getMissingBadgeIds = (): string[] => Array.from(missingBadgeIds);
 
 export const hasMissingBadges = (): boolean => missingBadgeIds.size > 0;

--- a/src/store/chat/actions/userCosmeticsFetch.ts
+++ b/src/store/chat/actions/userCosmeticsFetch.ts
@@ -68,9 +68,6 @@ export async function fetchUserCosmetics(
   }
 }
 
-/**
- * Called on chat unmount so the next session re-requests cosmetics.
- */
 export function clearFetchedCosmeticsUsers(): void {
   fetchedCosmeticsUsers.clear();
 }

--- a/src/store/chat/react/selectors.ts
+++ b/src/store/chat/react/selectors.ts
@@ -196,10 +196,6 @@ export const useChannelEmoteDataForReprocess = (channelId: string | null) => {
   });
 };
 
-/**
- * Global provider caches for surfaces outside a joined channel; pair with
- * `ensureGlobalChatResources()` so the caches fill on cold entry.
- */
 export const useGlobalEmoteBadgeCaches = () =>
   useSelector(() => {
     const globalCache$ = chatStore$.persisted.globalCaches;

--- a/src/store/chat/types/chatPressData.ts
+++ b/src/store/chat/types/chatPressData.ts
@@ -4,10 +4,6 @@ import type { UserNoticeVariantMap } from '@app/types/chat/irc-tags/usernotice';
 import type { SanitisedBadgeSet } from '@app/types/twitch/badge';
 import type { ParsedPart } from '@app/utils/chat/parsedPart';
 
-/**
- * The payloads a chat row hands to the overlay layer on press; store-side
- * because the overlay observables carry them.
- */
 export type EmotePressData = ParsedPart<'emote'>;
 export type BadgePressData = SanitisedBadgeSet;
 export type MessageActionData<

--- a/src/store/chat/types/constants.ts
+++ b/src/store/chat/types/constants.ts
@@ -154,10 +154,6 @@ export interface ChannelCacheType {
   badgesLastUpdated?: number;
 }
 
-/**
- * Channel-invariant provider data stored once; `lastUpdated` gives global
- * slices their own TTL, independent of any channel's.
- */
 export interface GlobalCacheType {
   lastUpdated: number;
   twitchGlobalEmotes: SanitisedEmote[];
@@ -204,10 +200,6 @@ export const makeEmptyGlobalCacheData = () =>
     ffzGlobalBadges: [],
   }) satisfies GlobalCacheType;
 
-/**
- * Channel-cache fields plus the slices not stored per channel: global slices,
- * session 7TV personal emotes, and chatterinoBadges resolved at read time.
- */
 export interface ResolvedEmoteData extends ChannelCacheType, GlobalCacheType {
   sevenTvPersonalEmotes: Record<string, SanitisedEmote[]>;
   chatterinoBadges: SanitisedBadgeSet[];

--- a/src/store/preferenceStore.ts
+++ b/src/store/preferenceStore.ts
@@ -37,9 +37,6 @@ export interface Preferences {
   streamListLayout: 'compact' | 'media';
   chatDensity: 'comfortable' | 'compact';
   showAlternatingChatRows: boolean;
-  /**
-   * Slide-in animation for new chat messages.
-   */
   animate: boolean;
   chatTimestamps: boolean;
   highlightOwnMentions: boolean;
@@ -85,14 +82,7 @@ export interface Preferences {
    * re-clamped to the current screen at layout time.
    */
   landscapeChatWidth: number | null;
-  /**
-   * Use foam's custom-controls player (hidden Twitch chrome + ControlsOverlay).
-   * Off = stock player.
-   */
   customPlayerEnabled: boolean;
-  /**
-   * Opt in to anonymous Firebase usage analytics.
-   */
   analyticsEnabled: boolean;
   sharedChatEnabled: boolean;
   enhancedVideoStability: boolean;

--- a/src/store/stream/liveSyncBus.ts
+++ b/src/store/stream/liveSyncBus.ts
@@ -1,7 +1,3 @@
-/**
- * Event bus so the chat settings sheet can ask the sibling stream player to
- * seek to the live edge without threading a callback through the overlay tree.
- */
 type LiveSyncListener = () => void;
 
 const listeners = new Set<LiveSyncListener>();

--- a/src/styles/motion.ts
+++ b/src/styles/motion.ts
@@ -12,9 +12,6 @@ export const motion = {
     standard: Easing.inOut(Easing.cubic),
   },
 
-  /**
-   * withSpring configs: `responsive` for gesture and layout-driven motion, `gentle` for ambient reveals.
-   */
   spring: {
     responsive: { damping: 28, stiffness: 320, mass: 0.8 },
     gentle: { damping: 22, stiffness: 240, mass: 0.55 },

--- a/src/styles/spacing.ts
+++ b/src/styles/spacing.ts
@@ -46,9 +46,6 @@ const NO_MARGIN = Object.freeze({});
 
 export function getMargin(theme: AppTheme) {
   return ({ m, mb, ml, mr, mt, mx, my }: MarginProps) => {
-    /**
-     * Chat spans route every rendered text through this and almost none pass margin props - skip the fourteen resolve calls and seven conditional spreads for that case.
-     */
     if (
       m === undefined &&
       mb === undefined &&

--- a/src/styles/themes.ts
+++ b/src/styles/themes.ts
@@ -14,7 +14,6 @@ const fontScale = (value: number) =>
   isIpad ? Math.round(value * FONT_SCALE) : value;
 
 const alpha = (hex: string, opacityHex: string) => `${hex}${opacityHex}`;
-// Flat legacy `colorX` tokens read the dark value; theme.color.accent / accentPress carries the { light, dark } pair.
 const primaryAccent = { light: '#1083FE', dark: '#2E86FF' } as const;
 const primaryAccentPress = { light: '#0A6CE0', dark: '#5AA1FF' } as const;
 
@@ -27,7 +26,6 @@ export const semanticColorGroups = {
     accentHover: primaryAccentPress.dark,
     accentHoverAlpha: alpha(primaryAccentPress.dark, 'CC'),
     bgAltAlpha: alpha(primaryAccent.dark, '1A'),
-    // Accent takes white text in both themes.
     contrast: '#FFFFFF',
     ui: primaryAccent.dark,
     uiAlpha: alpha(primaryAccent.dark, '24'),
@@ -139,7 +137,6 @@ export const theme = {
   colorBorderTertiary: semanticColorGroups.gray.borderUi,
   colorSurfaceAlpha: semanticColorGroups.gray.uiAlpha,
 
-  // Each token is a { light, dark } pair resolved with theme.color.X[useColorScheme() ?? 'dark'], except brand/notice/chatSample - scheme-independent raw strings.
   color: {
     reactBlue: {
       light: '#087EA4',
@@ -149,15 +146,12 @@ export const theme = {
       light: 'rgba(255,255,255,0)',
       dark: 'rgba(0,0,0,0)',
     },
-    // Page background.
     canvas: CANVAS,
     background: {
       ...CANVAS,
-      // Retained for existing call sites; mapped onto the new slate surfaces.
       darkAlt: SURFACE.dark,
       darkAltAlpha: 'rgba(22,29,38,0.92)',
     },
-    // Raised surfaces (cards, sheets, inputs).
     surface: SURFACE,
     surfaceSunken: SURFACE_SUNKEN,
     surfaceElevated: SURFACE_ELEVATED,
@@ -166,7 +160,6 @@ export const theme = {
       light: 'rgba(16,24,40,0.04)',
       dark: 'rgba(255,255,255,0.04)',
     },
-    // Existing surface aliases re-pointed at the slate palette for coherence.
     backgroundSecondary: SURFACE,
     backgroundTertiary: SURFACE_SUNKEN,
     backgroundElement: SURFACE_PRESSED,
@@ -210,7 +203,6 @@ export const theme = {
       light: 'rgba(16,131,254,0.35)',
       dark: 'rgba(46,134,255,0.45)',
     },
-    // Accent takes white text in both themes.
     onAccent: {
       light: '#FFFFFF',
       dark: '#FFFFFF',
@@ -231,7 +223,6 @@ export const theme = {
       light: '#DC4B4B',
       dark: '#FF6B6B',
     },
-    // Twitch purple — chat links/mentions only.
     twitch: {
       light: '#8A4FE6',
       dark: '#A172F0',
@@ -244,7 +235,6 @@ export const theme = {
       light: '#FFFFFF',
       dark: '#1C1C1E',
     },
-    // Near-black menu surfaces (emote sheet), off the blue-slate palette to read as a system menu; dark-only raw strings.
     menu: {
       background: '#0A0A0B',
       header: '#0E0E10',
@@ -272,7 +262,6 @@ export const theme = {
       purple: Color.purple[400],
       amber: Color.amber[500],
     },
-    // Video chrome — dark in both themes.
     scrim: {
       light: 'rgba(0,0,0,0.60)',
       dark: 'rgba(0,0,0,0.62)',
@@ -350,11 +339,9 @@ export const theme = {
   borderRadius80: 80,
   borderRadius999: 999,
 
-  // Retained for existing call sites (theme.dropShadow.boxShadow).
   dropShadow: {
     boxShadow: '0 24px 64px 0 rgba(0, 0, 0, 0.45)',
   },
-  // Elevation scale; each a { light, dark } boxShadow pair resolved with useColorScheme().
   shadow: {
     sm: {
       light: '0 1px 2px rgba(16,30,50,0.06)',

--- a/src/styles/ui.ts
+++ b/src/styles/ui.ts
@@ -38,7 +38,6 @@ export type UIColor =
   | 'white'
   | 'transparent';
 
-// Biased to the small end for a tighter, more native feel.
 export const RADIUS_VALUES = {
   none: 0,
   xxs: 4,

--- a/src/test/render.tsx
+++ b/src/test/render.tsx
@@ -54,9 +54,6 @@ export const DefaultWrapper = ({ children }: { children: ReactNode }) => {
   );
 };
 
-/**
- * Test render pre-wired with the app's providers.
- */
 export default function render(
   ui: ReactElement,
   options?: Omit<RenderOptions, 'queries'>,

--- a/src/types/bttv/badge.ts
+++ b/src/types/bttv/badge.ts
@@ -2,10 +2,6 @@ export interface BttvBadge {
   id: string;
   name: string;
   displayName: string;
-  /**
-   * The badge owner's Twitch user id; BTTV badges are matched to chatters by
-   * this id.
-   */
   providerId: string;
   badge?: {
     type: number;

--- a/src/types/chat/irc-tags/clearchat.ts
+++ b/src/types/chat/irc-tags/clearchat.ts
@@ -3,13 +3,7 @@ export interface ClearChatTags {
    * Present for timeouts, absent for bans; timeout duration in seconds.
    */
   'ban-duration'?: string;
-
   'room-id': string;
-
   'target-user-id'?: string;
-
-  /**
-   * UNIX timestamp
-   */
   'tmi-send-ts': string;
 }

--- a/src/types/chat/irc-tags/clearmsg.ts
+++ b/src/types/chat/irc-tags/clearmsg.ts
@@ -4,9 +4,5 @@ export interface ClearMsgTags {
   'room-id'?: string;
 
   'target-msg-id': string;
-
-  /**
-   * UNIX timestamp
-   */
   'tmi-sent-ts': string;
 }

--- a/src/types/chat/irc-tags/notice.ts
+++ b/src/types/chat/irc-tags/notice.ts
@@ -1,126 +1,33 @@
 type NoticeMsgId =
-  /**
-   * This room is no longer in emote-only mode.
-   */
   | 'emote_only_off'
-
-  /**
-   * This room is now in emote-only mode.
-   */
   | 'emote_only_on'
-  /**
-   * This room is no longer in followers-only mode.
-   */
   | 'followers_off'
-  /**
-   * This room is now in <duration> followers-only mode.
-   */
   | 'followers_on'
-  /**
-   * This room is now in followers-only mode.
-   */
   | 'followers_on_zero'
-  /**
-   * You are permanently banned from talking in <channel>.
-   */
   | 'msg_banned'
-  /**
-   * Message contained too many unprocessable characters.
-   */
   | 'msg_bad_characters'
-  /**
-   * Your message was not sent because your account is not in good standing in this channel.
-   */
   | 'msg_channel_blocked'
-  /**
-   * This channel does not exist or has been suspended.
-   */
   | 'msg_channel_suspended'
-  /**
-   * Your message was not sent because it is identical to the previous one you sent, less than 30 seconds ago.
-   */
   | 'msg_duplicate'
-  /**
-   * This room is in emote-only mode.
-   */
   | 'msg_emoteonly'
-  /**
-   * This room is in <duration> followers-only mode; the user does not follow
-   * or has not followed long enough.
-   */
   | 'msg_followersonly'
-  /**
-   * This room is in <duration1> followers-only mode. You have been following for <duration2>. Continue following to chat!
-   */
   | 'msg_followersonly_followed'
-  /**
-   * This room is in followers-only mode. Follow <channel> to join the community!
-   */
   | 'msg_followersonly_zero'
-  /**
-   * This room is in unique-chat mode and the message you attempted to send is not unique.
-   */
   | 'msg_r9k'
-  /**
-   * Your message was not sent because you are sending messages too quickly.
-   */
   | 'msg_ratelimit'
-  /**
-   * Hey! Your message is being checked by mods and has not been sent.
-   */
   | 'msg_rejected'
-  /**
-   * Your message wasn’t posted due to conflicts with the channel’s moderation settings.
-   */
   | 'msg_rejected_mandatory'
-  /**
-   * A verified phone number is required to chat in this channel.
-   */
   | 'msg_requires_verified_phone_number'
-  /**
-   * This room is in slow mode and you are sending messages too quickly. You will be able to talk again in <number> seconds.
-   */
   | 'msg_slowmode'
-  /**
-   * This room is in subscribers-only mode.
-   */
   | 'msg_subsonly'
-  /**
-   * You don’t have permission to perform that action.
-   */
   | 'msg_suspended'
-  /**
-   * You are timed out for <number> more seconds.
-   */
   | 'msg_timedout'
-  /**
-   * This room requires a verified account to chat.
-   */
   | 'msg_verified_email'
-  /**
-   * This room is no longer in slow mode.
-   */
   | 'slow_off'
-  /**
-   * This room is now in slow mode. You may send messages every <number> seconds.
-   */
   | 'slow_on'
-  /**
-   * This room is no longer in subscribers-only mode.
-   */
   | 'subs_off'
-
-  /**
-   * This room is now in subscribers-only mode.
-   */
   | 'subs_on'
-  /**
-   * The community has closed channel <channel> due to Terms of Service violations.
-   */
   | 'tos_ban'
-  /**
-   * Unrecognized command: <command>
-   */
   | 'unrecognized_cmd';
 
 export interface NoticeTags {

--- a/src/types/chat/irc-tags/roomstate.ts
+++ b/src/types/chat/irc-tags/roomstate.ts
@@ -1,21 +1,14 @@
 export interface RoomStateTags {
   emote_only: '1' | '0';
-
   /**
    * -1 = not restricted.
    */
   'followers-only': number;
-
   /**
    * Unique-messages mode; applies to messages over 9 characters.
    */
   r9k: '1' | '0';
-
   'room-id': string;
-
-  /**
-   * Seconds users must wait between messages.
-   */
   slow: number;
 
   'subs-only': boolean;

--- a/src/types/chat/irc-tags/usernotice.ts
+++ b/src/types/chat/irc-tags/usernotice.ts
@@ -40,9 +40,6 @@ export interface SubscriptionTags extends BaseUserNoticeTags {
 
   'msg-param-should-share-streak': '1' | '0';
 
-  /**
-   * Zero when msg-param-should-share-streak is 0.
-   */
   'msg-param-streak-months': string;
 
   'msg-param-sub-plan': MsgParamSubPlan;
@@ -63,9 +60,6 @@ export interface SubGiftTags extends BaseUserNoticeTags {
 
   'msg-param-recipient-id': string;
 
-  /**
-   * The recipient's total subscribed months.
-   */
   'msg-param-months': string;
 }
 

--- a/src/types/chat/irc-tags/userstate.ts
+++ b/src/types/chat/irc-tags/userstate.ts
@@ -1,6 +1,3 @@
-/**
- * Twitch IRC user-state tags - see https://dev.twitch.tv/docs/irc/tags/
- */
 export interface UserStateTags {
   'display-name'?: string;
   login?: string;

--- a/src/types/chat/irc-tags/userstate.ts
+++ b/src/types/chat/irc-tags/userstate.ts
@@ -30,9 +30,6 @@ export interface UserStateTags {
   mod?: string;
   subscriber?: string;
   turbo?: string;
-  /**
-   * Total bits cheered in this message (PRIVMSG `bits` tag).
-   */
   bits?: string;
   emotes?: string;
   'emote-sets'?: string;
@@ -45,9 +42,6 @@ export interface UserStateTags {
   'msg-param-custom-reward-title'?: string;
   'msg-param-reward-title'?: string;
 
-  /**
-   * Custom tags we add to support reply threads.
-   */
   'reply-parent-msg-id': string;
   'reply-parent-msg-body': string;
   'reply-parent-display-name': string;

--- a/src/types/emote.ts
+++ b/src/types/emote.ts
@@ -11,10 +11,6 @@ export interface SevenTvEmoteSetMetadata {
   totalCount: number;
 }
 
-/**
- * The canonical provider discriminant for emotes and badges; dispatch on this
- * field, never on the `site` display string.
- */
 export type EmoteProvider = 'twitch' | '7tv' | 'bttv' | 'ffz' | 'emoji';
 
 export type EmoteImageScale = '1x' | '2x' | '3x' | '4x';

--- a/src/types/seventv/cosmetics.ts
+++ b/src/types/seventv/cosmetics.ts
@@ -32,23 +32,13 @@ export type SevenTvColor = number;
 
 export interface PaintShadow {
   color: SevenTvColor;
-
-  /**
-   * Blur radius in pixels.
-   */
   radius: number;
-
   x_offset: number;
-
   y_offset: number;
 }
 
 export interface PaintStop {
   color: SevenTvColor;
-
-  /**
-   * Position along the gradient axis, 0-1.
-   */
   at: number;
 }
 
@@ -80,8 +70,7 @@ export interface PaintLayerData {
   at: [number, number] | null;
   size: [number, number] | null;
   /**
-   * v4 per-layer opacity (0-1); the whole layer span fades by this amount.
-   * v3-era data carries no opacity; normalization defaults it to 1.
+   * v4 per-layer opacity (0-1). v3-era data has no opacity; normalize it to 1.
    */
   opacity: number;
 }
@@ -108,22 +97,12 @@ export interface PaintData {
   id: string;
 
   name: string;
-
-  /**
-   * Solid fallback used when the paint is not gradient-based or stops are missing.
-   */
   color: SevenTvColor | null;
-
   layers: IndexedCollection<PaintLayerData>;
-
   shadows: IndexedCollection<PaintShadow>;
-
   textStyle: PaintTextStyle | null;
-
   function: PaintFunction;
-
   repeat: boolean;
-
   /**
    * Linear gradient angle in degrees; 0 = left to right, 90 = bottom to top.
    */
@@ -299,8 +278,8 @@ export interface SevenTvEventData<
 }
 
 /**
- * Condition for Subscribe (op 35) / Unsubscribe (op 36) payloads. Creation
- * events filter by platform context; everything else filters on an object id.
+ * Subscribe (op 35) / Unsubscribe (op 36). Creation events filter by platform
+ * context; everything else filters on an object id.
  */
 type SevenTvSubscriptionCondition<TEventType> = TEventType extends
   'entitlement.create' | 'cosmetic.create'
@@ -314,26 +293,20 @@ type SevenTvSubscriptionCondition<TEventType> = TEventType extends
     };
 
 export type SevenTvWsMessage<TData = unknown, TEventType = SevenTvEventType> =
-  /**
-   * Dispatch: sent when a subscribed event fires.
-   */
   | {
+      /**
+       * Dispatch
+       */
       op: 0;
       d: TData;
     }
-  /**
-   * Hello: session info, sent on connect.
-   */
   | {
+      /**
+       * Hello
+       */
       op: 1;
       d?: {
-        /**
-         * Milliseconds between heartbeats.
-         */
         heartbeat_interval: number;
-        /**
-         * Token used to resume or mutate the session.
-         */
         session_id: string;
         subscription_limit: number;
         instance: {
@@ -344,10 +317,10 @@ export type SevenTvWsMessage<TData = unknown, TEventType = SevenTvEventType> =
       t?: number;
       s?: number;
     }
-  /**
-   * Heartbeat.
-   */
   | {
+      /**
+       * Heartbeat
+       */
       op: 2;
       d: {
         count: number;
@@ -355,35 +328,28 @@ export type SevenTvWsMessage<TData = unknown, TEventType = SevenTvEventType> =
       t: number;
       s: number;
     }
-  /**
-   * Reconnect: server wants the client to reconnect.
-   */
   | {
+      /**
+       * Reconnect
+       */
       op: 4;
     }
-  /**
-   * ACK
-   */
   | {
+      /**
+       * ACK
+       */
       op: 5;
       d: {
-        /**
-         * The acknowledged opcode in text form.
-         */
         command: string;
-        /**
-         * Echoed client data for SUBSCRIBE/UNSUBSCRIBE; a result object for RESUME.
-         */
         data: unknown;
       };
       t: number;
       s: number;
     }
-
-  /**
-   * Invalid subscription condition.
-   */
   | {
+      /**
+       * Invalid subscription condition
+       */
       op: 6;
       d: {
         code: number;
@@ -392,10 +358,10 @@ export type SevenTvWsMessage<TData = unknown, TEventType = SevenTvEventType> =
       t: number;
       s: number;
     }
-  /**
-   * Resume the previous connection.
-   */
   | {
+      /**
+       * Resume
+       */
       op: 34;
       d: {
         session_id: string;
@@ -403,25 +369,22 @@ export type SevenTvWsMessage<TData = unknown, TEventType = SevenTvEventType> =
       t?: number;
       s?: number;
     }
-
-  /**
-   * End of stream: server closed the connection; the code says why and
-   * whether to reconnect.
-   */
   | {
+      /**
+       * End of stream
+       */
       op: 7;
       d?: {
         code: number;
-
         message: string;
       };
       t?: never;
       s?: never;
     }
-  /**
-   * Subscribe to an event.
-   */
   | {
+      /**
+       * Subscribe
+       */
       op: 35;
       d: {
         type: TEventType;
@@ -430,10 +393,10 @@ export type SevenTvWsMessage<TData = unknown, TEventType = SevenTvEventType> =
       t?: number;
       s?: never;
     }
-  /**
-   * Unsubscribe from an event.
-   */
   | {
+      /**
+       * Unsubscribe
+       */
       op: 36;
       d: {
         type: TEventType;

--- a/src/types/seventv/cosmetics.ts
+++ b/src/types/seventv/cosmetics.ts
@@ -104,10 +104,6 @@ export interface BadgeData extends EventObject {
   tooltip: string;
 }
 
-/**
- * A 7TV paint cosmetic applied to a username: a linear/radial gradient,
- * solid colour or image fill, plus optional drop shadows.
- */
 export interface PaintData {
   id: string;
 

--- a/src/types/streamelements/stats.ts
+++ b/src/types/streamelements/stats.ts
@@ -9,10 +9,6 @@ export interface StreamElementsChatterStat {
   amount: number;
 }
 
-/**
- * Public chat statistics for a Twitch channel that uses StreamElements.
- * @see https://api.streamelements.com/kappa/v2/chatstats/:channel/stats
- */
 export interface StreamElementsChatStats {
   channel: string;
   totalMessages: number;

--- a/src/types/twitch/badge.ts
+++ b/src/types/twitch/badge.ts
@@ -1,9 +1,5 @@
 import { OpenStringUnion } from '@app/utils/typescript/OpenStringUnion';
 
-/**
- * The canonical provider discriminant for badges; dispatch on this field,
- * never on the `type` display string.
- */
 export type BadgeProvider = 'twitch' | '7tv' | 'bttv' | 'ffz' | 'chatterino';
 
 export interface SanitisedBadgeSet {

--- a/src/types/twitch/eventsub.ts
+++ b/src/types/twitch/eventsub.ts
@@ -1,9 +1,5 @@
 import type { JsonValue } from '@app/utils/object/deepEqualJson';
 
-/**
- * The raw `event` object Twitch attaches to a notification, before a consumer
- * narrows it to the payload its subscription type declares.
- */
 export type EventSubEvent = {
   [field: string]: JsonValue;
 };
@@ -43,9 +39,6 @@ export interface EventSubPayload {
   };
 }
 
-/**
- * TODO: make more precise with generic and discriminated unions
- */
 export interface EventSubMessage {
   metadata: EventSubMetadata;
   payload: EventSubPayload;

--- a/src/types/twitch/moderation.ts
+++ b/src/types/twitch/moderation.ts
@@ -1,6 +1,3 @@
-/**
- * PATCH /helix/chat/settings body; only the provided fields change.
- */
 export interface TwitchChatSettingsPatch {
   emote_mode?: boolean;
   follower_mode?: boolean;

--- a/src/utils/appState/appStateTransitions.ts
+++ b/src/utils/appState/appStateTransitions.ts
@@ -54,10 +54,6 @@ export function isForegroundTransition(
   );
 }
 
-/**
- * All subscribers share one `AppState` listener, attached on the first
- * subscribe and removed with the last unsubscribe.
- */
 export function subscribeToAppStateTransitions(
   listener: AppStateTransitionListener,
 ): () => void {
@@ -83,10 +79,6 @@ export function subscribeToAppStateTransitions(
   };
 }
 
-/**
- * Subscribes to came-to-foreground events only (see
- * {@link isForegroundTransition}).
- */
 export function subscribeToAppForeground(listener: () => void): () => void {
   return subscribeToAppStateTransitions(transition => {
     if (isForegroundTransition(transition)) {

--- a/src/utils/appUpdate/isUpdateAppButtonAllowed.ts
+++ b/src/utils/appUpdate/isUpdateAppButtonAllowed.ts
@@ -1,9 +1,5 @@
 import { normaliseChatUsername } from '@app/utils/chat/chatUsernames/normaliseChatUsername';
 
-/**
- * An empty allow-list shows the Settings "update app" button to everyone;
- * otherwise only Twitch logins on the list see it.
- */
 export function isUpdateAppButtonAllowed(
   login: string | null | undefined,
   allowedUsers: readonly string[],

--- a/src/utils/authentication/tokenLifecycle.ts
+++ b/src/utils/authentication/tokenLifecycle.ts
@@ -42,9 +42,6 @@ export const isTokenExpired = (token: TwitchToken): boolean => {
   return now >= expiresAt - bufferTime;
 };
 
-/**
- * Calculate the expiration timestamp from `expiresIn` and add it to a token.
- */
 export const addExpirationTimestamp = (
   token: Omit<TwitchToken, 'expiresAt'>,
 ): TwitchToken => {

--- a/src/utils/chat/cheermoteStore/fetchChannelCheermotes.ts
+++ b/src/utils/chat/cheermoteStore/fetchChannelCheermotes.ts
@@ -2,10 +2,6 @@ import type { TwitchCheermote } from '@app/types/twitch/bits';
 import { cheermoteFetchGuard } from '@app/utils/chat/cheermoteStore/cheermoteFetchGuard';
 import { setChannelCheermotes } from '@app/utils/chat/cheermoteStore/setChannelCheermotes';
 
-/**
- * Fetches a channel's cheermotes at most once per TTL window; a rejected
- * fetcher propagates and leaves the channel immediately retryable.
- */
 export function fetchChannelCheermotes(
   channelId: string,
   fetcher: () => Promise<TwitchCheermote[]>,

--- a/src/utils/chat/createModeratedMessageText.ts
+++ b/src/utils/chat/createModeratedMessageText.ts
@@ -1,10 +1,6 @@
 import type { ParsedPart } from '@app/utils/chat/parsedPart';
 import { replaceEmotesWithText } from '@app/utils/chat/replaceEmotesWithText';
 
-/**
- * Both the pre-commit buffer and the store rewrite moderated messages, so
- * they share the wording from here.
- */
 export function createModeratedMessageText(
   message: ParsedPart[],
   moderationNotice: string,

--- a/src/utils/chat/deriveChatBody/types.ts
+++ b/src/utils/chat/deriveChatBody/types.ts
@@ -35,9 +35,5 @@ export interface ChatBodyScan extends MessageStructure {
   hasStvEmoteEvent: boolean;
   hasViewerMilestone: boolean;
   hasModAnniversary: boolean;
-  /**
-   * Normalised logins this message @-mentions; render compares against the
-   * current user instead of re-scanning parts.
-   */
   mentionLogins: string[];
 }

--- a/src/utils/chat/ircProtocol/buildPrivmsgLine.ts
+++ b/src/utils/chat/ircProtocol/buildPrivmsgLine.ts
@@ -16,9 +16,6 @@ export function buildPrivmsgLine({
   message,
   replyParentMsgId,
 }: {
-  /**
-   * Already formatted with its `#` prefix.
-   */
   channel: string;
   message: string;
   replyParentMsgId?: string;

--- a/src/utils/chat/ircProtocol/routeIrcMessage.ts
+++ b/src/utils/chat/ircProtocol/routeIrcMessage.ts
@@ -2,10 +2,6 @@ import type { IrcMessage } from '@app/utils/chat/ircProtocol/parseIrcMessage';
 
 const EMPTY_TAGS: Record<string, string> = Object.freeze({});
 
-/**
- * Handlers receive positional arguments, never a payload object - this runs
- * once per received line and must not allocate.
- */
 export interface IrcRouteHandlers {
   privmsg?: (
     channel: string,
@@ -47,10 +43,6 @@ export interface IrcRouteHandlers {
   unhandled?: (command: string, params: string[]) => void;
 }
 
-/**
- * The one command demux for Twitch IRC lines, shared by the live socket and
- * the recent-messages replay so a new command or tag contract is one edit.
- */
 export function routeIrcMessage(
   message: IrcMessage,
   handlers: IrcRouteHandlers,

--- a/src/utils/chat/messageHandlers/__tests__/createUserStateFromTags.test.ts
+++ b/src/utils/chat/messageHandlers/__tests__/createUserStateFromTags.test.ts
@@ -39,7 +39,6 @@ describe('createUserStateFromTags', () => {
 
     const result = createUserStateFromTags(tags);
 
-    // When display-name is missing, username falls back to login.
     expect(result).toEqual<UserStateTags>({
       login: 'testuser',
       username: 'testuser',

--- a/src/utils/chat/messageHandlers/createOptimisticMessage.ts
+++ b/src/utils/chat/messageHandlers/createOptimisticMessage.ts
@@ -7,10 +7,6 @@ import type {
 } from '@app/utils/chat/messageHandlers/createOptimisticUserState';
 import { formatDate } from '@app/utils/date-time/date';
 
-/**
- * Local echo of a just-sent message; `sentAt` doubles as id and nonce, and
- * the real message carries Twitch's own id so the two never collide.
- */
 export function createOptimisticMessage({
   badges,
   channelName,

--- a/src/utils/chat/messageHandlers/createOptimisticUserState.ts
+++ b/src/utils/chat/messageHandlers/createOptimisticUserState.ts
@@ -15,10 +15,6 @@ export interface OptimisticReplyTarget {
   replyParentUserLogin?: string;
 }
 
-/**
- * Userstate for the local echo of a just-sent message; the row renders before
- * IRC echoes real tags, so this fills gaps from the last USERSTATE.
- */
 export function createOptimisticUserState({
   currentUserState,
   replyTo,

--- a/src/utils/chat/messageIdentity/getChatMessageStoreId.ts
+++ b/src/utils/chat/messageIdentity/getChatMessageStoreId.ts
@@ -1,10 +1,6 @@
 import { getChatMessageKey } from '@app/utils/chat/messageIdentity/getChatMessageKey';
 import { normaliseMessageField } from '@app/utils/chat/messageIdentity/normaliseMessageField';
 
-/**
- * A message's stable id: the store-assigned `id` once committed, else the key
- * it commits under - buffered and stored messages share one identity.
- */
 export function getChatMessageStoreId(message: {
   id?: string;
   message_id: string;

--- a/src/utils/chat/parsedPart.ts
+++ b/src/utils/chat/parsedPart.ts
@@ -20,18 +20,12 @@ export type TwitchNotices =
 
 export type PartVariant =
   | 'text'
-  /**
-   * Emoji i.e. a normal unicode emoji 🚀
-   */
   | 'emote'
   | 'mention'
   | 'stvEmote'
   | 'twitchClip'
   | 'link'
   | 'notice'
-  /**
-   * Bits cheer token, e.g. Cheer100
-   */
   | 'cheermote'
   | 'stv_emote_added'
   | 'stv_emote_removed'
@@ -188,9 +182,6 @@ export type ParsedPart<TType extends PartVariant = PartVariant> = TType extends
                         : TType extends 'cheermote'
                           ? {
                               type: TType;
-                              /**
-                               * The original cheer token, e.g. "Cheer100".
-                               */
                               content: string;
                               cheermote: {
                                 bits: number;
@@ -200,10 +191,7 @@ export type ParsedPart<TType extends PartVariant = PartVariant> = TType extends
                                 url: string;
                               };
                             }
-                          : /**
-                             * Normal message
-                             */
-                            Pick<
+                          : Pick<
                               Partial<SanitisedEmote>,
                               | 'creator'
                               | 'emote_link'
@@ -231,8 +219,5 @@ export type ParsedPart<TType extends PartVariant = PartVariant> = TType extends
                                */
                               overlaid?: ParsedPart<'emote'>[];
 
-                              /**
-                               * Used for emote and twitch clip previews
-                               */
                               thumbnail?: string;
                             };

--- a/src/utils/chat/replaceEmotesWithText.ts
+++ b/src/utils/chat/replaceEmotesWithText.ts
@@ -1,9 +1,6 @@
 import { ParsedPart } from './parsedPart';
 import { getParsedPartStringContent } from './parsedPartContent';
 
-/**
- * Rebuilds the plain text of a parsed message, for copying it back out.
- */
 export function replaceEmotesWithText(parts: ParsedPart[]): string {
   if (parts.length === 0) {
     return '';

--- a/src/utils/color/lightenColor.ts
+++ b/src/utils/color/lightenColor.ts
@@ -13,10 +13,6 @@ type HslChannels = {
   l: number;
 };
 
-/**
- * The composited chat row surface; colours are corrected against this real
- * background because a lightness floor says nothing about legibility.
- */
 const CHAT_SURFACE_RGB = { r: 20, g: 27, b: 35 };
 
 // WCAG AA for normal-size text; higher washes the hues together.
@@ -43,7 +39,6 @@ export function lightenColor(hex: string): string {
 
   const { h, s, l } = rgbToHsl(rgb.r, rgb.g, rgb.b);
 
-  // Lowest lightness that clears the target, so a colour keeps its identity.
   let low = l;
   let high = 1;
   let best = hslToRgb(h, s, 1);

--- a/src/utils/device/deviceTier.ts
+++ b/src/utils/device/deviceTier.ts
@@ -5,10 +5,6 @@ export type DeviceTier = 'low' | 'high';
 let cached: DeviceTier | null = null;
 let cachedTotalMemoryBytes: number | null = null;
 
-/**
- * Total physical RAM in bytes (0 when unavailable); used to scale
- * image-memory budgets to the device.
- */
 export function getTotalDeviceMemoryBytes(): number {
   if (cachedTotalMemoryBytes !== null) {
     return cachedTotalMemoryBytes;

--- a/src/utils/emote/resolveEmoteDisplayUrl.ts
+++ b/src/utils/emote/resolveEmoteDisplayUrl.ts
@@ -10,10 +10,6 @@ export interface ResolvableDisplayEmote {
   static_url?: string | null;
 }
 
-/**
- * Owns which url an emote displays at: warm, prefetch, render and the action
- * sheet all resolve here so they cannot disagree on scale or animation variant.
- */
 export function resolveEmoteDisplayUrl(
   emote: ResolvableDisplayEmote,
   {

--- a/src/utils/image/preloadEmotes.ts
+++ b/src/utils/image/preloadEmotes.ts
@@ -1,7 +1,3 @@
-/**
- * Warms emote images into expo-image's disk cache; goes through prefetchToDisk
- * so it targets the same cache ChatInlineImage reads.
- */
 import type { SanitisedEmote } from '@app/types/emote';
 import { describeEmoteUrl } from '@app/utils/emote/describeEmoteUrl';
 import { withResolvedEmoteImageVariants } from '@app/utils/emote/emoteImageVariants/withResolvedEmoteImageVariants';
@@ -92,9 +88,6 @@ export async function preloadEmotes(
   }
 }
 
-/**
- * Call once per session.
- */
 export async function preloadGlobalEmotes(emoteData: {
   twitchGlobalEmotes?: SanitisedEmote[];
   sevenTvGlobalEmotes?: SanitisedEmote[];

--- a/src/utils/log/sanitiseLogValue.ts
+++ b/src/utils/log/sanitiseLogValue.ts
@@ -15,10 +15,6 @@ const loggableEmoteSchema = z.object({
   site: z.string(),
 });
 
-/**
- * Accepts exactly what the old plain-object typeof check accepted, so the
- * record branch below is unchanged.
- */
 const looseObjectSchema = z.looseObject({});
 
 export function isRecord<T>(
@@ -40,10 +36,6 @@ function summariseHomogeneousArray(value: unknown[]): string | null {
   return null;
 }
 
-/**
- * Bounds an arbitrary value so a huge object can't blow up Sentry envelope
- * serialization on-device.
- */
 export function sanitiseLogValue(value: string, seen?: WeakSet<object>): string;
 export function sanitiseLogValue<T>(
   value: T,

--- a/src/utils/object/deepEqualJson.ts
+++ b/src/utils/object/deepEqualJson.ts
@@ -1,6 +1,3 @@
-/**
- * A JSON-shaped value: primitives, arrays, and plain key-value objects.
- */
 export type JsonValue =
   | string
   | number
@@ -22,10 +19,6 @@ function isJsonObject<T>(value: T): value is T & { [key: string]: JsonValue } {
   );
 }
 
-/**
- * Key-order-insensitive structural equality for JSON-shaped values; the object
- * overload covers domain types that lack `JsonValue`'s index signature.
- */
 export function deepEqualJson(a: JsonValue, b: JsonValue): boolean;
 export function deepEqualJson<T extends object>(
   a: T | null | undefined,

--- a/src/utils/seventv/cosmetics/normalizeSevenTvBadge.ts
+++ b/src/utils/seventv/cosmetics/normalizeSevenTvBadge.ts
@@ -9,20 +9,12 @@ import { buildSevenTvBadgeImageUrl } from './buildSevenTvBadgeImageUrl';
  */
 const BADGE_IMAGE_EXTENSION = /\.(webp|png|avif|gif|jpe?g)(?:$|\?)/i;
 
-/**
- * Runs per badge on every row render; WeakMap-keyed so entries drop with the
- * badge and no eviction is needed.
- */
 const normalizedBadges = new WeakMap<SanitisedBadgeSet, SanitisedBadgeSet>();
 
 function isSevenTvBadge(badge: SanitisedBadgeSet): boolean {
   return badge.provider === '7tv';
 }
 
-/**
- * A url an image loader can actually fetch: absolute, and pointing at a badge
- * file rather than a bare CDN directory.
- */
 function isLoadableBadgeUrl(url: string): boolean {
   return (
     url.startsWith('https://') &&

--- a/src/utils/seventv/sevenTvSessionId.ts
+++ b/src/utils/seventv/sevenTvSessionId.ts
@@ -1,7 +1,3 @@
-/**
- * Latest 7TV EventAPI session id from the HELLO frame; presence writes attach
- * it and reconnects use it to RESUME.
- */
 let sevenTvSessionId: string | null = null;
 
 export const setSevenTvSessionId = (sessionId: string | null): void => {

--- a/src/utils/seventv/sevenTvUserCache.ts
+++ b/src/utils/seventv/sevenTvUserCache.ts
@@ -49,10 +49,6 @@ export type SevenTvUserFetcher = (
   twitchUserId: string,
 ) => Promise<SevenTvUser | null>;
 
-/**
- * Twitch to 7TV user resolution cache: bounded in-memory map, MMKV persistence
- * with positive/negative TTLs, and in-flight request dedup.
- */
 export function createSevenTvUserCache(
   storage: SevenTvUserCacheStorage,
   options: { maxResolvedEntries?: number } = {},

--- a/src/utils/seventv/seventvInitialSubscriptions.ts
+++ b/src/utils/seventv/seventvInitialSubscriptions.ts
@@ -23,10 +23,6 @@ export interface SetupInitialSubscriptionsOptions {
   getSevenTvEmoteSetId: () => string | undefined;
 }
 
-/**
- * Initial-subscription pass for a fresh 7TV socket; every wait iteration is
- * fenced by `session.beginSubscriptionRun()` so a reset or channel hop mid-poll bails the run.
- */
 export const setupInitialSubscriptions = async ({
   getSevenTvChannelUserId,
   getSevenTvEmoteSetId,

--- a/src/utils/shake/shakeDetection.ts
+++ b/src/utils/shake/shakeDetection.ts
@@ -5,13 +5,7 @@ export interface AccelerometerSample {
 }
 
 export interface ShakeDetectorOptions {
-  /**
-   * Total acceleration (in g, gravity included) that counts as a spike.
-   */
   magnitudeThreshold?: number;
-  /**
-   * Spikes required inside the window to register a shake.
-   */
   minSpikes?: number;
   windowMs?: number;
 }
@@ -21,10 +15,6 @@ export type ShakeDetector = (
   timestampMs: number,
 ) => boolean;
 
-/**
- * Stateful spike counter over accelerometer samples: a deliberate shake
- * produces repeated spikes well above 2g, a single bump does not.
- */
 export function createShakeDetector({
   magnitudeThreshold = 2.2,
   minSpikes = 3,

--- a/src/utils/sharing/shareDeepLink.ts
+++ b/src/utils/sharing/shareDeepLink.ts
@@ -2,15 +2,7 @@ import { Share } from 'react-native';
 
 import { logger } from '@app/utils/logger';
 
-/**
- * App URL scheme defined in app.config.ts.
- */
 const APP_SCHEME = 'foam';
-
-/**
- * Public https fallback for users who don't have the app installed.
- * Matches the intentFilters/associated domains in app.config.ts.
- */
 const PUBLIC_TWITCH_BASE = 'https://www.twitch.tv';
 
 export type ShareableEntity =

--- a/src/utils/storeReview/reviewPromptGate.ts
+++ b/src/utils/storeReview/reviewPromptGate.ts
@@ -18,10 +18,6 @@ export interface ReviewPromptInput {
   now: number;
 }
 
-/**
- * Rate-limits review prompts well below Apple/Google's hard caps: engaged,
- * error-free sessions only, once per app version, 90 days apart.
- */
 export function shouldRequestReview({
   state,
   currentVersion,

--- a/src/utils/storeReview/sessionErrorFlag.ts
+++ b/src/utils/storeReview/sessionErrorFlag.ts
@@ -1,7 +1,3 @@
-/**
- * Tracks whether this session recorded an error so the store-review gate never
- * asks for a rating in a bad session; module state resets on cold start.
- */
 let sessionHadError = false;
 
 export function markSessionError(): void {

--- a/src/utils/string/formatViewCount.ts
+++ b/src/utils/string/formatViewCount.ts
@@ -9,9 +9,6 @@ function getViewCountFormatter() {
   return viewCountFormatter;
 }
 
-/**
- * Missing and invalid counts render as '0'.
- */
 export function formatViewCount(count: number | undefined | null): string {
   if (count == null || !Number.isFinite(count) || count < 0) {
     return '0';

--- a/src/utils/twitch/channelActivity/channelActivity.ts
+++ b/src/utils/twitch/channelActivity/channelActivity.ts
@@ -6,10 +6,6 @@ export interface ChannelActivityEvent<TState> {
   normalise: (event: EventSubEvent) => TState;
 }
 
-/**
- * One broadcaster-driven channel activity (a poll or a prediction). Pure data
- * plus pure functions - `useChannelActivity` drives the orchestration.
- */
 export interface ChannelActivity<THelix, TState> {
   fetch: (broadcasterId: string) => Promise<PaginatedList<THelix>>;
   normaliseHelix: (item: THelix) => TState;

--- a/src/utils/version/getMinimumVersion.ts
+++ b/src/utils/version/getMinimumVersion.ts
@@ -7,10 +7,6 @@ import type {
 
 import type { Variant } from '../../../app.config';
 
-/**
- * Resolves the minimum required app version from Remote Config; returns an
- * empty string (no force-upgrade) for never-gated tracks like `e2e`.
- */
 export function getMinimumVersion(
   variant: Variant,
   remoteConfig: RemoteConfigType,


### PR DESCRIPTION
Removes comments that weren't pulling their weight - TODOs, junk labels, and JSDoc/inline notes that just restated the code.

