### PR TITLE
fix: iPad type legibility for App Review, player rotation recovery

### DIFF
--- a/src/components/StreamPlayer/StreamPlayer.tsx
+++ b/src/components/StreamPlayer/StreamPlayer.tsx
@@ -1,5 +1,11 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { InteractionManager, Platform, StyleSheet, View } from 'react-native';
+import {
+  InteractionManager,
+  type LayoutChangeEvent,
+  Platform,
+  StyleSheet,
+  View,
+} from 'react-native';
 import type { WebViewMessageEvent } from 'react-native-webview';
 import { WebView } from 'react-native-webview';
 
@@ -144,6 +150,25 @@ export const StreamPlayer = memo(function StreamPlayer({
       nudgeLayerTree();
     }
   });
+
+  const lastPlayerSizeRef = useRef<{ width: number; height: number } | null>(
+    null,
+  );
+  const handlePlayerLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const { width: nextWidth, height: nextHeight } = event.nativeEvent.layout;
+      const previous = lastPlayerSizeRef.current;
+      lastPlayerSizeRef.current = { width: nextWidth, height: nextHeight };
+      if (
+        previous &&
+        (Math.round(previous.width) !== Math.round(nextWidth) ||
+          Math.round(previous.height) !== Math.round(nextHeight))
+      ) {
+        nudgeLayerTree();
+      }
+    },
+    [nudgeLayerTree],
+  );
 
   useEffect(() => {
     const timeoutsRef = nudgeTimeoutsRef;
@@ -400,6 +425,7 @@ export const StreamPlayer = memo(function StreamPlayer({
   return (
     <View
       collapsable={false}
+      onLayout={handlePlayerLayout}
       style={[
         styles.container,
         { width: playerWidth, height: playerHeight },

--- a/src/screens/Stream/__tests__/StreamerProfileScreen.test.tsx
+++ b/src/screens/Stream/__tests__/StreamerProfileScreen.test.tsx
@@ -105,6 +105,8 @@ const mockChatStats: StreamElementsChatStats = {
   sevenTVEmotes: [{ id: '2', emote: 'OMEGALUL', amount: 9999 }],
 };
 
+const FIND_TIMEOUT = { timeout: 5000 };
+
 describe('StreamerProfileScreen', () => {
   beforeEach(() => {
     getUserSpy.mockResolvedValue(mockUser);
@@ -118,7 +120,7 @@ describe('StreamerProfileScreen', () => {
     render(<StreamerProfileScreen id='shroud' />);
 
     expect(
-      await screen.findByText('Epic Broadcast', {}, { timeout: 5000 }),
+      await screen.findByText('Epic Broadcast', {}, FIND_TIMEOUT),
     ).toBeOnTheScreen();
     expect(screen.getByText('shroud')).toBeOnTheScreen();
     expect(screen.getByText('@shroud')).toBeOnTheScreen();
@@ -129,11 +131,13 @@ describe('StreamerProfileScreen', () => {
   test('switches to clips when the Clips tab is selected', async () => {
     render(<StreamerProfileScreen id='shroud' />);
 
-    await screen.findByText('Epic Broadcast');
+    await screen.findByText('Epic Broadcast', {}, FIND_TIMEOUT);
 
     fireEvent.press(screen.getByTestId('tab-clips'));
 
-    expect(await screen.findByText('Funny Clip')).toBeOnTheScreen();
+    expect(
+      await screen.findByText('Funny Clip', {}, FIND_TIMEOUT),
+    ).toBeOnTheScreen();
     expect(screen.getByText('Clipped by Clipper')).toBeOnTheScreen();
   });
 
@@ -142,7 +146,9 @@ describe('StreamerProfileScreen', () => {
 
     render(<StreamerProfileScreen id='shroud' />);
 
-    expect(await screen.findByText('via StreamElements')).toBeOnTheScreen();
+    expect(
+      await screen.findByText('via StreamElements', {}, FIND_TIMEOUT),
+    ).toBeOnTheScreen();
     // Top emote across all platforms is the highest-count one.
     expect(screen.getByText('OMEGALUL')).toBeOnTheScreen();
   });
@@ -150,7 +156,7 @@ describe('StreamerProfileScreen', () => {
   test('hides StreamElements stats when unavailable', async () => {
     render(<StreamerProfileScreen id='shroud' />);
 
-    await screen.findByText('Epic Broadcast');
+    await screen.findByText('Epic Broadcast', {}, FIND_TIMEOUT);
 
     expect(screen.queryByText('via StreamElements')).not.toBeOnTheScreen();
   });
@@ -160,7 +166,9 @@ describe('StreamerProfileScreen', () => {
 
     render(<StreamerProfileScreen id='shroud' />);
 
-    expect(await screen.findByText('No VODs found')).toBeOnTheScreen();
+    expect(
+      await screen.findByText('No VODs found', {}, FIND_TIMEOUT),
+    ).toBeOnTheScreen();
   });
 
   test('shows a not-found state when the user fails to load', async () => {
@@ -168,6 +176,8 @@ describe('StreamerProfileScreen', () => {
 
     render(<StreamerProfileScreen id='shroud' />);
 
-    expect(await screen.findByText('Streamer not found')).toBeOnTheScreen();
+    expect(
+      await screen.findByText('Streamer not found', {}, FIND_TIMEOUT),
+    ).toBeOnTheScreen();
   });
 });

--- a/src/styles/themes.ts
+++ b/src/styles/themes.ts
@@ -2,8 +2,8 @@ import * as Device from 'expo-device';
 
 import { Color } from './palette';
 
-const SPACE_SCALE = 1.33;
-const FONT_SCALE = 1.2;
+const SPACE_SCALE = 1.4;
+const FONT_SCALE = 1.4;
 
 const isIpad = Device.osName === 'iPadOS';
 


### PR DESCRIPTION
App Review flagged 1.0.9 under guideline 4 for hard-to-read type on iPad. The app is iPhone-only, so on iPad it runs in compatibility mode - a small letterboxed window with everything shrunk.
